### PR TITLE
Update Time class

### DIFF
--- a/src/sedtrails/exceptions/exceptions.py
+++ b/src/sedtrails/exceptions/exceptions.py
@@ -35,3 +35,10 @@ class YamlOutputError(SedtrailsException):
     """
 
     pass
+
+
+class ReferenceDateFormatError(ValueError):
+    """
+    Exception raised when the reference_date string does not match the required 
+    format 'YYYY-MM-DD 00:00:00'.
+    """

--- a/src/sedtrails/particle_tracer/time.py
+++ b/src/sedtrails/particle_tracer/time.py
@@ -65,12 +65,22 @@ class Time:
         total_seconds = self.start_time + delta_seconds
         return self._reference_date_np + np.timedelta64(total_seconds, 's')
 
-    def get_seconds_since_reference(self) -> str:
+    def get_seconds_since_reference(self, delta_seconds: int = 0) -> int:
         """
-        Returns the number of seconds since the reference date/time in a 
-        human readable format
+        Returns the current time in simulation as integer in units of seconds.
+
+        Parameters
+        ----------
+        delta_seconds : int, optional
+            Additional seconds to add to the current simulation time (default is 0).
+
+        Returns
+        -------
+        total_seconds : int
+            The total seconds in the simulation since the reference date.
         """
-        return str(self.get_current_time())   
+        total_seconds = self.start_time + delta_seconds
+        return total_seconds
 
     def time_as_timedelta64(self) -> np.timedelta64:
         """

--- a/src/sedtrails/particle_tracer/time.py
+++ b/src/sedtrails/particle_tracer/time.py
@@ -36,7 +36,7 @@ class Time:
 
     def _convert_to_datetime64(self, date_str: str) -> np.datetime64:
         """Convert reference_date in str format to numpy.datetime64"""
-        return np.datetime64(f"{date_str}T00:00:00", 's')
+        return np.datetime64(f"{date_str} 00:00:00", 's')
     
     def __post_init__(self):
         # Accept reference_date in str format TODO: should we allow for non str formats?
@@ -47,23 +47,30 @@ class Time:
         if not isinstance(self.start_time, int):
                 raise TypeError(f"Expected 'start_time' to be an int, got {type(self.start_time).__name__}")
 
-    def get_current_time(self) -> np.datetime64:
+    def get_current_time(self, delta_seconds: int = 0) -> np.datetime64:
         """
-        Returns the current time as a numpy.datetime64 object.
+        Returns the current time in simulation as a numpy.datetime64 object,
+        optionally including an additional delta in seconds.
+
+        Parameters
+        ----------
+        delta_seconds : int, optional
+            Additional seconds to add to the current simulation time (default is 0).
 
         Returns
         -------
         numpy.datetime64
             The current time in the simulation.
         """
-        return self._reference_date_np + self.time_as_timedelta64()
+        total_seconds = self.start_time + delta_seconds
+        return self._reference_date_np + np.timedelta64(total_seconds, 's')
 
-    def get_seconds_since_reference(self) -> int:
+    def get_seconds_since_reference(self) -> str:
         """
-        Returns the number of seconds since the reference date/time.
+        Returns the number of seconds since the reference date/time in a 
+        human readable format
         """
-        # Will complete once I can clarify the different between reference_date and simulation start
-        pass   
+        return str(self.get_current_time())   
 
     def time_as_timedelta64(self) -> np.timedelta64:
         """

--- a/tests/particle_tracer/test_time.py
+++ b/tests/particle_tracer/test_time.py
@@ -18,7 +18,7 @@ class TestTime:
         reference_date = "2025-05-20"
         start_time = 0
         time_instance = Time(reference_date=reference_date, start_time=start_time)
-        expected = np.datetime64("2025-05-20T00:00:00", 's')
+        expected = np.datetime64("2025-05-20 00:00:00", 's')
         actual = time_instance.get_current_time()
         assert actual == expected, f"Initial current time: expected={expected}, actual={actual}"
 
@@ -31,7 +31,7 @@ class TestTime:
         time_instance = Time(reference_date=reference_date, start_time=start_time)
         delta_seconds = 120
         time_instance.update(delta_seconds)
-        expected = np.datetime64("2025-05-20T00:02:00", 's')
+        expected = np.datetime64("2025-05-20 00:02:00", 's')
         actual = time_instance.get_current_time()
         assert actual == expected, f"After adding 120s: expected={expected}, actual={actual}"
         
@@ -44,7 +44,7 @@ class TestTime:
         time_instance = Time(reference_date=reference_date, start_time=start_time)
         delta_seconds = -60
         time_instance.update(delta_seconds)
-        expected = np.datetime64("2025-05-20T00:01:00", 's')
+        expected = np.datetime64("2025-05-20 00:01:00", 's')
         actual = time_instance.get_current_time()
         assert actual == expected, f"After subtracting 60s: expected={expected}, actual={actual}"
 

--- a/tests/particle_tracer/test_time.py
+++ b/tests/particle_tracer/test_time.py
@@ -15,7 +15,7 @@ class TestTime:
         """
         Test that the initial current time matches the reference date.
         """
-        reference_date = "2025-05-20"
+        reference_date = "2025-05-20 00:00:00"
         start_time = 0
         time_instance = Time(reference_date=reference_date, start_time=start_time)
         expected = np.datetime64("2025-05-20T00:00:00", 's')
@@ -26,7 +26,7 @@ class TestTime:
         """
         Test updating the current time by adding seconds.
         """
-        reference_date = "2025-05-20"
+        reference_date = "2025-05-20 00:00:00"
         start_time = 0
         time_instance = Time(reference_date=reference_date, start_time=start_time)
         delta_seconds = 120
@@ -39,7 +39,7 @@ class TestTime:
         """
         Test updating the current time by subtracting seconds.
         """
-        reference_date = "2025-05-20"
+        reference_date = "2025-05-20 00:00:00"
         start_time = 120
         time_instance = Time(reference_date=reference_date, start_time=start_time)
         delta_seconds = -60
@@ -53,9 +53,9 @@ class TestTime:
         Test retrieving the number of seconds since the reference date in a 
         human readable format
         """
-        reference_date = "2025-05-20"
+        reference_date = "2025-05-20 00:00:00"
         start_time = 90
         time_instance = Time(reference_date=reference_date, start_time=start_time)
         actual = time_instance.get_seconds_since_reference()
-        expected = "2025-05-20T00:01:30"
+        expected = 90
         assert actual == expected, f"Current time string: expected={expected}, actual={actual}"

--- a/tests/particle_tracer/test_time.py
+++ b/tests/particle_tracer/test_time.py
@@ -18,7 +18,7 @@ class TestTime:
         reference_date = "2025-05-20"
         start_time = 0
         time_instance = Time(reference_date=reference_date, start_time=start_time)
-        expected = np.datetime64("2025-05-20 00:00:00", 's')
+        expected = np.datetime64("2025-05-20T00:00:00", 's')
         actual = time_instance.get_current_time()
         assert actual == expected, f"Initial current time: expected={expected}, actual={actual}"
 
@@ -31,7 +31,7 @@ class TestTime:
         time_instance = Time(reference_date=reference_date, start_time=start_time)
         delta_seconds = 120
         time_instance.update(delta_seconds)
-        expected = np.datetime64("2025-05-20 00:02:00", 's')
+        expected = np.datetime64("2025-05-20T00:02:00", 's')
         actual = time_instance.get_current_time()
         assert actual == expected, f"After adding 120s: expected={expected}, actual={actual}"
         
@@ -44,13 +44,18 @@ class TestTime:
         time_instance = Time(reference_date=reference_date, start_time=start_time)
         delta_seconds = -60
         time_instance.update(delta_seconds)
-        expected = np.datetime64("2025-05-20 00:01:00", 's')
+        expected = np.datetime64("2025-05-20T00:01:00", 's')
         actual = time_instance.get_current_time()
         assert actual == expected, f"After subtracting 60s: expected={expected}, actual={actual}"
 
     def test_get_seconds_since_reference(self):
         """
-        Test retrieving the number of seconds since the reference date.
-        TODO: will finish when the refence_date is clarified
+        Test retrieving the number of seconds since the reference date in a 
+        human readable format
         """
-        pass
+        reference_date = "2025-05-20"
+        start_time = 90
+        time_instance = Time(reference_date=reference_date, start_time=start_time)
+        actual = time_instance.get_seconds_since_reference()
+        expected = "2025-05-20T00:01:30"
+        assert actual == expected, f"Current time string: expected={expected}, actual={actual}"


### PR DESCRIPTION
This PR includes:

- Updates to [`src/sedtrails/particle_tracer/time.py`](https://github.com/sedtrails/sedtrails/blob/dev/src/sedtrails/particle_tracer/particle.py) to follow the CF conventions and `get_seconds_since_reference` to get seconds since reference in a human readable format
- Modifications to [`tests/particle_tracer/test_time.py`](https://github.com/sedtrails/sedtrails/blob/dev/tests/particle_tracer/test_particle.py) to add unit test for the `get_seconds_since_reference` method

Closes #164