### PR TITLE
Exception Examples

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,21 +1,25 @@
 line-length = 120
 indent-width = 4
- 
+
 [lint]
 # 1. Enable flake8-bugbear (`B`) rules, in addition to the defaults.
 select = ["E4", "E7", "E9", "F", "B"]
- 
+
 # 2. Avoid enforcing line-length violations (`E501`)
 ignore = ["E501"]
- 
+
 # 3. Avoid trying to fix flake8-bugbear (`B`) violations.
 unfixable = ["B"]
- 
+
 # 4. Ignore `E402` (import violations) in all `__init__.py` files, and in selected subdirectories.
 [lint.per-file-ignores]
 "__init__.py" = ["E402"]
 "**/{tests,docs,tools}/*" = ["E402"]
- 
+
 [format]
 # 5. Use single quotes in `ruff format`.
 quote-style = "single"
+
+[lint.flake8-bugbear]
+# Allow default arguments like, e.g., `data: List[str] = fastapi.Query(None)`.
+extend-immutable-calls = ["typer.Option"]

--- a/src/sedtrails/configuration_interface/validator.py
+++ b/src/sedtrails/configuration_interface/validator.py
@@ -167,7 +167,7 @@ class YAMLConfigValidator:
                     try:
                         data[key] = self._resolve_default_directive(default_val, root_data)
                     except Exception as e:
-                        raise ValueError(f"Error resolving default for '{key}': {e}")
+                        raise ValueError(f"Error resolving default for '{key}': {e}") from e
                 else:
                     data[key] = default_val
             if key in data and subschema.get('type') == 'object':

--- a/src/sedtrails/configuration_interface/validator.py
+++ b/src/sedtrails/configuration_interface/validator.py
@@ -1,8 +1,8 @@
 import os
-from typing import Any, Dict, Optional
-
 import jsonschema
 import yaml
+from typing import Any, Dict, Optional
+from sedtrails.exceptions import YamlParsingError, YamlOutputError, YamlValidationError
 
 
 class YAMLConfigValidator:
@@ -42,17 +42,19 @@ class YAMLConfigValidator:
 
         Raises
         ------
-        ValueError
-            If the schema file cannot be read or if the loaded schema is not a valid dictionary.
+        YamlParsingError
+            If the schema file cannot be parsed by the yaml library.
+        TypeError
+            If the loaded schema is not a valid dictionary.
         """
         try:
-            with open(schema_file, "r") as f:
+            with open(schema_file, 'r') as f:
                 schema_data: Any = yaml.safe_load(f)
             if not isinstance(schema_data, dict):
-                raise ValueError("Loaded schema is not a valid dictionary.")
+                raise TypeError('Loaded schema is not a valid dictionary.')
             return schema_data
         except Exception as e:
-            raise ValueError(f"Error reading schema file: {e}")
+            raise YamlParsingError(f'Error reading schema file: {e}') from e
 
     def _resolve_json_pointer(self, pointer: str, data: Dict[str, Any]) -> Any:
         """
@@ -78,23 +80,19 @@ class YAMLConfigValidator:
         ValueError
             If the pointer cannot be fully resolved.
         """
-        if pointer.startswith("#/"):
+        if pointer.startswith('#/'):
             pointer = pointer[2:]
-        tokens = pointer.split("/")
-        tokens = [token for token in tokens if token != "properties"]
+        tokens = pointer.split('/')
+        tokens = [token for token in tokens if token != 'properties']
         value: Any = data
         for token in tokens:
             if isinstance(value, dict) and token in value:
                 value = value[token]
             else:
-                raise ValueError(
-                    f"Could not resolve pointer '{pointer}' in configuration data."
-                )
+                raise ValueError(f"Could not resolve pointer '{pointer}' in configuration data.")
         return value
 
-    def _resolve_default_directive(
-        self, directive: Dict[str, Any], root_data: Dict[str, Any]
-    ) -> str:
+    def _resolve_default_directive(self, directive: Dict[str, Any], root_data: Dict[str, Any]) -> str:
         """
         Resolves a default directive specified as a dictionary with a "$ref" and optional
         transformation instructions.
@@ -114,37 +112,33 @@ class YAMLConfigValidator:
         Raises
         ------
         ValueError
-            If the directive does not contain a '$ref' or if the referenced value is not a string.
+            If the directive does not contain a '$ref
+        TypeError:
+            If the referenced value is not a string.
         NotImplementedError
             If the specified transformation is not supported.
         """
-        if "$ref" not in directive:
+        if '$ref' not in directive:
             raise ValueError("Directive must contain a '$ref' key.")
-        ref_value: Any = self._resolve_json_pointer(directive["$ref"], root_data)
+        ref_value: Any = self._resolve_json_pointer(directive['$ref'], root_data)
         if not isinstance(ref_value, str):
-            raise ValueError(
-                "Referenced value must be a string for folder name transformations."
-            )
+            raise TypeError('Referenced value must be a string for folder name transformations.')
         result: str = ref_value
         # Apply transformation if specified.
-        if "transform" in directive:
-            match directive["transform"]:
-                case "dirname":
+        if 'transform' in directive:
+            match directive['transform']:
+                case 'dirname':
                     result = os.path.dirname(result)
                 case _:
-                    raise NotImplementedError(
-                        f"Transform '{directive['transform']}' is not supported."
-                    )
+                    raise NotImplementedError(f"Transform '{directive['transform']}' is not supported.")
         # Apply prefix if specified.
-        if "prefix" in directive:
-            result = directive["prefix"] + result
-        if "suffix" in directive:
-            result = os.path.normpath(result + directive["suffix"])
+        if 'prefix' in directive:
+            result = directive['prefix'] + result
+        if 'suffix' in directive:
+            result = os.path.normpath(result + directive['suffix'])
         return result
 
-    def _apply_defaults(
-        self, schema: Dict[str, Any], data: Dict[str, Any], root_data: Dict[str, Any]
-    ) -> None:
+    def _apply_defaults(self, schema: Dict[str, Any], data: Dict[str, Any], root_data: Dict[str, Any]) -> None:
         """
         Recursively applies default values from the schema to the data dictionary.
         If a default is specified as a dictionary with "$ref" and transformation keys,
@@ -158,22 +152,25 @@ class YAMLConfigValidator:
             The portion of configuration data to update.
         root_data : dict
             The full configuration data (for resolving references).
+
+        Raises
+        ------
+        ValueError
+            If the default value cannot be resolved.
         """
         if not isinstance(data, dict):
             return
-        for key, subschema in schema.get("properties", {}).items():
-            if key not in data and "default" in subschema:
-                default_val: Any = subschema["default"]
-                if isinstance(default_val, dict) and "$ref" in default_val:
+        for key, subschema in schema.get('properties', {}).items():
+            if key not in data and 'default' in subschema:
+                default_val: Any = subschema['default']
+                if isinstance(default_val, dict) and '$ref' in default_val:
                     try:
-                        data[key] = self._resolve_default_directive(
-                            default_val, root_data
-                        )
+                        data[key] = self._resolve_default_directive(default_val, root_data)
                     except Exception as e:
                         raise ValueError(f"Error resolving default for '{key}': {e}")
                 else:
                     data[key] = default_val
-            if key in data and subschema.get("type") == "object":
+            if key in data and subschema.get('type') == 'object':
                 self._apply_defaults(subschema, data[key], root_data)
 
     def validate_yaml(self, yml_filepath: str) -> Dict[str, Any]:
@@ -194,20 +191,22 @@ class YAMLConfigValidator:
 
         Raises
         ------
-        ValueError
-            If the YAML file cannot be read or if the configuration is invalid.
+        YamlParsingError
+            If the YAML file cannot be read
+        YamlValidationError
+            If the YAML configuration is invalid.
         """
         try:
-            with open(yml_filepath, "r") as f:
+            with open(yml_filepath, 'r') as f:
                 data: Dict[str, Any] = yaml.safe_load(f)
         except Exception as e:
-            raise ValueError(f"Error reading YAML file: {e}")
+            raise YamlParsingError(f'Error reading YAML file: {e}') from e
 
         ValidatorClass = jsonschema.validators.validator_for(self.schema)
         validator = ValidatorClass(self.schema)
         errors = sorted(validator.iter_errors(data), key=lambda e: e.path)
         if errors:
-            raise ValueError(f"YAML file validation error: {errors[0].message}")
+            raise YamlValidationError(f'YAML file validation error: {errors[0].message}')
 
         self._apply_defaults(self.schema, data, data)
         self.config = data
@@ -229,14 +228,14 @@ class YAMLConfigValidator:
 
         Raises
         ------
-        ValueError
-            If there is an error writing the schema to the file.
+        YamlOutputError
+            If there is an error while writing the schema to the file.
         """
         schema_yaml: str = yaml.dump(self.schema, sort_keys=False)
         if output_file:
             try:
-                with open(output_file, "w") as f:
+                with open(output_file, 'w') as f:
                     f.write(schema_yaml)
             except Exception as e:
-                raise ValueError(f"Error writing schema to file: {e}")
+                raise YamlOutputError(f'Error writing schema to file: {e}') from e
         return schema_yaml

--- a/src/sedtrails/exceptions/__init__.py
+++ b/src/sedtrails/exceptions/__init__.py
@@ -1,1 +1,5 @@
 """Custom exceptions go in this directory."""
+
+from .sedtrails import SedtrailsException, YamlParsingError, YamlOutputError, YamlValidationError
+
+__all__ = ['SedtrailsException', 'YamlParsingError', 'YamlOutputError', 'YamlValidationError']

--- a/src/sedtrails/exceptions/example.py
+++ b/src/sedtrails/exceptions/example.py
@@ -1,0 +1,58 @@
+"""
+This is an example of how to create a custom exception in Python.
+
+'Programs may name their own exceptions by creating a new exception class (see Classes for more about Python classes).
+Exceptions should typically be derived from the Exception class, either directly or indirectly.
+
+Exception classes can be defined which do anything any other class can do, but are usually kept simple,
+often only offering a number of attributes that allow information about the error to be extracted by handlers
+for the exception.
+
+Most exceptions are defined with names that end in “Error”, similar to the naming of the standard exceptions.
+
+Many standard modules define their own exceptions to report errors that may occur in functions they define.
+' -Python documentation
+
+"""
+
+
+# Custom exceptions inherit from the built-in Exception class.
+class ValueTooLargeError(Exception):
+    """
+    Exception raised when the input value is too large.
+    """
+
+    pass  # This is enought to define the exception class. However, you can do more. See below.
+
+
+class ValueTooSmallError(Exception):
+    """
+    Exception raised when the input value is too small.
+    """
+
+    def __init__(self, value, limit):  # this add behavior to the exception.
+        # In this example, the exception always require a value and a limit.
+        """
+        Initialize the exception with a value.
+        """
+        self.value = value
+        self.limit = limit
+        super().__init__(f'Value {value} is too small. It should be at least {limit}.')
+
+
+# Example of how to use the custom exceptions
+if __name__ == '__main__':
+    try:
+        x = 10
+        if x > 5:
+            raise ValueTooLargeError('Value is too large')
+    except ValueTooLargeError as e:
+        print(e)
+
+    try:
+        x = 1
+        if x < 5:
+            raise ValueTooSmallError(x, 5)
+    except ValueTooSmallError as e:
+        raise ValueTooSmallError(e.value, e.limit) from e  # the use of 'from e' will show the original
+        # exception in the traceback. This is useful to understand the context of the error.

--- a/src/sedtrails/exceptions/sedtrails.py
+++ b/src/sedtrails/exceptions/sedtrails.py
@@ -1,0 +1,37 @@
+"""
+Custom exceptions for the Sedtrails package.
+This module defines custom exceptions that can be raised during the execution of the Sedtrails package.
+"""
+
+
+class SedtrailsException(Exception):
+    """
+    Base class for all exceptions in the Sedtrails package.
+    This class inherits from the built-in Exception class.
+    """
+
+    pass
+
+
+class YamlParsingError(SedtrailsException):
+    """
+    Exception raised when there is an error parsing a YAML file.
+    """
+
+    pass
+
+
+class YamlValidationError(SedtrailsException):
+    """
+    Exception raised when a YAML file does not conform to the expected schema.
+    """
+
+    pass
+
+
+class YamlOutputError(SedtrailsException):
+    """
+    Exception raised when there is an error writing to a YAML file.
+    """
+
+    pass

--- a/src/sedtrails/sedtrails.py
+++ b/src/sedtrails/sedtrails.py
@@ -1,20 +1,17 @@
+import typer
 from pathlib import Path
 
-import typer
-
-app = typer.Typer(
-    help="Sedtrails: Configure, run, and analyze sediment particle tracking."
-)
+app = typer.Typer(help='Sedtrails: Configure, run, and analyze sediment particle tracking.')
 
 
 # Subcommand to load and validate a YAML configuration file.
-@app.command("load-config")
+@app.command('load-config')
 def load_config(
     config_file: Path = typer.Option(
-        "sedtrails.yml",
-        "--config",
-        "-c",
-        help="Path to the SedTRAILS configuration file.",
+        'sedtrails.yml',
+        '--config',
+        '-c',
+        help='Path to the SedTRAILS configuration file.',
     ),
 ) -> dict:
     """
@@ -38,29 +35,29 @@ def load_config(
         # from config_validator import ConfigValidator
         # config = ConfigValidator.validate(config_file)
         # Dummy dictionary result for demonstration purposes:
-        config = {"setting1": "value1", "setting2": "value2"}
-        typer.echo("Configuration validated successfully:")
+        config = {'setting1': 'value1', 'setting2': 'value2'}
+        typer.echo('Configuration validated successfully:')
         typer.echo(str(config))
         return config
     except Exception as e:
-        typer.echo(f"Error loading configuration: {e}")
-        raise typer.Exit(code=1)
+        typer.echo(f'Error loading configuration: {e}')
+        raise typer.Exit(code=1) from e
 
 
 # Subcommand to run a simulation; it also validates the configuration.
-@app.command("run-simulation")
+@app.command('run-simulation')
 def run_simulation(
     config_file: Path = typer.Option(
-        "sedtrails.yml",
-        "--config",
-        "-c",
-        help="Path to the SedTRAILS configuration file.",
+        'sedtrails.yml',
+        '--config',
+        '-c',
+        help='Path to the SedTRAILS configuration file.',
     ),
     output_file: Path = typer.Option(
-        "sedtrails.nc",
-        "--output",
-        "-o",
-        help="Path to the output SedTRAILS netCDF file.",
+        'sedtrails.nc',
+        '--output',
+        '-o',
+        help='Path to the output SedTRAILS netCDF file.',
     ),
 ):
     """
@@ -74,45 +71,46 @@ def run_simulation(
       output_file : Path
          Path to the output SedTRAILS netCDF file.
 
+    Example
+    -------
+      sedtrails run-simulation --config my_config.yml --output results.nc
+
     """
     # First, load and validate the configuration.
     try:
         typer.echo(f"Validating configuration from '{config_file}'...")
         # from config_validator import ConfigValidator
         # config = ConfigValidator.validate(config_file)
-        config = {
-            "setting1": "value1",
-            "setting2": "value2",
-        }  # Dummy config for example
-        typer.echo("Configuration validated successfully.")
+
+        typer.echo('Configuration validated successfully.')
     except Exception as e:
-        typer.echo(f"Error validating configuration: {e}")
-        raise typer.Exit(code=1)
+        typer.echo(f'Error validating configuration: {e}')
+        raise typer.Exit(code=1) from e
 
     # Run the simulation with the validated configuration.
     try:
-        typer.echo("Running simulation...")
+        typer.echo('Running simulation...')
         pass
         typer.echo(f"Simulation complete. Output saved to '{output_file}'.")
     except Exception as e:
-        typer.echo(f"Error running simulation: {e}")
-        raise typer.Exit(code=1)
+        typer.echo(f'Error running simulation: {e}')
+        raise typer.Exit(code=1) from e
 
 
 # Subcommand to perform statistical analysis on the simulation results.
-@app.command("analyze")
+@app.command('analyze')
 def analyze(
     input_file: Path = typer.Option(
-        "sedtrails.nc",
-        "--input",
-        "-i",
-        help="Input SedTRAILS netCDF file containing particle tracks.",
+        'sedtrails.nc',
+        '--input',
+        '-i',
+        help='Input SedTRAILS netCDF file containing particle tracks.',
     ),
     output_file: Path = typer.Option(
-        "analysis.nc",
-        "--output",
-        "-o",
-        help="Output SedTRAILS netCDF file containing statistical and connectivity results.",
+        'analysis.nc',
+        '--output',
+        '-o',
+        help='Output SedTRAILS netCDF file containing statistical and connectivity results.',
     ),
 ):
     """
@@ -131,24 +129,24 @@ def analyze(
         pass
         typer.echo(f"Analysis complete. Results saved to '{output_file}'.")
     except Exception as e:
-        typer.echo(f"Error performing analysis: {e}")
-        raise typer.Exit(code=1)
+        typer.echo(f'Error performing analysis: {e}')
+        raise typer.Exit(code=1) from e
 
 
 # Subcommand to perform network analysis on the simulation results.
-@app.command("network-analysis")
+@app.command('network-analysis')
 def network_analysis(
     input_file: Path = typer.Option(
-        "sedtrails.nc",
-        "--input",
-        "-i",
-        help="Input netCDF file containing particle tracking results.",
+        'sedtrails.nc',
+        '--input',
+        '-i',
+        help='Input netCDF file containing particle tracking results.',
     ),
     output_file: Path = typer.Option(
-        "sedtrails.nc",
-        "--output",
-        "-o",
-        help="Path to the output SedTRAILS netCDF file containing statistical and connectivity results.",
+        'sedtrails.nc',
+        '--output',
+        '-o',
+        help='Path to the output SedTRAILS netCDF file containing statistical and connectivity results.',
     ),
 ):
     """
@@ -167,9 +165,9 @@ def network_analysis(
         pass
         typer.echo(f"Network analysis complete. Results saved to '{output_file}'.")
     except Exception as e:
-        typer.echo(f"Error performing network analysis: {e}")
-        raise typer.Exit(code=1)
+        typer.echo(f'Error performing network analysis: {e}')
+        raise typer.Exit(code=1) from e
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     app()

--- a/tests/test_configuration_interface/test_inputconfigurator.py
+++ b/tests/test_configuration_interface/test_inputconfigurator.py
@@ -8,20 +8,20 @@ import pytest
 import yaml
 
 from sedtrails.configuration_interface.validator import YAMLConfigValidator
+from sedtrails.exceptions import YamlValidationError
 
 
 class TestYAMLConfigValidator:
     """
     Test suite for validating YAML configuration files using YAMLConfigValidator.
     """
+
     def setup_method(self):
         """
         Setup method to create a temporary dummy schema file for tests that do not require a real schema
         """
         self.dummy_schema = {}
-        self.dummy_schema_file = tempfile.NamedTemporaryFile(
-            mode="w", delete=False, suffix=".yml"
-        )
+        self.dummy_schema_file = tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.yml')
         yaml.dump(self.dummy_schema, self.dummy_schema_file)
         self.dummy_schema_file.close()
         self.validator = YAMLConfigValidator(self.dummy_schema_file.name)
@@ -37,29 +37,29 @@ class TestYAMLConfigValidator:
     # -----------------------------
     def test_resolve_json_pointer_success(self):
         """
-        Test successful resolution of a JSON pointer 
+        Test successful resolution of a JSON pointer
         """
-        data = {"a": {"b": "value"}}
-        pointer = "#/a/b"
+        data = {'a': {'b': 'value'}}
+        pointer = '#/a/b'
         result = self.validator._resolve_json_pointer(pointer, data)
-        assert result == "value"
+        assert result == 'value'
 
     def test_resolve_json_pointer_with_properties(self):
         """
-        Test successful resolution of a JSON pointer with properties 
+        Test successful resolution of a JSON pointer with properties
         """
-        data = {"a": {"b": "value"}}
+        data = {'a': {'b': 'value'}}
         # Pointer includes "properties" tokens that should be removed.
-        pointer = "#/properties/a/properties/b"
+        pointer = '#/properties/a/properties/b'
         result = self.validator._resolve_json_pointer(pointer, data)
-        assert result == "value"
+        assert result == 'value'
 
     def test_resolve_json_pointer_failure(self):
         """
         Test that resolving an invalid JSON pointer raises a ValueError
         """
-        data = {"a": {"b": "value"}}
-        pointer = "#/a/c"
+        data = {'a': {'b': 'value'}}
+        pointer = '#/a/c'
         with pytest.raises(ValueError):
             self.validator._resolve_json_pointer(pointer, data)
 
@@ -71,41 +71,41 @@ class TestYAMLConfigValidator:
         Test that default directive is resolved
         """
         # Setup root data with a key "path" holding a file path.
-        root_data = {"path": "/a/b/c.txt"}
+        root_data = {'path': '/a/b/c.txt'}
         directive = {
-            "$ref": "#/path",
-            "transform": "dirname",
-            "prefix": "pre_",
-            "suffix": "_suf",
+            '$ref': '#/path',
+            'transform': 'dirname',
+            'prefix': 'pre_',
+            'suffix': '_suf',
         }
         result = self.validator._resolve_default_directive(directive, root_data)
-        expected = os.path.normpath("pre_" + os.path.dirname("/a/b/c.txt") + "_suf")
+        expected = os.path.normpath('pre_' + os.path.dirname('/a/b/c.txt') + '_suf')
         assert result == expected
 
     def test_resolve_default_directive_missing_ref(self):
         """
         Test that default directive with missing ref raises a ValueError
         """
-        root_data = {"path": "/a/b/c.txt"}
-        directive = {"transform": "dirname"}
+        root_data = {'path': '/a/b/c.txt'}
+        directive = {'transform': 'dirname'}
         with pytest.raises(ValueError):
             self.validator._resolve_default_directive(directive, root_data)
 
     def test_resolve_default_directive_non_string_ref(self):
         """
-        Test that default directive with a nonstring ref raises a ValueError
+        Test that default directive with a nonstring ref raises a TypeError
         """
-        root_data = {"path": 123}
-        directive = {"$ref": "#/path", "transform": "dirname"}
-        with pytest.raises(ValueError):
+        root_data = {'path': 123}
+        directive = {'$ref': '#/path', 'transform': 'dirname'}
+        with pytest.raises(TypeError):
             self.validator._resolve_default_directive(directive, root_data)
 
     def test_resolve_default_directive_unsupported_transform(self):
         """
         Test that default directive with unsupported transform raises a NotImplementedError
         """
-        root_data = {"path": "/a/b/c.txt"}
-        directive = {"$ref": "#/path", "transform": "unsupported"}
+        root_data = {'path': '/a/b/c.txt'}
+        directive = {'$ref': '#/path', 'transform': 'unsupported'}
         with pytest.raises(NotImplementedError):
             self.validator._resolve_default_directive(directive, root_data)
 
@@ -118,77 +118,71 @@ class TestYAMLConfigValidator:
         """
         # Define a schema with defaults (including a directive for "folder")
         schema = {
-            "properties": {
-                "folder": {
-                    "type": "string",
-                    "default": {
-                        "$ref": "#/path",
-                        "transform": "dirname",
-                        "prefix": "pre_",
-                        "suffix": "_suf",
+            'properties': {
+                'folder': {
+                    'type': 'string',
+                    'default': {
+                        '$ref': '#/path',
+                        'transform': 'dirname',
+                        'prefix': 'pre_',
+                        'suffix': '_suf',
                     },
                 },
-                "name": {"type": "string", "default": "default_name"},
-                "nested": {
-                    "type": "object",
-                    "properties": {
-                        "value": {"type": "string", "default": "nested_default"}
-                    },
+                'name': {'type': 'string', 'default': 'default_name'},
+                'nested': {
+                    'type': 'object',
+                    'properties': {'value': {'type': 'string', 'default': 'nested_default'}},
                 },
             }
         }
         # Data missing "folder", "name", and nested.value.
-        data = {"path": "/a/b/c.txt", "nested": {}}
+        data = {'path': '/a/b/c.txt', 'nested': {}}
         self.validator._apply_defaults(schema, data, data)
-        expected_folder = os.path.normpath(
-            "pre_" + os.path.dirname("/a/b/c.txt") + "_suf"
-        )
-        assert data["folder"] == expected_folder
-        assert data["name"] == "default_name"
-        assert data["nested"]["value"] == "nested_default"
+        expected_folder = os.path.normpath('pre_' + os.path.dirname('/a/b/c.txt') + '_suf')
+        assert data['folder'] == expected_folder
+        assert data['name'] == 'default_name'
+        assert data['nested']['value'] == 'nested_default'
 
     # -----------------------------
     # Tests for validate_yaml
     # -----------------------------
     def test_validate_yaml_success(self, tmp_path):
         """
-        Test YAML file validation when a YAML file is created successfully 
+        Test YAML file validation when a YAML file is created successfully
         """
         # Define a schema that requires "path" and provides defaults for "name" and "folder"
         schema = {
-            "$schema": "http://json-schema.org/draft-07/schema#",
-            "type": "object",
-            "properties": {
-                "path": {"type": "string"},
-                "name": {"type": "string", "default": "default_name"},
-                "folder": {
-                    "type": "string",
-                    "default": {
-                        "$ref": "#/path",
-                        "transform": "dirname",
-                        "prefix": "pre_",
-                        "suffix": "_suf",
+            '$schema': 'http://json-schema.org/draft-07/schema#',
+            'type': 'object',
+            'properties': {
+                'path': {'type': 'string'},
+                'name': {'type': 'string', 'default': 'default_name'},
+                'folder': {
+                    'type': 'string',
+                    'default': {
+                        '$ref': '#/path',
+                        'transform': 'dirname',
+                        'prefix': 'pre_',
+                        'suffix': '_suf',
                     },
                 },
             },
-            "required": ["path"],
+            'required': ['path'],
         }
         # Create a temporary schema file with the desired schema.
-        schema_file = tmp_path / "schema.yml"
+        schema_file = tmp_path / 'schema.yml'
         schema_file.write_text(yaml.dump(schema))
         # Create a temporary YAML configuration file containing only "path"
-        config_data = {"path": "/a/b/c.txt"}
-        config_file = tmp_path / "config.yml"
+        config_data = {'path': '/a/b/c.txt'}
+        config_file = tmp_path / 'config.yml'
         config_file.write_text(yaml.dump(config_data))
         # Instantiate the validator with the schema file.
         validator_instance = YAMLConfigValidator(str(schema_file))
         config = validator_instance.validate_yaml(str(config_file))
-        expected_folder = os.path.normpath(
-            "pre_" + os.path.dirname("/a/b/c.txt") + "_suf"
-        )
-        assert config["path"] == "/a/b/c.txt"
-        assert config["name"] == "default_name"
-        assert config["folder"] == expected_folder
+        expected_folder = os.path.normpath('pre_' + os.path.dirname('/a/b/c.txt') + '_suf')
+        assert config['path'] == '/a/b/c.txt'
+        assert config['name'] == 'default_name'
+        assert config['folder'] == expected_folder
 
     def test_validate_yaml_validation_error(self, tmp_path):
         """
@@ -196,22 +190,22 @@ class TestYAMLConfigValidator:
         """
         # Schema requires "path", so if it's missing, validation should error.
         schema = {
-            "$schema": "http://json-schema.org/draft-07/schema#",
-            "type": "object",
-            "properties": {"path": {"type": "string"}},
-            "required": ["path"],
+            '$schema': 'http://json-schema.org/draft-07/schema#',
+            'type': 'object',
+            'properties': {'path': {'type': 'string'}},
+            'required': ['path'],
         }
         # Create a temporary schema file.
-        schema_file = tmp_path / "schema.yml"
+        schema_file = tmp_path / 'schema.yml'
         schema_file.write_text(yaml.dump(schema))
         # Create a YAML file missing the required "path" property.
-        config_data = {"name": "some_name"}
-        config_file = tmp_path / "config_invalid.yml"
+        config_data = {'name': 'some_name'}
+        config_file = tmp_path / 'config_invalid.yml'
         config_file.write_text(yaml.dump(config_data))
         validator_instance = YAMLConfigValidator(str(schema_file))
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(YamlValidationError) as excinfo:
             validator_instance.validate_yaml(str(config_file))
-        assert "YAML file validation error" in str(excinfo.value)
+        assert 'YAML file validation error' in str(excinfo.value)
 
     # -----------------------------
     # Tests for export_schema_to_yaml: file contents
@@ -220,7 +214,7 @@ class TestYAMLConfigValidator:
         """
         Test yaml file contents to see if a yaml file with the correct input schema is saved to the file system
         """
-        schema = {"test": "value"}
+        schema = {'test': 'value'}
         self.validator.schema = schema
         # Test export without writing to a file.
         yaml_str = self.validator.export_schema_to_yaml()
@@ -228,7 +222,7 @@ class TestYAMLConfigValidator:
         assert loaded_schema == schema
 
         # Test export with writing to a file.
-        output_file = tmp_path / "schema_output.yml"
+        output_file = tmp_path / 'schema_output.yml'
         yaml_str_exported = self.validator.export_schema_to_yaml(str(output_file))
         file_content = output_file.read_text()
         loaded_schema_file = yaml.safe_load(file_content)
@@ -243,11 +237,11 @@ class TestYAMLConfigValidator:
         Test if a yaml file is saved to the file saved
         """
         # Define the data to be written to the YAML file
-        schema = {"test": "value"}
+        schema = {'test': 'value'}
         self.validator.schema = schema
 
         # Define the path for the temporary YAML file
-        output_file = tmp_path / "schema_output.yml"
+        output_file = tmp_path / 'schema_output.yml'
 
         # Write the data to the YAML file
         _ = self.validator.export_schema_to_yaml(str(output_file))


### PR DESCRIPTION
This RP add examples of how to define and use custom exceptions in Python. 

- As we develop the code we should be attentive to when we should prioritize the use of custom exceptions over built-in exception, with the purpose of providing better error messages to the end user.
- It  contains a few custom exceptions for the CLI and YAML parset.
- It allow mutable function calls when using `typer.Option()` 