### PR TITLE
Update Time class and the corresponding tests

### DIFF
--- a/src/sedtrails/particle_tracer/time.py
+++ b/src/sedtrails/particle_tracer/time.py
@@ -15,11 +15,11 @@ class Time:
     Attributes
     ----------
     reference_date : str
-        The reference date as string in format 'YYYY-MM-DD'
+        The reference date as string in format 'YYYY-MM-DD hh:mm:ss'
     start_time : int
         The simulation start time in seconds (from the reference date).
-    end_time : int
-        The simulation end time in seconds (from the reference date).
+    duration : int
+        The simulation duration in seconds.
 
     Methods
     -------
@@ -30,10 +30,17 @@ class Time:
     """
 
     # reference_date should be a str, the class will do the transformation into a numpy.datetime64 object
-    reference_date: str = field(default='1970-01-01')
+    reference_date: str = field(default='1970-01-01 00:00:00')
     start_time: int = 0
-    end_time: int = 0
+    duration: int = 0
     _reference_date_np: np.datetime64 = field(init=False)
+
+    @property
+    def end_time(self) -> int:
+        """
+        Returns the simulation end time in seconds from the reference date.
+        """
+        return self.start_time + self.duration        
 
     def _convert_to_datetime64(self, date_str: str) -> np.datetime64:
         """

--- a/src/sedtrails/particle_tracer/time.py
+++ b/src/sedtrails/particle_tracer/time.py
@@ -20,6 +20,8 @@ class Time:
         The simulation start time in seconds (from the reference date).
     duration : int
         The simulation duration in seconds.
+    time_step : int or float
+        The simulation time step in seconds.
 
     Methods
     -------
@@ -33,6 +35,7 @@ class Time:
     reference_date: str = field(default='1970-01-01 00:00:00')
     start_time: int = 0
     duration: int = 0
+    time_step: float = 1.0
     _reference_date_np: np.datetime64 = field(init=False)
 
     @property
@@ -60,24 +63,27 @@ class Time:
         except ReferenceDateFormatError as e:
             raise ReferenceDateFormatError(str(e)) from e
         if not isinstance(self.start_time, int):
-                raise TypeError(f"Expected 'start_time' to be an int, got {type(self.start_time).__name__}")
+            raise TypeError(f"Expected 'start_time' to be an int, got {type(self.start_time).__name__}")
+        if not isinstance(self.time_step, (int, float)):
+            raise TypeError(f"Expected 'time_step' to be int or float, got {type(self.time_step).__name__}")
 
-    def get_current_time(self, delta_seconds: int = 0) -> np.datetime64:
+
+    def get_current_time(self, step: int = 0) -> np.datetime64:
         """
         Returns the current time in simulation as a numpy.datetime64 object,
-        optionally including an additional delta in seconds.
+        given a simulation step.
 
         Parameters
         ----------
-        delta_seconds : int, optional
-            Additional seconds to add to the current simulation time (default is 0).
+        step : int
+            The simulation step number (default is 0).
 
         Returns
         -------
         numpy.datetime64
             The current time in the simulation.
         """
-        total_seconds = self.start_time + delta_seconds
+        total_seconds = int(self.start_time + step * self.time_step)
         return self._reference_date_np + np.timedelta64(total_seconds, 's')
 
     def get_seconds_since_reference(self, delta_seconds: int = 0) -> int:

--- a/tests/particle_tracer/test_time.py
+++ b/tests/particle_tracer/test_time.py
@@ -16,10 +16,51 @@ class TestTime:
         """
         reference_date = "2025-05-20 00:00:00"
         start_time = 0
-        time_instance = Time(reference_date=reference_date, start_time=start_time)
+        time_step = 30
+        time_instance = Time(reference_date=reference_date, start_time=start_time, time_step=time_step)
         expected = np.datetime64("2025-05-20T00:00:00", 's')
         actual = time_instance.get_current_time()
         assert actual == expected, f"Initial current time: expected={expected}, actual={actual}"
+
+    def test_get_current_time_with_steps(self):
+        """
+        Test getting the current time at a specific simulation step.
+        """
+        reference_date = "2025-05-20 00:00:00"
+        start_time = 0
+        time_step = 30
+        time_instance = Time(reference_date=reference_date, start_time=start_time, time_step=time_step)
+        # At step 2, should be 60 seconds after start
+        expected = np.datetime64("2025-05-20T00:01:00", 's')
+        actual = time_instance.get_current_time(step=2)
+        assert actual == expected, f"Current time at step 2: expected={expected}, actual={actual}"
+
+    def test_get_current_time_with_start_time(self):
+        """
+        Test getting the current time with a nonzero start_time.
+        """
+        reference_date = "2025-05-20 00:00:00"
+        start_time = 90
+        time_step = 30
+        time_instance = Time(reference_date=reference_date, start_time=start_time, time_step=time_step)
+        # At step 1, should be 90 + 30 = 120 seconds after reference
+        expected = np.datetime64("2025-05-20T00:02:00", 's')
+        actual = time_instance.get_current_time(step=1)
+        assert actual == expected, f"Current time with start_time and step: expected={expected}, actual={actual}"
+
+
+    def test_get_seconds_since_reference(self):
+        """
+        Test retrieving the number of seconds since the reference date.
+        """
+        reference_date = "2025-05-20 00:00:00"
+        start_time = 90
+        time_step = 30
+        time_instance = Time(reference_date=reference_date, start_time=start_time, time_step=time_step)
+        # At step 2, should be 90 + 2*30 = 150 seconds
+        actual = time_instance.get_seconds_since_reference(delta_seconds=2*time_step)
+        expected = 150
+        assert actual == expected, f"Seconds since reference: expected={expected}, actual={actual}"
 
     def test_update_add_seconds(self):
         """


### PR DESCRIPTION
Updated the Time class to follow the examples @bartvanwesten shared in [`examples/particle_simulation_example.py`](https://github.com/sedtrails/sedtrails/blob/dev/examples/particle_simulation_example.py)

Relevant files:
- `src/sedtrails/particle_tracer/time.py`
  - Added `duration` and `time_step` attributes to the Time class.
  - The new `end_time` property is calculated based on the `start_time` and the `duration` attributes in seconds
  - The `get_current_time` method now calculates the current time based on `start_time`, `step` and `time_step` in simulation
- `tests/particle_tracer/test_time.py`
  - Added new test functions to test `get_current_time` using simulation steps

