### PR TITLE
Add pythonpath to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ Changelog = "https://github.com/sedtrails/sedtrails/blob/main/CHANGELOG.md"
 [project.scripts]
 
 [tool.pytest.ini_options]
+pythonpath = "src"
 addopts = [
     "--import-mode=importlib",
 ]


### PR DESCRIPTION
Add pythonpath to explciitly define the python scripts source path. This circumvents the need to install a dummy sedtrails package using pip inside a conda environment.

Closes #98  