### PR TITLE
Autodoc

### DIFF
--- a/docs/api-refs.rst
+++ b/docs/api-refs.rst
@@ -1,0 +1,23 @@
+SedTRAILS API
+================
+
+This is an example about how Autodoc can render Python docstrings.
+Autodoc requires the `sphinx.ext.autodoc` extension to be enabled in `conf.py`, 
+and this file to be written in `reStructuredText` format.
+
+.. admonition:: Source code must be available when rendering the documentation
+   :class: important
+
+   This can be achieved by any of the approces explain here: https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#ensuring-the-code-can-be-imported
+
+
+A Function
+-----------
+
+.. autofunction:: sedtrails.mock_api.sum
+
+A Class
+-----------
+
+.. autoclass:: sedtrails.mock_api.Calculator
+   :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,11 @@ release = '0.0.1'
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path('..', 'src').resolve()))
+
 extensions = [
     'myst_parser',
     "sphinx_rtd_theme",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,9 @@ release = '0.0.1'
 
 extensions = [
     'myst_parser',
-    "sphinx_rtd_theme"]
+    "sphinx_rtd_theme",
+    "sphinx.ext.autodoc",
+    ]
 
 myst_enable_extensions = [
     "amsmath",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,3 +28,9 @@ documentation for details.
    :caption: DEVELOPER DOCUMENTATION
 
    developer/contribution
+
+.. toctree::
+   :maxdepth: 2
+   :caption: API DOCUMENTATION
+
+   api-refs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,0 @@
-Sphinx==8.2.0
-myst-parser==4.0.1
-sphinx-rtd-theme==3.0.2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+Sphinx==8.2.0
+myst-parser==4.0.1
+sphinx-rtd-theme==3.0.2

--- a/src/sedtrails/mock_api.py
+++ b/src/sedtrails/mock_api.py
@@ -1,0 +1,76 @@
+"""
+This file serves as a mock API for the SedTRAILS project. 
+It is used to demonstrate the use of the `autodoc` extension in Sphinx.
+"""
+
+def sum(x: int, y: int) -> int:
+    """
+    Add two numbers together.
+
+    Parameters
+    ----------
+    x : int
+        The first number.
+    y : int
+        The second number.
+
+    Returns
+    -------
+    int
+        The sum of the two numbers.
+
+    Examples
+    --------
+    You can include examples in RST
+    
+    .. code-block:: python
+
+        from sedtrails import sum
+        sum(1, 2)
+        # Output: 3
+    
+    """
+    return x + y
+
+
+class Calculator:
+    """
+    A simple calculator class.
+    """
+    def __init__(self):
+        pass
+    def add(self, x: int, y: int) -> int:
+        """
+        Add two numbers together.
+
+        Parameters
+        ----------
+        x : int
+            The first number.
+        y : int
+            The second number.
+
+        Returns
+        -------
+        int
+            The sum of the two numbers.
+        """
+        return x + y
+    
+    def subtract(self, x: int, y: int) -> int:
+        """
+        Subtract two numbers.
+
+        Parameters
+        ----------
+        x : int
+            The first number.
+        y : int
+            The second number.
+
+        Returns
+        -------
+        int
+            The difference between the two numbers.
+        """
+        return x - y


### PR DESCRIPTION
This PR contains an example of how to use 'autodoc' to render docstrings as part of Sphinx documentation. 
Mock code is used in the example.

if you want to render the documentation yourself, you have to install the dependencies in `docs/requirements.txt` and then use `make html` while in the `docs/` directory.

Closes #59 