### PR TITLE
Update Time class 

### DIFF
--- a/src/sedtrails/exceptions/exceptions.py
+++ b/src/sedtrails/exceptions/exceptions.py
@@ -42,3 +42,9 @@ class DateFormatError(ValueError):
     Exception raised when the date string does not match the required 
     format 'YYYY-MM-DD 00:00:00'.
     """
+
+class DurationFormatError(ValueError):
+    """
+    Exception raised when the duration string does not match the required format '3D 2H1M3S'.
+    """
+    pass    

--- a/src/sedtrails/exceptions/exceptions.py
+++ b/src/sedtrails/exceptions/exceptions.py
@@ -37,8 +37,8 @@ class YamlOutputError(SedtrailsException):
     pass
 
 
-class ReferenceDateFormatError(ValueError):
+class DateFormatError(ValueError):
     """
-    Exception raised when the reference_date string does not match the required 
+    Exception raised when the date string does not match the required 
     format 'YYYY-MM-DD 00:00:00'.
     """

--- a/tests/particle_tracer/test_time.py
+++ b/tests/particle_tracer/test_time.py
@@ -15,9 +15,10 @@ class TestTime:
         Test that the initial current time matches the reference date.
         """
         reference_date = "2025-05-20 00:00:00"
-        start_time = 0
-        time_step = 30
-        time_instance = Time(reference_date=reference_date, start_time=start_time, time_step=time_step)
+        start_time = "2025-05-20 00:00:00"
+        time_step = "30S"
+        duration = "1H"
+        time_instance = Time(reference_date=reference_date, start_time=start_time, time_step=time_step, duration=duration)
         expected = np.datetime64("2025-05-20T00:00:00", 's')
         actual = time_instance.get_current_time()
         assert actual == expected, f"Initial current time: expected={expected}, actual={actual}"
@@ -27,9 +28,10 @@ class TestTime:
         Test getting the current time at a specific simulation step.
         """
         reference_date = "2025-05-20 00:00:00"
-        start_time = 0
-        time_step = 30
-        time_instance = Time(reference_date=reference_date, start_time=start_time, time_step=time_step)
+        start_time = "2025-05-20 00:00:00"
+        time_step = "30S"
+        duration = "1H"
+        time_instance = Time(reference_date=reference_date, start_time=start_time, time_step=time_step, duration=duration)
         # At step 2, should be 60 seconds after start
         expected = np.datetime64("2025-05-20T00:01:00", 's')
         actual = time_instance.get_current_time(step=2)
@@ -40,62 +42,24 @@ class TestTime:
         Test getting the current time with a nonzero start_time.
         """
         reference_date = "2025-05-20 00:00:00"
-        start_time = 90
-        time_step = 30
-        time_instance = Time(reference_date=reference_date, start_time=start_time, time_step=time_step)
+        start_time = "2025-05-20 00:01:30"
+        time_step = "30S"
+        duration = "1H"
+        time_instance = Time(reference_date=reference_date, start_time=start_time, time_step=time_step, duration=duration)
         # At step 1, should be 90 + 30 = 120 seconds after reference
         expected = np.datetime64("2025-05-20T00:02:00", 's')
         actual = time_instance.get_current_time(step=1)
         assert actual == expected, f"Current time with start_time and step: expected={expected}, actual={actual}"
 
-
-    def test_get_seconds_since_reference(self):
+    def test_end_time(self):
         """
-        Test retrieving the number of seconds since the reference date.
-        """
-        reference_date = "2025-05-20 00:00:00"
-        start_time = 90
-        time_step = 30
-        time_instance = Time(reference_date=reference_date, start_time=start_time, time_step=time_step)
-        # At step 2, should be 90 + 2*30 = 150 seconds
-        actual = time_instance.get_seconds_since_reference(delta_seconds=2*time_step)
-        expected = 150
-        assert actual == expected, f"Seconds since reference: expected={expected}, actual={actual}"
-
-    def test_update_add_seconds(self):
-        """
-        Test updating the current time by adding seconds.
+        Test the calculation of the simulation end time.
         """
         reference_date = "2025-05-20 00:00:00"
-        start_time = 0
-        time_instance = Time(reference_date=reference_date, start_time=start_time)
-        delta_seconds = 120
-        time_instance.update(delta_seconds)
-        expected = np.datetime64("2025-05-20T00:02:00", 's')
-        actual = time_instance.get_current_time()
-        assert actual == expected, f"After adding 120s: expected={expected}, actual={actual}"
-        
-    def test_update_subtract_seconds(self):
-        """
-        Test updating the current time by subtracting seconds.
-        """
-        reference_date = "2025-05-20 00:00:00"
-        start_time = 120
-        time_instance = Time(reference_date=reference_date, start_time=start_time)
-        delta_seconds = -60
-        time_instance.update(delta_seconds)
-        expected = np.datetime64("2025-05-20T00:01:00", 's')
-        actual = time_instance.get_current_time()
-        assert actual == expected, f"After subtracting 60s: expected={expected}, actual={actual}"
-
-    def test_get_seconds_since_reference(self):
-        """
-        Test retrieving the number of seconds since the reference date in a 
-        human readable format
-        """
-        reference_date = "2025-05-20 00:00:00"
-        start_time = 90
-        time_instance = Time(reference_date=reference_date, start_time=start_time)
-        actual = time_instance.get_seconds_since_reference()
-        expected = 90
-        assert actual == expected, f"Current time string: expected={expected}, actual={actual}"
+        start_time = "2025-05-20 00:00:00"
+        time_step = "30S"
+        duration = "1H"
+        time_instance = Time(reference_date=reference_date, start_time=start_time, time_step=time_step, duration=duration)
+        expected = np.datetime64("2025-05-20T01:00:00", 's')
+        actual = time_instance.end_time
+        assert actual == expected, f"End time: expected={expected}, actual={actual}"


### PR DESCRIPTION
Following the changes in the simulation configuration parameters, I updated the Time class in `src/sedtrails/particle_tracer/time.py`.

- Relevant files:
    - `src/sedtrails/particle_tracer/time.py`
        - `reference_date` and `start_time` are numpy.datetime64 objects. Input as str in 'YYYY-MM-DD hh:mm:ss' format
        - `duration` and `time_step` are numpy.timedelta64 objects. Input as str in human friendly ISO format. e.g. '3D 2H1M3S'
        - Added a static method to parse duration in str to seconds
        - Removed methods that are not in use at the moment
   - `tests/particle_tracer/test_time.py`
        - Updated tests to comply with changes in the Time class
        - Removed unnecessary tests
    - `src/sedtrails/exceptions/exceptions.py`
        - Defined a new custom exception `DurationFormatError` to catch incorrect duration input formats

Closes #180 