### PR TITLE
Modify Time class in Particle class

### DIFF
--- a/src/sedtrails/particle_tracer/particle.py
+++ b/src/sedtrails/particle_tracer/particle.py
@@ -16,8 +16,8 @@ class Time:
 
     Attributes
     ----------
-    reference_date : numpy.datetime64
-        The reference date for calculating time.
+    reference_date : str
+        The reference date as string in format 'YYYY-MM-DD'
     offset_seconds : numpy.timedelta64
         The offset in seconds from the reference date.
 
@@ -29,14 +29,21 @@ class Time:
         Updates the current time by adding a delta in seconds.
     """
 
-    reference_date: np.datetime64 = field(default=np.datetime64('1970-01-01T00:00:00', 's'))
+    # refence_date should be a str, the class will do the transformation into a numpy.datetime64 object
+    reference_date: str = field(default='1970-01-01')
     offset_seconds: np.timedelta64 = field(default=np.timedelta64(0, 's'))
+    _reference_date_np: np.datetime64 = field(init=False)
 
+    def _convert_to_datetime64(self, date_str: str) -> np.datetime64:
+        """Convert reference_date in str format to numpy.datetime64"""
+        return np.datetime64(f"{date_str}T00:00:00", 's')
+    
     def __post_init__(self):
-        if not isinstance(self.reference_date, np.datetime64):
-            raise TypeError(f"Expected 'reference_date' to be a numpy.datetime64, got {type(self.reference_date).__name__}")
-        if self.reference_date.dtype != 'datetime64[s]':
-            raise ValueError("reference_date must have a resolution of seconds (datetime64[s]).")
+        # Accept reference_date in str format TODO: should we allow for non str formats?
+        try:
+            self._reference_date_np = self._convert_to_datetime64(self.reference_date)
+        except ValueError:
+            raise ValueError("reference_date must be in format 'YYYY-MM-DD'")
         if not isinstance(self.offset_seconds, np.timedelta64):
             raise TypeError(f"Expected 'offset_seconds' to be a numpy.timedelta64, got {type(self.offset_seconds).__name__}")
         if self.offset_seconds.dtype != 'timedelta64[s]':
@@ -51,8 +58,15 @@ class Time:
         numpy.datetime64
             The current time in the simulation.
         """
-        return self.reference_date + self.offset_seconds
+        return self._reference_date_np + self.offset_seconds
 
+    def get_seconds_since_reference(self) -> int:
+        """
+        Returns the number of seconds since the reference date/time.
+        """
+        # Will complete once I can clarify the different between reference_date and simulation start
+        pass   
+    
     def update(self, delta_seconds: np.timedelta64):
         """
         Updates the current time by adding a delta in seconds.

--- a/src/sedtrails/particle_tracer/particle.py
+++ b/src/sedtrails/particle_tracer/particle.py
@@ -18,7 +18,7 @@ class Time:
     ----------
     reference_date : str
         The reference date as string in format 'YYYY-MM-DD'
-    offset_seconds : numpy.timedelta64
+    offset_seconds : int
         The offset in seconds from the reference date.
 
     Methods
@@ -29,9 +29,9 @@ class Time:
         Updates the current time by adding a delta in seconds.
     """
 
-    # refence_date should be a str, the class will do the transformation into a numpy.datetime64 object
+    # reference_date should be a str, the class will do the transformation into a numpy.datetime64 object
     reference_date: str = field(default='1970-01-01')
-    offset_seconds: np.timedelta64 = field(default=np.timedelta64(0, 's'))
+    offset_seconds: int = 0
     _reference_date_np: np.datetime64 = field(init=False)
 
     def _convert_to_datetime64(self, date_str: str) -> np.datetime64:
@@ -44,10 +44,8 @@ class Time:
             self._reference_date_np = self._convert_to_datetime64(self.reference_date)
         except ValueError:
             raise ValueError("reference_date must be in format 'YYYY-MM-DD'")
-        if not isinstance(self.offset_seconds, np.timedelta64):
-            raise TypeError(f"Expected 'offset_seconds' to be a numpy.timedelta64, got {type(self.offset_seconds).__name__}")
-        if self.offset_seconds.dtype != 'timedelta64[s]':
-            raise ValueError("offset_seconds must have a resolution of seconds (timedelta64[s]).")
+        if not isinstance(self.offset_seconds, int):
+                raise TypeError(f"Expected 'offset_seconds' to be an int, got {type(self.offset_seconds).__name__}")
 
     def get_current_time(self) -> np.datetime64:
         """
@@ -58,7 +56,7 @@ class Time:
         numpy.datetime64
             The current time in the simulation.
         """
-        return self._reference_date_np + self.offset_seconds
+        return self._reference_date_np + self.offset_as_timedelta64()
 
     def get_seconds_since_reference(self) -> int:
         """
@@ -66,20 +64,29 @@ class Time:
         """
         # Will complete once I can clarify the different between reference_date and simulation start
         pass   
-    
+
+    def offset_as_timedelta64(self) -> np.timedelta64:
+        """
+        Returns the offset_seconds as a numpy.timedelta64 object.
+        """
+        return np.timedelta64(self.offset_seconds, 's')
+
     def update(self, delta_seconds: np.timedelta64):
         """
-        Updates the current time by adding a delta in seconds.
+        Advances the simulation time by a given number of seconds.
+
+        The reference_date defines simulation time zero (Ts=0). The simulation
+        can start at any time after that, with offset_seconds representing the
+        number of seconds since reference_date. This method increments the
+        simulation time by delta_seconds.
 
         Parameters
         ----------
-        delta_seconds : numpy.timedelta64
-            The time delta to add to the current time.
+        delta_seconds : int
+            The number of seconds to advance the simulation time.
         """
-        if not isinstance(delta_seconds, np.timedelta64):
-            raise TypeError(f"Expected 'delta_seconds' to be a numpy.timedelta64, got {type(delta_seconds).__name__}")
-        if delta_seconds.dtype != 'timedelta64[s]':
-            raise ValueError("delta_seconds must have a resolution of seconds (timedelta64[s]).")
+        if not isinstance(delta_seconds, int):
+            raise TypeError(f"Expected 'delta_seconds' to be an int, got {type(delta_seconds).__name__}")
         self.offset_seconds += delta_seconds
 
 

--- a/tests/particle_tracer/test_particle.py
+++ b/tests/particle_tracer/test_particle.py
@@ -3,7 +3,8 @@ Unit tests for data classes in the particle.py module of the sedtrails package.
 """
 
 import pytest
-from sedtrails.particle_tracer.particle import Mud, Sand, Passive, Particle
+import numpy as np
+from sedtrails.particle_tracer.particle import Mud, Sand, Passive, Particle, Time
 
 
 class TestParticle:
@@ -97,3 +98,52 @@ class TestPhysics:
     """
     Test suite for the Physics class.
     """
+
+class TestTime:
+    """
+    Test suite for the Time class.
+    """
+
+    def test_initial_current_time(self):
+        """
+        Test that the initial current time matches the reference date.
+        """
+        reference_date = np.datetime64('2023-01-01T00:00:00', 's')
+        offset_seconds = np.timedelta64(0, 's')
+        time_instance = Time(reference_date=reference_date, offset_seconds=offset_seconds)
+
+        assert time_instance.get_current_time() == reference_date, \
+            "Initial current time should match the reference date."
+
+    def test_update_add_seconds(self):
+        """
+        Test updating the current time by adding seconds.
+        """
+        reference_date = np.datetime64('2023-01-01T00:00:00', 's')
+        offset_seconds = np.timedelta64(0, 's')
+        time_instance = Time(reference_date=reference_date, offset_seconds=offset_seconds)
+
+        delta_seconds = np.timedelta64(120, 's')
+        time_instance.update(delta_seconds)
+
+        expected_time = reference_date + delta_seconds
+        assert time_instance.get_current_time() == expected_time, \
+            f"Updated current time should be {expected_time}, but got {time_instance.get_current_time()}."
+
+    def test_update_subtract_seconds(self):
+        """
+        Test updating the current time by subtracting seconds.
+        """
+        reference_date = np.datetime64('2023-01-01T00:00:00', 's')
+        offset_seconds = np.timedelta64(0, 's')
+        time_instance = Time(reference_date=reference_date, offset_seconds=offset_seconds)
+
+        delta_seconds = np.timedelta64(120, 's')
+        time_instance.update(delta_seconds)
+
+        delta_seconds = np.timedelta64(-60, 's')
+        time_instance.update(delta_seconds)
+
+        expected_time = reference_date + np.timedelta64(120, 's') + np.timedelta64(-60, 's')
+        assert time_instance.get_current_time() == expected_time, \
+            f"Updated current time after subtraction should be {expected_time}, but got {time_instance.get_current_time()}."

--- a/tests/particle_tracer/test_particle.py
+++ b/tests/particle_tracer/test_particle.py
@@ -108,42 +108,47 @@ class TestTime:
         """
         Test that the initial current time matches the reference date.
         """
-        reference_date = np.datetime64('2023-01-01T00:00:00', 's')
+        reference_date = "2023-01-01"
         offset_seconds = np.timedelta64(0, 's')
         time_instance = Time(reference_date=reference_date, offset_seconds=offset_seconds)
-
-        assert time_instance.get_current_time() == reference_date, \
-            "Initial current time should match the reference date."
+        expected = np.datetime64("2023-01-01T00:00:00", 's')
+        assert actual == expected, 
+            f"Initial current time: expected={expected}, actual={actual}"
 
     def test_update_add_seconds(self):
         """
         Test updating the current time by adding seconds.
         """
-        reference_date = np.datetime64('2023-01-01T00:00:00', 's')
+        reference_date = "2023-01-01"
         offset_seconds = np.timedelta64(0, 's')
         time_instance = Time(reference_date=reference_date, offset_seconds=offset_seconds)
-
         delta_seconds = np.timedelta64(120, 's')
         time_instance.update(delta_seconds)
-
-        expected_time = reference_date + delta_seconds
-        assert time_instance.get_current_time() == expected_time, \
-            f"Updated current time should be {expected_time}, but got {time_instance.get_current_time()}."
+        expected = np.datetime64("2023-01-01T00:02:00", 's')
+        assert time_instance.get_current_time() == expected,
+            f"Updated current time should be {expected}, but got {time_instance.get_current_time()}."
 
     def test_update_subtract_seconds(self):
         """
         Test updating the current time by subtracting seconds.
         """
-        reference_date = np.datetime64('2023-01-01T00:00:00', 's')
-        offset_seconds = np.timedelta64(0, 's')
+        reference_date = "2023-01-01"
+        offset_seconds = np.timedelta64(120, 's')
         time_instance = Time(reference_date=reference_date, offset_seconds=offset_seconds)
-
-        delta_seconds = np.timedelta64(120, 's')
-        time_instance.update(delta_seconds)
-
         delta_seconds = np.timedelta64(-60, 's')
         time_instance.update(delta_seconds)
+        expected = np.datetime64("2023-01-01T00:01:00", 's')
+        assert time_instance.get_current_time() == expected,
+            f"Updated current time after subtraction should be {expected}, but got {time_instance.get_current_time()}."
 
-        expected_time = reference_date + np.timedelta64(120, 's') + np.timedelta64(-60, 's')
-        assert time_instance.get_current_time() == expected_time, \
-            f"Updated current time after subtraction should be {expected_time}, but got {time_instance.get_current_time()}."
+    def test_get_seconds_since_reference(self):
+        """
+        Test retrieving the number of seconds since the reference date.
+        """
+        reference_date = "2023-01-01"
+        offset_seconds = np.timedelta64(90, 's')
+        time_instance = Time(reference_date=reference_date, offset_seconds=offset_seconds)
+        actual = time_instance.get_seconds_since_reference()
+        expected = 90
+        assert actual == expected, 
+            f"Seconds since reference: expected={expected}, actual={actual}"

--- a/tests/particle_tracer/test_particle.py
+++ b/tests/particle_tracer/test_particle.py
@@ -108,47 +108,42 @@ class TestTime:
         """
         Test that the initial current time matches the reference date.
         """
-        reference_date = "2023-01-01"
-        offset_seconds = np.timedelta64(0, 's')
+        reference_date = "2025-05-20"
+        offset_seconds = 0
         time_instance = Time(reference_date=reference_date, offset_seconds=offset_seconds)
-        expected = np.datetime64("2023-01-01T00:00:00", 's')
-        assert actual == expected, 
-            f"Initial current time: expected={expected}, actual={actual}"
+        expected = np.datetime64("2025-05-20T00:00:00", 's')
+        actual = time_instance.get_current_time()
+        assert actual == expected, f"Initial current time: expected={expected}, actual={actual}"
 
     def test_update_add_seconds(self):
         """
         Test updating the current time by adding seconds.
         """
-        reference_date = "2023-01-01"
-        offset_seconds = np.timedelta64(0, 's')
+        reference_date = "2025-05-20"
+        offset_seconds = 0
         time_instance = Time(reference_date=reference_date, offset_seconds=offset_seconds)
-        delta_seconds = np.timedelta64(120, 's')
+        delta_seconds = 120
         time_instance.update(delta_seconds)
-        expected = np.datetime64("2023-01-01T00:02:00", 's')
-        assert time_instance.get_current_time() == expected,
-            f"Updated current time should be {expected}, but got {time_instance.get_current_time()}."
-
+        expected = np.datetime64("2025-05-20T00:02:00", 's')
+        actual = time_instance.get_current_time()
+        assert actual == expected, f"After adding 120s: expected={expected}, actual={actual}"
+        
     def test_update_subtract_seconds(self):
         """
         Test updating the current time by subtracting seconds.
         """
-        reference_date = "2023-01-01"
-        offset_seconds = np.timedelta64(120, 's')
+        reference_date = "2025-05-20"
+        offset_seconds = 120
         time_instance = Time(reference_date=reference_date, offset_seconds=offset_seconds)
-        delta_seconds = np.timedelta64(-60, 's')
+        delta_seconds = -60
         time_instance.update(delta_seconds)
-        expected = np.datetime64("2023-01-01T00:01:00", 's')
-        assert time_instance.get_current_time() == expected,
-            f"Updated current time after subtraction should be {expected}, but got {time_instance.get_current_time()}."
+        expected = np.datetime64("2025-05-20T00:01:00", 's')
+        actual = time_instance.get_current_time()
+        assert actual == expected, f"After subtracting 60s: expected={expected}, actual={actual}"
 
     def test_get_seconds_since_reference(self):
         """
         Test retrieving the number of seconds since the reference date.
+        TODO: will finish when the refence_date is clarified
         """
-        reference_date = "2023-01-01"
-        offset_seconds = np.timedelta64(90, 's')
-        time_instance = Time(reference_date=reference_date, offset_seconds=offset_seconds)
-        actual = time_instance.get_seconds_since_reference()
-        expected = 90
-        assert actual == expected, 
-            f"Seconds since reference: expected={expected}, actual={actual}"
+        pass


### PR DESCRIPTION
I modified the Time class in the SedTRAILS internal Particle class following our discussions about how to incorporate time internally. Closes #160 

## Important points to note:
- We will stick to the `numpy.datetime64` in seconds to represent time throughout the simulation
- The time difference (or time offset, or simulation run time) is a `numpy.timedelta64` object in seconds
- Also added preliminary tests for the modified Time class in `test/particle_tracer/test_particle.py` as a new `TestTime` class

## Relevant files:
- `src/sedtrails/particle_tracer/particle.py`
- `src/sedtrails/tests/particle_tracer/test_particle.py`