### PR TITLE
Modify Sphinx documentation action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,8 @@ on:
     pull_request:
       branches:
         - main
+      paths:
+        - 'docs/**'
 
 permissions:
   contents: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,9 @@
 name: Sphinx Docs
 
 on:
-    workflow_dispatch:
+    pull_request:
+      branches:
+        - main
 
 permissions:
   contents: write


### PR DESCRIPTION
Modifed the Sphinx documentation action so that the workflow runs only on the pull requests on the `main` branch when there has been changes made in contents of the `docs` folder

Closes #184 