### PR TITLE
Implement SedTRAILS format_converter module for NetCDF processing

### DIFF
--- a/examples/reading_flowfields_example.py
+++ b/examples/reading_flowfields_example.py
@@ -1,0 +1,58 @@
+"""
+Comprehensive example of SedTRAILS functionality.
+
+This script demonstrates the complete workflow for visualizing flow fields:
+1. Loading and converting flow data from NetCDF files
+2. Creating a flow field data retriever
+3. Processing and visualizing flow fields at specified time steps
+"""
+
+from pathlib import Path
+import matplotlib.pyplot as plt
+
+# Import Sedtrails modules
+from sedtrails.transport_converter.format_converter import FormatConverter, InputType
+from sedtrails.particle_tracer.data_retriever import FlowFieldDataRetriever
+
+# Import visualization utilities
+from visualization_utils import plot_flow_field
+
+# Set up the file path for the NetCDF file
+file_path = Path("../sedtrails_data/inlet_sedtrails.nc")
+print(f"Processing file: {file_path}")
+
+# Number of time steps to process (default: 5)
+num_timesteps = 10
+
+# ===== STEP 1: Load and Convert NetCDF File =====
+print("\n=== STEP 1: Loading and Converting Data ===")
+converter = FormatConverter(file_path, input_type=InputType.NETCDF_DFM)
+converter.read_data()
+time_info = converter.get_time_info()
+print(f"Time range: {time_info['time_start']} to {time_info['time_end']}, with total timestamps: {time_info['num_times']}")
+
+# Convert to SedtrailsData
+sedtrails_data = converter.convert_to_sedtrails_data()
+
+# ===== STEP 2: Create Flow Field Data Retriever =====
+print("\n=== STEP 2: Creating Flow Field Data Retriever ===")
+retriever = FlowFieldDataRetriever(sedtrails_data)
+print(f"Retriever created for flow field: {retriever.flow_field_name}")
+
+# ===== STEP 3: Process Each Time Step =====
+print("\n=== STEP 3: Processing Time Steps ===")
+indices = [int(1 + i * (num_timesteps - 2) / (num_timesteps - 1)) for i in range(num_timesteps)]
+for i, idx in enumerate(indices):
+
+    current_time = sedtrails_data.times[idx]
+    print(f"Time step {i+1}/{num_timesteps} - Time: {current_time:.2f} s")
+    
+    # Get flow field data for the current time
+    flow_data = retriever.get_flow_field(current_time)
+    
+    # Create individual plot for current time step
+    fig, ax = plot_flow_field(flow_data)
+    fig.savefig(f"../sedtrails_data/flow_field_{i+1:03d}.png", dpi=300, bbox_inches='tight')
+    plt.close(fig)  # Close the figure to save memory
+
+print("\nExample completed successfully!")

--- a/examples/visualization_utils.py
+++ b/examples/visualization_utils.py
@@ -1,0 +1,87 @@
+"""
+TEMPORARY visualization utilities for SedTRAILS.
+
+This module provides visualization functions for SedTRAILS data,
+particularly for flow field visualization.
+"""
+import matplotlib.pyplot as plt
+
+def plot_flow_field(flow_data, title=None, downsample=5, figsize=(12, 10), 
+                   cmap='viridis', vector_color='white', save_path=None):
+    """
+    Plot flow field with magnitude as contour and vectors for direction.
+    
+    Parameters:
+    -----------
+    flow_data : dict
+        Dictionary containing 'x', 'y', 'u', 'v', and 'magnitude' arrays
+    title : str, optional
+        Title for the plot
+    downsample : int, optional
+        Factor to downsample vectors for clearer visualization
+    figsize : tuple, optional
+        Figure size (width, height) in inches
+    cmap : str, optional
+        Colormap for the contour plot
+    vector_color : str, optional
+        Color for the velocity vectors
+    save_path : str, optional
+        Path to save the figure. If None, figure is not saved.
+        
+    Returns:
+    --------
+    tuple
+        (fig, ax) matplotlib figure and axis objects
+    """
+    # Extract data
+    x = flow_data['x']
+    y = flow_data['y']
+    u = flow_data['u']
+    v = flow_data['v']
+    magnitude = flow_data['magnitude']
+    
+    # Create figure
+    fig, ax = plt.subplots(figsize=figsize)
+    
+    # Plot magnitude as contour/heatmap
+    contour = ax.tricontourf(x, y, magnitude, cmap=cmap, levels=20)
+    
+    # Add colorbar
+    cbar = plt.colorbar(contour, ax=ax)
+    cbar.set_label('Flow Magnitude (m/s)')
+    
+    # Downsample for vectors to avoid cluttering
+    skip = (slice(None, None, downsample), slice(None, None, downsample))
+    if len(x.shape) > 1:  # 2D grid
+        x_subset = x[skip]
+        y_subset = y[skip]
+        u_subset = u[skip]
+        v_subset = v[skip]
+    else:  # 1D arrays
+        x_subset = x[::downsample]
+        y_subset = y[::downsample]
+        u_subset = u[::downsample]
+        v_subset = v[::downsample]
+    
+    # Plot velocity vectors
+    q = ax.quiver(x_subset, y_subset, u_subset, v_subset, 
+                 color=vector_color, scale=15, width=0.002)
+    ax.quiverkey(q, 0.85, 0.02, 0.5, "0.5 m/s", 
+                labelpos='E', coordinates='figure', color=vector_color)
+    
+    # Set labels and title
+    ax.set_xlabel('X (m)')
+    ax.set_ylabel('Y (m)')
+    if title:
+        ax.set_title(title)
+    else:
+        ax.set_title('Flow Field Visualization')
+    
+    # Equal aspect ratio for geographic data
+    ax.set_aspect('equal')
+    
+    # Save figure if path is provided
+    if save_path:
+        fig.savefig(save_path, dpi=300, bbox_inches='tight')
+        
+    return fig, ax

--- a/src/sedtrails/particle_tracer/data_retriever.py
+++ b/src/sedtrails/particle_tracer/data_retriever.py
@@ -4,10 +4,9 @@ Flow Field Data Retriever
 Retrieves flow field data from the transport converter or the simulation caching and state tracker.
 Performs temporal interpolation to provide accurate flow field data at any time point for particle tracing.
 """
-from typing import Dict, Tuple, Optional, Callable
+from typing import Tuple
 import numpy as np
 import sys
-import os
 from pathlib import Path
 
 # Add parent directory to path to allow importing from other packages

--- a/src/sedtrails/particle_tracer/data_retriever.py
+++ b/src/sedtrails/particle_tracer/data_retriever.py
@@ -1,5 +1,165 @@
 """
 Flow Field Data Retriever
-=========================
-Retrieve flow field data from the transport converter or the simulation caching and state tracker.
+
+Retrieves flow field data from the transport converter or the simulation caching and state tracker.
+Performs temporal interpolation to provide accurate flow field data at any time point for particle tracing.
 """
+from typing import Dict, Tuple, Optional, Callable
+import numpy as np
+import sys
+import os
+from pathlib import Path
+
+# Add parent directory to path to allow importing from other packages
+sys.path.append(str(Path(__file__).parent.parent.parent))
+from sedtrails.transport_converter.format_converter import SedtrailsData
+
+
+class FlowFieldDataRetriever:
+    """
+    Retrieves and interpolates flow field data from SedtrailsData.
+    
+    This class provides methods to extract flow fields at specific times,
+    performing temporal interpolation as needed. Currently supports depth-averaged
+    flow velocity.
+    """
+    
+    def __init__(self, sedtrails_data: SedtrailsData):
+        """
+        Initialize the FlowFieldDataRetriever.
+        
+        Parameters:
+        -----------
+        sedtrails_data : SedtrailsData
+            The SedtrailsData object containing the flow fields
+        """
+        self.sedtrails_data = sedtrails_data
+        
+        # Only using depth-averaged flow velocity for now
+        self.flow_field_name = "depth_avg_flow_velocity"
+    
+    def get_interpolation_indices(self, target_time: float) -> Tuple[int, int, float]:
+        """
+        Get indices for interpolation between two time steps.
+        
+        Parameters:
+        -----------
+        target_time : float
+            Target time in seconds since reference_date
+            
+        Returns:
+        --------
+        Tuple[int, int, float]
+            (lower_index, upper_index, weight) where weight is the interpolation factor [0-1]
+        """
+        times = self.sedtrails_data.times
+        
+        # Handle edge cases
+        if target_time <= times[0]:
+            return 0, 0, 0.0
+        
+        if target_time >= times[-1]:
+            last_idx = len(times) - 1
+            return last_idx, last_idx, 1.0
+        
+        # Find the index of the last time that is less than or equal to the target time
+        lower_idx = np.searchsorted(times, target_time, side='right') - 1
+        upper_idx = lower_idx + 1
+        
+        # Calculate the interpolation weight
+        time_range = times[upper_idx] - times[lower_idx]
+        
+        # Avoid division by zero
+        if time_range == 0:
+            weight = 0.0
+        else:
+            weight = (target_time - times[lower_idx]) / time_range
+            
+        return lower_idx, upper_idx, weight
+    
+    def get_flow_field(self, time: float) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Get the flow field at the specified time.
+        
+        This method performs temporal interpolation between the two closest time steps
+        in the SedtrailsData object to obtain the flow field at the requested time.
+        
+        Parameters:
+        -----------
+        time : float
+            Time in seconds since the reference date of the SedtrailsData object
+            
+        Returns:
+        --------
+        Tuple[np.ndarray, np.ndarray]
+            Tuple containing (flow_x, flow_y) arrays
+        """
+        # Get indices for interpolation
+        lower_idx, upper_idx, weight = self.get_interpolation_indices(time)
+        
+        # If time is exactly at a time step or outside the range, no interpolation needed
+        if lower_idx == upper_idx:
+            time_slice = self.sedtrails_data[lower_idx]
+            flow_field = time_slice[self.flow_field_name]
+            return flow_field['x'], flow_field['y']
+        
+        # Otherwise, perform linear interpolation between the two time steps
+        lower_slice = self.sedtrails_data[lower_idx]
+        upper_slice = self.sedtrails_data[upper_idx]
+        
+        lower_flow = lower_slice[self.flow_field_name]
+        upper_flow = upper_slice[self.flow_field_name]
+        
+        # Linear interpolation: result = (1-w)*lower + w*upper
+        flow_x = (1 - weight) * lower_flow['x'] + weight * upper_flow['x']
+        flow_y = (1 - weight) * lower_flow['y'] + weight * upper_flow['y']
+        
+        return flow_x, flow_y
+
+
+if __name__ == "__main__":
+    # Example usage - this requires SedtrailsData from format_converter.py
+    try:
+        # Import from the correct location
+        from sedtrails.transport_converter.format_converter import FormatConverter, InputType
+        
+        # Default file path (can be overridden by command line argument)
+        file_path = r"c:\Users\weste_bt\GitHub\sedtrails_data\inlet_sedtrails.nc"
+        
+        # Allow command line override of file path
+        if len(sys.argv) > 1:
+            file_path = sys.argv[1]
+        
+        # Create converter and read data
+        converter = FormatConverter(file_path, input_type=InputType.NETCDF_DFM)
+        converter.read_data()
+        
+        # Convert to SedtrailsData
+        sedtrails_data = converter.convert_to_sedtrails_data()
+        
+        # Create flow field data retriever
+        retriever = FlowFieldDataRetriever(sedtrails_data)
+        
+        # Choose a time for interpolation (30% between first and last time step)
+        test_time = sedtrails_data.times[0] + (sedtrails_data.times[-1] - sedtrails_data.times[0]) * 0.3
+        
+        # Get flow field at the test time
+        flow_x, flow_y = retriever.get_flow_field(test_time)
+        
+        # Print some information
+        print(f"Time: {test_time} seconds since {sedtrails_data.reference_date}")
+        print(f"Flow field shape - X: {flow_x.shape}, Y: {flow_y.shape}")
+        
+        # Calculate mean and max flow for verification
+        mean_fx = np.nanmean(flow_x)
+        max_fx = np.nanmax(np.abs(flow_x))
+        mean_fy = np.nanmean(flow_y)
+        max_fy = np.nanmax(np.abs(flow_y))
+        
+        print(f"Mean flow: ({mean_fx:.5f}, {mean_fy:.5f}) m/s")
+        print(f"Max flow magnitude: ({max_fx:.5f}, {max_fy:.5f}) m/s")
+        
+    except ImportError as e:
+        print(f"Import error: {e}")
+        print("Make sure the format_converter.py module is in the correct location:")
+        print("src/sedtrails/transport_converter/format_converter.py")

--- a/src/sedtrails/transport_converter/format_converter.py
+++ b/src/sedtrails/transport_converter/format_converter.py
@@ -1,80 +1,509 @@
 """
-Format Converter: manage the conversion of input data formats and into a internal format.
+Format Converter: manage the conversion of input data formats into an internal format.
+
+This module provides functionality to read various input data formats (e.g., NetCDF files
+from different hydrodynamic models) and convert them into the SedtrailsData structure
+for use in the SedTRAILS particle tracking system.
 """
+import os
+import numpy as np
+import xarray as xr
+import xugrid as xu
+from enum import Enum
+from typing import Union, Dict, List, Optional, Tuple
 from dataclasses import dataclass, field
-from typing import List
+from pathlib import Path
+
+
+class InputType(Enum):
+    """Enumeration of supported input data types."""
+    NETCDF_DFM = "netcdf_dfm"  # Delft3D Flexible Mesh NetCDF
+    NETCDF_GENERIC = "netcdf_generic"  # Generic NetCDF
+    # Add more input types as needed
+
 
 @dataclass
 class SedtrailsData:
     """
-    A data class for internal structuring SedTrails data.
+    A data class for internally structuring SedTrails data.
+    
+    This class holds data for multiple time steps with time as the first dimension
+    for time-dependent variables.
 
     Attributes:
     -----------
-        time: int
+        times: np.ndarray
+            Array of time values in seconds since epoch
+        x: np.ndarray
+            X-coordinates of the grid cells
+        y: np.ndarray
+            Y-coordinates of the grid cells
+        time_step: int
+            Time step in seconds
+        bed_level: np.ndarray
+            Bed level in meters (typically time-independent)
+        depth_avg_flow_velocity: Dict[str, np.ndarray]
+            Depth-averaged flow velocity components in m/s 
+            (keys: 'x', 'y', 'magnitude', each with time as first dimension)
+        fractions: int
+            Number of sediment fractions
+        bed_load_sediment: Dict[str, np.ndarray]
+            Bed load sediment transport in kg/m/s 
+            (keys: 'x', 'y', 'magnitude', each with time as first dimension)
+        suspended_sediment: Dict[str, np.ndarray]
+            Suspended sediment transport in kg/m/s 
+            (keys: 'x', 'y', 'magnitude', each with time as first dimension)
+        water_depth: np.ndarray
+            Water depth in meters (with time as first dimension)
+        mean_bed_shear_stress: np.ndarray
+            Mean bed shear stress in pascal (with time as first dimension)
+        max_bed_shear_stress: np.ndarray
+            Max bed shear stress in pascal (with time as first dimension)
+        sediment_concentration: np.ndarray
+            Suspended sediment concentration in kg/m^3 (with time as first dimension)
+        nonlinear_wave_velocity: Dict[str, np.ndarray]
+            Nonlinear wave velocity in m/s 
+            (keys: 'x', 'y', 'magnitude', each with time as first dimension)
     """
     
-    time: int # current time in seconds
-    x: int # spatial coordinate in x direction
-    y: int # spatial coordinate in y direction
-    time_step: int # time step in seconds
-    bed_level: float # bed level in meters
-    depth_avg_flow_velocity: float # depth average flow velocity in m/s
-    fractions: int # number of fractions
-    bed_load_sediment: float # bed load sediment transport in kg/m/s
-    suspended_sediment: float # suspended sediment transport in kg/m/s
-    water_depth: float # water depth in meters
-    mean_bed_shear_stress: float # mean bed shear stress in pascal
-    max_bed_shear_stress: float # max bed shear stress in pascal
-    sediment_concentration: float # suspended sediment concentration in kg/m^3
-    nonlinear_wave_velocity: float # nonlinear wave velocity in m/s
-    previous = field(default=None, init=False)  # previous data in the sequence
-    next= field(default=None, init=False)  # next data in the sequence
+    times: np.ndarray
+    x: np.ndarray
+    y: np.ndarray
+    time_step: int
+    bed_level: np.ndarray
+    depth_avg_flow_velocity: Dict[str, np.ndarray]
+    fractions: int
+    bed_load_sediment: Dict[str, np.ndarray]
+    suspended_sediment: Dict[str, np.ndarray]
+    water_depth: np.ndarray
+    mean_bed_shear_stress: np.ndarray
+    max_bed_shear_stress: np.ndarray
+    sediment_concentration: np.ndarray
+    nonlinear_wave_velocity: Dict[str, np.ndarray]
     
-    @property
-    def previous(self):
-        return self._previous
-    
-    @property
-    def next(self):
-        return self._next
-    
-    @previous.setter
-    def previous(self, data_sequence):
-        self._previous = data_sequence
-
-    @next.setter
-    def next(self, data_sequence):
-        self._next = data_sequence
-
-    def data_instance(self):
+    def __getitem__(self, time_idx: int) -> Dict:
         """
-        Returns an instance of the current data.
+        Get data for a specific time index.
+        
+        Parameters:
+        -----------
+        time_idx : int
+            Time index to extract
+            
+        Returns:
+        --------
+        Dict
+            Dictionary containing all data for the specified time index
         """
-        return self
+        if time_idx < 0 or time_idx >= len(self.times):
+            raise IndexError(f"Time index {time_idx} out of bounds (0-{len(self.times)-1})")
+        
+        # Create a dictionary with time-specific data
+        time_data = {
+            'time': self.times[time_idx],
+            'x': self.x,
+            'y': self.y,
+            'time_step': self.time_step,
+            'bed_level': self.bed_level,  # Bed level is typically time-independent
+            'fractions': self.fractions,
+            
+            # Extract time slice from time-dependent variables
+            'water_depth': self.water_depth[time_idx],
+            'mean_bed_shear_stress': self.mean_bed_shear_stress[time_idx],
+            'max_bed_shear_stress': self.max_bed_shear_stress[time_idx],
+            'sediment_concentration': self.sediment_concentration[time_idx],
+            
+            # Extract time slice from vector quantities
+            'depth_avg_flow_velocity': {
+                'x': self.depth_avg_flow_velocity['x'][time_idx],
+                'y': self.depth_avg_flow_velocity['y'][time_idx],
+                'magnitude': self.depth_avg_flow_velocity['magnitude'][time_idx]
+            },
+            'bed_load_sediment': {
+                'x': self.bed_load_sediment['x'][time_idx],
+                'y': self.bed_load_sediment['y'][time_idx],
+                'magnitude': self.bed_load_sediment['magnitude'][time_idx]
+            },
+            'suspended_sediment': {
+                'x': self.suspended_sediment['x'][time_idx],
+                'y': self.suspended_sediment['y'][time_idx],
+                'magnitude': self.suspended_sediment['magnitude'][time_idx]
+            },
+            'nonlinear_wave_velocity': {
+                'x': self.nonlinear_wave_velocity['x'][time_idx],
+                'y': self.nonlinear_wave_velocity['y'][time_idx],
+                'magnitude': self.nonlinear_wave_velocity['magnitude'][time_idx]
+            }
+        }
+        
+        return time_data
+    
+    def __len__(self) -> int:
+        """
+        Get the number of time steps.
+        
+        Returns:
+        --------
+        int
+            Number of time steps
+        """
+        return len(self.times)
+    
+    def get_time_index(self, target_time) -> int:
+        """
+        Find the index of the closest time to the target time.
+        
+        Parameters:
+        -----------
+        target_time : np.datetime64 or similar
+            Target time to find
+            
+        Returns:
+        --------
+        int
+            Index of the closest time
+        """
+        # Convert target_time to seconds since epoch if it's datetime64
+        if isinstance(target_time, np.datetime64):
+            target_seconds = target_time.astype('datetime64[s]').astype(int)
+        else:
+            target_seconds = target_time
+            
+        # Find the closest time
+        time_diffs = np.abs(self.times - target_seconds)
+        return np.argmin(time_diffs)
 
 
-
+class FormatConverter:
+    """
+    A class to convert various input data formats to the SedtrailsData format.
+    
+    This class provides methods to read data from different file formats and
+    convert them to the SedtrailsData format for use in the SedTRAILS particle
+    tracking system.
+    """
+    
+    def __init__(self, input_file: Union[str, Path], input_type: Union[str, InputType] = InputType.NETCDF_DFM):
+        """
+        Initialize the FormatConverter.
+        
+        Parameters:
+        -----------
+        input_file : str or Path
+            Path to the input file
+        input_type : str or InputType, optional
+            Type of input data, by default InputType.NETCDF_DFM
+        """
+        self.input_file = Path(input_file)
+        
+        if isinstance(input_type, str):
+            try:
+                self.input_type = InputType(input_type.lower())
+            except ValueError:
+                raise ValueError(f"Invalid input type: {input_type}. Must be one of {[t.value for t in InputType]}")
+        else:
+            self.input_type = input_type
+            
+        self.input_data = None
+        
+    def read_data(self) -> None:
+        """
+        Read the input data based on the input type.
+        """
+        if not self.input_file.exists():
+            raise FileNotFoundError(f"Input file not found: {self.input_file}")
+        
+        if self.input_type == InputType.NETCDF_DFM:
+            self._read_netcdf_dfm()
+        elif self.input_type == InputType.NETCDF_GENERIC:
+            self._read_netcdf_generic()
+        else:
+            raise NotImplementedError(f"Input type not implemented: {self.input_type}")
+    
+    def _read_netcdf_dfm(self) -> None:
+        """
+        Read a Delft3D Flexible Mesh NetCDF file using xugrid.
+        """
+        try:
+            # First try using xugrid's open_dataset which handles UGRID conventions
+            self.input_data = xu.open_dataset(self.input_file)
+        except Exception as e:
+            print(f"Could not open file with xugrid: {e}")
+            # Fallback to regular xarray
+            try:
+                self.input_data = xr.open_dataset(self.input_file)
+            except Exception as e:
+                raise IOError(f"Failed to open NetCDF file: {e}")
+                
+        print(f"Successfully loaded {self.input_file}")
+        print(f"Variables in dataset: {list(self.input_data.data_vars)}")
+    
+    def _read_netcdf_generic(self) -> None:
+        """
+        Read a generic NetCDF file using xarray.
+        """
+        try:
+            self.input_data = xr.open_dataset(self.input_file)
+        except Exception as e:
+            raise IOError(f"Failed to open NetCDF file: {e}")
+    
+    def get_time_info(self) -> Dict:
+        """
+        Get time information from the dataset.
+        
+        Returns:
+        --------
+        Dict
+            Dictionary containing time values, start time, end time, and time step
+        """
+        if self.input_data is None:
+            raise ValueError("Dataset not loaded. Call read_data() first.")
+        
+        time_values = self.input_data['time'].values
+        time_start = time_values[0]
+        time_end = time_values[-1]
+        
+        # Calculate time step if more than one time value
+        if len(time_values) > 1:
+            time_step = time_values[1] - time_values[0]
+        else:
+            time_step = np.timedelta64(0, 'ns')
+        
+        return {
+            'time_values': time_values,
+            'time_start': time_start,
+            'time_end': time_end,
+            'time_step': time_step,
+            'num_times': len(time_values)
+        }
+    
+    def _map_dfm_variables(self) -> Dict:
+        """
+        Map Delft3D Flexible Mesh variables to SedtrailsData structure.
+        
+        This function processes all time steps at once.
+            
+        Returns:
+        --------
+        Dict
+            Dictionary with mapped variables
+        """
+        if self.input_data is None:
+            raise ValueError("Dataset not loaded. Call read_data() first.")
+            
+        # Get time information
+        time_info = self.get_time_info()
+        num_times = time_info['num_times']
+        
+        # Variable mapping for DFM files
+        variable_map = {
+            'x': 'net_xcc',  # X-coordinates
+            'y': 'net_ycc',  # Y-coordinates
+            'bed_level': 'bedlevel',  # Bed level
+            'water_depth': 'waterdepth',  # Water depth
+            'flow_velocity_x': 'sea_water_x_velocity',  # X-component of flow velocity
+            'flow_velocity_y': 'sea_water_y_velocity',  # Y-component of flow velocity
+            'mean_bed_shear_stress': 'mean_bss_magnitude',  # Mean bed shear stress
+            'max_bed_shear_stress': 'max_bss_magnitude',  # Max bed shear stress
+            'bed_load_sediment_x': 'bedload_x_comp',  # X-component of bed load sediment transport
+            'bed_load_sediment_y': 'bedload_y_comp',  # Y-component of bed load sediment transport
+            'suspended_sediment_x': 'susload_x_comp',  # X-component of suspended sediment transport
+            'suspended_sediment_y': 'susload_y_comp',  # Y-component of suspended sediment transport
+            'sediment_concentration': 'suspended_sed_conc',  # Suspended sediment concentration
+        }
+        
+        # Extract data from dataset
+        data = {}
+        
+        # First, get spatial coordinates (typically not time-dependent)
+        for key in ['x', 'y']:
+            var_name = variable_map[key]
+            if var_name in self.input_data:
+                data[key] = self.input_data[var_name].values
+            else:
+                raise KeyError(f"Required variable '{var_name}' not found in dataset")
+        
+        # Determine the spatial grid dimensions
+        grid_shape = data['x'].shape
+        
+        # Get bed level (typically not time-dependent)
+        var_name = variable_map['bed_level']
+        if var_name in self.input_data:
+            bed_level_var = self.input_data[var_name]
+            if 'time' in bed_level_var.dims:
+                # If bed level has a time dimension, take the first time step
+                data['bed_level'] = bed_level_var.isel(time=0).values
+            else:
+                data['bed_level'] = bed_level_var.values
+        else:
+            # Default to zeros if not found
+            data['bed_level'] = np.zeros(grid_shape)
+            
+        # Extract time-dependent variables
+        time_dependent_vars = [
+            'water_depth', 'mean_bed_shear_stress', 'max_bed_shear_stress',
+            'sediment_concentration', 'flow_velocity_x', 'flow_velocity_y',
+            'bed_load_sediment_x', 'bed_load_sediment_y',
+            'suspended_sediment_x', 'suspended_sediment_y'
+        ]
+        
+        for key in time_dependent_vars:
+            var_name = variable_map[key]
+            if var_name in self.input_data:
+                var = self.input_data[var_name]
+                
+                # Check if variable has time dimension
+                if 'time' in var.dims:
+                    # Check if variable has layer dimension
+                    if 'layer' in var.dims:
+                        # For variables with time and layer, select layer 0
+                        data[key] = var.isel(layer=0).values
+                    else:
+                        # For variables with time but no layer
+                        data[key] = var.values
+                else:
+                    # For variables without time dimension, broadcast to all time steps
+                    data[key] = np.broadcast_to(var.values, (num_times, *var.shape))
+            else:
+                # Default to zeros if not found
+                data[key] = np.zeros((num_times, *grid_shape))
+                print(f"Warning: Variable '{var_name}' not found, using zeros")
+                
+        return data
+    
+    def convert_to_sedtrails_data(self) -> SedtrailsData:
+        """
+        Convert the loaded dataset to SedtrailsData format for all time steps.
+            
+        Returns:
+        --------
+        SedtrailsData
+            Data in SedtrailsData format with time as the first dimension for
+            time-dependent variables
+        """
+        if self.input_data is None:
+            raise ValueError("Dataset not loaded. Call read_data() first.")
+        
+        # Get time information
+        time_info = self.get_time_info()
+        time_values = time_info['time_values']
+        time_step = time_info['time_step']
+        
+        # Convert time step to seconds
+        time_step_seconds = int(time_step / np.timedelta64(1, 's'))
+        
+        # Convert time values to seconds since epoch for consistency
+        times_seconds = np.array([t.astype('datetime64[s]').astype(int) for t in time_values])
+        
+        # Get mapped variables based on input type
+        if self.input_type == InputType.NETCDF_DFM:
+            data = self._map_dfm_variables()
+        else:
+            raise NotImplementedError(f"Conversion not implemented for input type: {self.input_type}")
+        
+        # Calculate magnitudes for vector quantities
+        # Flow velocity magnitude
+        depth_avg_velocity_magnitude = np.sqrt(
+            data['flow_velocity_x']**2 + data['flow_velocity_y']**2
+        )
+        
+        # Bed load magnitude
+        bed_load_magnitude = np.sqrt(
+            data['bed_load_sediment_x']**2 + data['bed_load_sediment_y']**2
+        )
+        
+        # Suspended sediment magnitude
+        suspended_sediment_magnitude = np.sqrt(
+            data['suspended_sediment_x']**2 + data['suspended_sediment_y']**2
+        )
+        
+        # Create dictionaries for vector quantities
+        depth_avg_flow_velocity = {
+            'x': data['flow_velocity_x'],
+            'y': data['flow_velocity_y'],
+            'magnitude': depth_avg_velocity_magnitude
+        }
+        
+        bed_load_sediment = {
+            'x': data['bed_load_sediment_x'],
+            'y': data['bed_load_sediment_y'],
+            'magnitude': bed_load_magnitude
+        }
+        
+        suspended_sediment = {
+            'x': data['suspended_sediment_x'],
+            'y': data['suspended_sediment_y'],
+            'magnitude': suspended_sediment_magnitude
+        }
+        
+        # Create nonlinear wave velocity dictionary with zeros
+        # Using the same shape as other vector quantities
+        nonlinear_wave_velocity = {
+            'x': np.zeros_like(data['flow_velocity_x']),
+            'y': np.zeros_like(data['flow_velocity_y']),
+            'magnitude': np.zeros_like(depth_avg_velocity_magnitude)
+        }
+        
+        # Create SedtrailsData object
+        sedtrails_data = SedtrailsData(
+            times=times_seconds,
+            x=data['x'],
+            y=data['y'],
+            time_step=time_step_seconds,
+            bed_level=data['bed_level'],
+            depth_avg_flow_velocity=depth_avg_flow_velocity,
+            fractions=1,  # Default to 1 fraction
+            bed_load_sediment=bed_load_sediment,
+            suspended_sediment=suspended_sediment,
+            water_depth=data['water_depth'],
+            mean_bed_shear_stress=data['mean_bed_shear_stress'],
+            max_bed_shear_stress=data['max_bed_shear_stress'],
+            sediment_concentration=data['sediment_concentration'],
+            nonlinear_wave_velocity=nonlinear_wave_velocity
+        )
+        
+        return sedtrails_data
 
 
 if __name__ == "__main__":
-    data = SedtrailsData(   time=0,
-                            x=0,
-                            y=0,
-                            time_step=0,
-                            bed_level=0.0,
-                            depth_avg_flow_velocity=0.0,
-                            fractions=0,
-                            bed_load_sediment=0.0,
-                            suspended_sediment=0.0,
-                            water_depth=0.0,
-                            mean_bed_shear_stress=0.0,
-                            max_bed_shear_stress=0.0,
-                            sediment_concentration=0.0,
-                            nonlinear_wave_velocity=0.0)
-    print(data)
-
-    data.previous = 'previous data'
-    print(data.previous)
-
-    # print(data.data_instance())
+    # Example usage
+    import sys
+    
+    # Default file path (can be overridden by command line argument)
+    file_path = r"c:\Users\weste_bt\GitHub\sedtrails_data\inlet_sedtrails.nc"
+    
+    # Allow command line override of file path
+    if len(sys.argv) > 1:
+        file_path = sys.argv[1]
+    
+    # Create converter and read data
+    converter = FormatConverter(file_path, input_type=InputType.NETCDF_DFM)
+    converter.read_data()
+    
+    # Print time information
+    time_info = converter.get_time_info()
+    print(f"Time information:")
+    print(f"  Start time: {time_info['time_start']}")
+    print(f"  End time: {time_info['time_end']}")
+    print(f"  Time step: {time_info['time_step']}")
+    print(f"  Number of time steps: {time_info['num_times']}")
+    
+    # Convert all time steps to SedtrailsData
+    sedtrails_data = converter.convert_to_sedtrails_data()
+    
+    # Print some information about the converted data
+    print("\nConverted data:")
+    print(f"  Number of time steps: {len(sedtrails_data)}")
+    print(f"  X shape: {sedtrails_data.x.shape}")
+    print(f"  Y shape: {sedtrails_data.y.shape}")
+    print(f"  Bed level shape: {sedtrails_data.bed_level.shape}")
+    
+    # Time-dependent data shapes
+    print(f"  Water depth shape: {sedtrails_data.water_depth.shape}")
+    print(f"  Flow velocity magnitude shape: {sedtrails_data.depth_avg_flow_velocity['magnitude'].shape}")
+    
+    # Demonstrate accessing a time slice
+    time_slice = sedtrails_data[0]  # Get first time step
+    print("\nFirst time slice:")
+    print(f"  Time: {time_slice['time']}")
+    print(f"  Flow velocity magnitude shape: {time_slice['depth_avg_flow_velocity']['magnitude'].shape}")

--- a/src/sedtrails/transport_converter/format_converter.py
+++ b/src/sedtrails/transport_converter/format_converter.py
@@ -5,15 +5,14 @@ This module reads various input data formats (e.g., NetCDF files from different
 hydrodynamic models) and converts them into the SedtrailsData structure for 
 use in the SedTRAILS particle tracking system.
 """
-import os
 import numpy as np
 import xarray as xr
 import xugrid as xu
 from enum import Enum
-from typing import Union, Dict, List, Optional, Tuple
-from dataclasses import dataclass, field
+from typing import Union, Dict, Tuple
+from dataclasses import dataclass
 from pathlib import Path
-from datetime import datetime, timezone
+from datetime import datetime
 
 
 class InputType(Enum):

--- a/src/sedtrails/transport_converter/format_converter.py
+++ b/src/sedtrails/transport_converter/format_converter.py
@@ -234,7 +234,7 @@ class FormatConverter:
             try:
                 self.input_type = InputType(input_type.lower())
             except ValueError:
-                raise ValueError(f"Invalid input type: {input_type}. Must be one of {[t.value for t in InputType]}")
+                raise ValueError(f"Invalid input type: {input_type}. Must be one of {[t.value for t in InputType]}") from ValueError
         else:
             self.input_type = input_type
         
@@ -259,7 +259,7 @@ class FormatConverter:
             self._read_netcdf_dfm()
         elif self.input_type == InputType.TRIM_D3D4:
             # Placeholder for future implementation
-            raise NotImplementedError(f"TRIM_D3D4 format not implemented yet")
+            raise NotImplementedError("TRIM_D3D4 format not implemented yet")
         else:
             raise NotImplementedError(f"Input type not implemented: {self.input_type}")
     
@@ -276,7 +276,7 @@ class FormatConverter:
             try:
                 self.input_data = xr.open_dataset(self.input_file)
             except Exception as e:
-                raise IOError(f"Failed to open NetCDF file: {e}")
+                raise IOError(f"Failed to open NetCDF file: {e}") from e
                 
         print(f"Successfully loaded {self.input_file}")
         print(f"Variables in dataset: {list(self.input_data.data_vars)}")
@@ -521,7 +521,7 @@ if __name__ == "__main__":
     
     # Print time information
     time_info = converter.get_time_info()
-    print(f"Time information:")
+    print("Time information:")
     print(f"  Reference date: {time_info['reference_date']}")
     print(f"  Start time: {time_info['time_start']}")
     print(f"  End time: {time_info['time_end']}")


### PR DESCRIPTION
Created a new format_converter module for the SedTRAILS particle tracking system  #151 

- Designed SedtrailsData structure for multidimensional hydrodynamic data with efficient time handling
- Implemented FormatConverter class to read and transform Delft3D Flexible Mesh NetCDF files
- Added robust variable mapping from DFM to SedtrailsData format
- Built time-dimension handling with time as first axis in all time-dependent variables
- Included dictionary-based storage for vector quantities (velocity, sediment transport)
- Added time indexing functionality for easy access to specific time slices
- Implemented comprehensive error handling for missing files and variables
- Added fallback to xarray when xugrid can't process a file
- Created command-line interface for testing with sample NetCDF files
- Added detailed docstrings and comments throughout the code

This module serves as the foundation for reading hydrodynamic simulation outputs and preparing them for particle tracing, supporting the overall SedTRAILS coastal sediment modeling workflow.