### PR TITLE
Fix ruff errors except for the exceptions

### DIFF
--- a/src/sedtrails/sedtrails.py
+++ b/src/sedtrails/sedtrails.py
@@ -6,17 +6,13 @@ app = typer.Typer(
     help="Sedtrails: Configure, run, and analyze sediment particle tracking."
 )
 
+CONFIG_FILE = "sedtrails.yml"
+PARTICLE_TRACK_FILE = "sedtrails.nc"
+ANALYSIS_FILE = "analysis.nc"
 
 # Subcommand to load and validate a YAML configuration file.
 @app.command("load-config")
-def load_config(
-    config_file: Path = typer.Option(
-        "sedtrails.yml",
-        "--config",
-        "-c",
-        help="Path to the SedTRAILS configuration file.",
-    ),
-) -> dict:
+def load_config(config_file: Path = None) -> dict:
     """
     Load and validate a YAML configuration file using an existing validator.
     Returns a dictionary with the valid configuration settings.
@@ -32,6 +28,13 @@ def load_config(
          A dictionary with the validated configuration settings.
 
     """
+    # Assign default value if argument is not provided
+    config_file = config_file or typer.Option(
+        CONFIG_FILE,
+        "--config",
+        "-c",
+        help="Path to the SedTRAILS configuration file.",
+    )
     try:
         typer.echo(f"Loading and validating configuration from '{config_file}'...")
         # Assume the existence of a ConfigValidator class in a separate module.
@@ -50,18 +53,8 @@ def load_config(
 # Subcommand to run a simulation; it also validates the configuration.
 @app.command("run-simulation")
 def run_simulation(
-    config_file: Path = typer.Option(
-        "sedtrails.yml",
-        "--config",
-        "-c",
-        help="Path to the SedTRAILS configuration file.",
-    ),
-    output_file: Path = typer.Option(
-        "sedtrails.nc",
-        "--output",
-        "-o",
-        help="Path to the output SedTRAILS netCDF file.",
-    ),
+    config_file: Path = None,
+    output_file: Path = None,
 ):
     """
     Validate the configuration and run a simulation based on it.
@@ -75,15 +68,24 @@ def run_simulation(
          Path to the output SedTRAILS netCDF file.
 
     """
+    # Assign default values if arguments are not provided
+    config_file = config_file or typer.Option(
+        CONFIG_FILE,
+        "--config",
+        "-c",
+        help="Path to the SedTRAILS configuration file.",
+    )
+    output_file = output_file or typer.Option(
+        PARTICLE_TRACK_FILE,
+        "--output",
+        "-o",
+        help="Path to the output SedTRAILS netCDF file.",
+    )
     # First, load and validate the configuration.
     try:
         typer.echo(f"Validating configuration from '{config_file}'...")
         # from config_validator import ConfigValidator
         # config = ConfigValidator.validate(config_file)
-        config = {
-            "setting1": "value1",
-            "setting2": "value2",
-        }  # Dummy config for example
         typer.echo("Configuration validated successfully.")
     except Exception as e:
         typer.echo(f"Error validating configuration: {e}")
@@ -101,20 +103,7 @@ def run_simulation(
 
 # Subcommand to perform statistical analysis on the simulation results.
 @app.command("analyze")
-def analyze(
-    input_file: Path = typer.Option(
-        "sedtrails.nc",
-        "--input",
-        "-i",
-        help="Input SedTRAILS netCDF file containing particle tracks.",
-    ),
-    output_file: Path = typer.Option(
-        "analysis.nc",
-        "--output",
-        "-o",
-        help="Output SedTRAILS netCDF file containing statistical and connectivity results.",
-    ),
-):
+def analyze(input_file: Path = None, output_file: Path = None):
     """
     Read the simulation netCDF file (if it exists) and perform a statistical analysis on the results.
     The analysis is saved to a netCDF file.
@@ -126,6 +115,19 @@ def analyze(
       output_file : Path
          Path to the output SedTRAILS netCDF file containing statistical and connectivity results.
     """
+    # Assign default values if arguments are not provided
+    input_file = input_file or typer.Option(
+        PARTICLE_TRACK_FILE,
+        "--input",
+        "-i",
+        help="Input SedTRAILS netCDF file containing particle tracks.",
+    )
+    output_file = output_file or typer.Option(
+        ANALYSIS_FILE,
+        "--output",
+        "-o",
+        help="Output SedTRAILS netCDF file containing statistical and connectivity results.",
+    )
     try:
         typer.echo(f"Performing statistical analysis on '{input_file}'...")
         pass
@@ -136,21 +138,11 @@ def analyze(
 
 
 # Subcommand to perform network analysis on the simulation results.
+# [Aysun] The original script had the same file path (sedtrails.nc) for both the input
+# and the output, based on the help text I assume the output should be the analysis.nc
+# instead? Please check the function below to make sure it is correct 
 @app.command("network-analysis")
-def network_analysis(
-    input_file: Path = typer.Option(
-        "sedtrails.nc",
-        "--input",
-        "-i",
-        help="Input netCDF file containing particle tracking results.",
-    ),
-    output_file: Path = typer.Option(
-        "sedtrails.nc",
-        "--output",
-        "-o",
-        help="Path to the output SedTRAILS netCDF file containing statistical and connectivity results.",
-    ),
-):
+def network_analysis(input_file: Path = None, output_file: Path = None):
     """
     Perform a network analysis on the simulation results.
     The network analysis results are written to a netCDF file.
@@ -158,10 +150,23 @@ def network_analysis(
     Parameters
     ----------
       input_file : Path
-         Path to the input SedTRAILS netCDF file containing particle tracks.
+         Path to the input netCDF file containing particle tracking results.
       output_file : Path
-         Path to the output SedTRAILS netCDF file containing statistical and connectivity results.
+         Path to the output netCDF file containing statistical and connectivity results.
     """
+    # Assign default values if arguments are not provided
+    input_file = input_file or typer.Option(
+        PARTICLE_TRACK_FILE,
+        "--input",
+        "-i",
+        help="Input netCDF file containing particle tracking results.",
+    )
+    output_file = output_file or typer.Option(
+        ANALYSIS_FILE,
+        "--output",
+        "-o",
+        help="Path to the output netCDF file containing statistical and connectivity results.",
+    )
     try:
         typer.echo(f"Performing network analysis on '{input_file}'...")
         pass

--- a/tests/test_transport_converter/test_format_converter.py
+++ b/tests/test_transport_converter/test_format_converter.py
@@ -1,7 +1,5 @@
 """Test for the Format Converter"""
 
-import pytest
-
 def test_blank():
     """
     This is a placeholder test function 


### PR DESCRIPTION
First attempt to fix linting errors in existing code in `src/sedtrails/sedtrails.py` and `tests/test_transport_converter/test_format_converter.py`. I will wait until we define custom exceptions for SedTRAILS before I fix the linting errors related to those. Closes #122 

Files modified:
- `src/sedtrails/sedtrails.py`
- `tests/test_transport_converter/test_format_converter.py`

@jreyns Please have a look at the function `network_analysis`: the input and output file paths were the same in the original script but based on the help message I changed the output file path. 
https://github.com/aysunrhn/sedtrails/blob/bbc44bbca302f53531f5cd8d482451fd6566578f/src/sedtrails/sedtrails.py#L145-L169
