### PR TITLE
Add physics converter for sediment transport calculations

### DIFF
--- a/examples/particle_simulation_numba_example.py
+++ b/examples/particle_simulation_numba_example.py
@@ -16,10 +16,9 @@ import matplotlib.pyplot as plt
 
 # Import SedTRAILS modules
 from sedtrails.transport_converter.format_converter import FormatConverter, InputType
+from sedtrails.transport_converter.physics_converter import PhysicsConverter, PhysicsMethod
 from sedtrails.particle_tracer.data_retriever import FlowFieldDataRetriever
 from sedtrails.particle_tracer.particle import Sand
-
-# Import both calculator implementations
 from sedtrails.particle_tracer.position_calculator import ParticlePositionCalculator
 from sedtrails.particle_tracer.position_calculator_numba import create_numba_particle_calculator
 
@@ -61,11 +60,16 @@ print(f'Total timestamps: {time_info["num_times"]}')
 sedtrails_data = converter.convert_to_sedtrails_data()
 print(f'Data conversion completed in {time.time() - start_time:.2f} seconds')
 
+# Add physics calculations to the SedtrailsData
+physics_converter = PhysicsConverter()
+physics_converter.add_physics_to_sedtrails_data(sedtrails_data, method=PhysicsMethod.VAN_WESTEN_2025)
+
 # ===== STEP 2: Initialize Particle and Position Calculator =====
 print('\n=== STEP 2: Initializing Particle and Flow Field ===')
 
 # Create flow field data retriever
 retriever = FlowFieldDataRetriever(sedtrails_data)
+retriever.flow_field_name = "suspended_velocity" # Options: "depth_avg_flow_velocity", "bed_load_velocity", "suspended_velocity"
 
 # Get the initial flow field at specified timestep
 initial_time = sedtrails_data.times[TIMESTEP_INDEX]
@@ -91,6 +95,7 @@ simulation_start = time.time()
 current_time = initial_time
 
 for step in range(1, NUM_STEPS + 1):
+
     # Update current time
     current_time = initial_time + step * TIMESTEP
 

--- a/src/sedtrails/transport_converter/format_converter.py
+++ b/src/sedtrails/transport_converter/format_converter.py
@@ -29,7 +29,63 @@ class SedtrailsData:
     A data class for internally structuring SedTrails data.
     
     This class holds data for multiple time steps with time as the first dimension
-    for time-dependent variables. Physics fields can be added dynamically.
+    for time-dependent variables.
+
+    Attributes:
+    -----------
+    times: np.ndarray
+        Array of time values in seconds since reference_date
+    reference_date: np.datetime64
+        Reference date for the time values
+    x: np.ndarray
+        X-coordinates of the grid cells
+    y: np.ndarray
+        Y-coordinates of the grid cells
+    bed_level: np.ndarray
+        Bed level in meters (typically time-independent)
+    depth_avg_flow_velocity: Dict[str, np.ndarray]
+        Depth-averaged flow velocity components in m/s 
+        (keys: 'x', 'y', 'magnitude', each with time as first dimension)
+    fractions: int
+        Number of sediment fractions
+    bed_load_transport: Dict[str, np.ndarray]
+        Bed load sediment transport in kg/m/s 
+        (keys: 'x', 'y', 'magnitude', each with time as first dimension)
+        Shape: (time, fractions, spatial) or (time, spatial)
+    suspended_transport: Dict[str, np.ndarray]
+        Suspended sediment transport in kg/m/s 
+        (keys: 'x', 'y', 'magnitude', each with time as first dimension)
+        Shape: (time, fractions, spatial) or (time, spatial)
+    water_depth: np.ndarray
+        Water depth in meters (with time as first dimension)
+    mean_bed_shear_stress: np.ndarray
+        Mean bed shear stress in pascal (with time as first dimension)
+    max_bed_shear_stress: np.ndarray
+        Max bed shear stress in pascal (with time as first dimension)
+    sediment_concentration: np.ndarray
+        Suspended sediment concentration in kg/m^3 (with time as first dimension)
+        Shape: (time, fractions, spatial) or (time, spatial)
+    nonlinear_wave_velocity: Dict[str, np.ndarray]
+        Nonlinear wave velocity in m/s 
+        (keys: 'x', 'y', 'magnitude', each with time as first dimension)
+    
+    # === PHYSICS FIELDS (added by PhysicsConverter) ===
+    # Note: All physics fields match the structure of transport data
+    # Shape: (time, fractions, spatial) if fractions exist, else (time, spatial)
+    shields_number: np.ndarray = None
+        Shields parameter (dimensionless bed shear stress) [-]
+    bed_load_layer_thickness: np.ndarray = None
+        Representative thickness of bed load transport layer [m]
+    suspended_layer_thickness: np.ndarray = None
+        Representative thickness of suspended transport layer [m]
+    mixing_layer_thickness: np.ndarray = None
+        Mixing layer thickness [m]
+    bed_load_velocity: Dict[str, np.ndarray] = None
+        Bed load velocity components in m/s
+        (keys: 'x', 'y', 'magnitude', each matching transport data structure)
+    suspended_velocity: Dict[str, np.ndarray] = None
+        Suspended sediment velocity components in m/s
+        (keys: 'x', 'y', 'magnitude', each matching transport data structure)
     """
     
     times: np.ndarray
@@ -104,83 +160,7 @@ class SedtrailsData:
             True if any physics fields exist
         """
         return len(self._physics_fields) > 0
-    """
-    A data class for internally structuring SedTrails data.
-    
-    This class holds data for multiple time steps with time as the first dimension
-    for time-dependent variables.
 
-    Attributes:
-    -----------
-    times: np.ndarray
-        Array of time values in seconds since reference_date
-    reference_date: np.datetime64
-        Reference date for the time values
-    x: np.ndarray
-        X-coordinates of the grid cells
-    y: np.ndarray
-        Y-coordinates of the grid cells
-    bed_level: np.ndarray
-        Bed level in meters (typically time-independent)
-    depth_avg_flow_velocity: Dict[str, np.ndarray]
-        Depth-averaged flow velocity components in m/s 
-        (keys: 'x', 'y', 'magnitude', each with time as first dimension)
-    fractions: int
-        Number of sediment fractions
-    bed_load_transport: Dict[str, np.ndarray]
-        Bed load sediment transport in kg/m/s 
-        (keys: 'x', 'y', 'magnitude', each with time as first dimension)
-        Shape: (time, fractions, spatial) or (time, spatial)
-    suspended_transport: Dict[str, np.ndarray]
-        Suspended sediment transport in kg/m/s 
-        (keys: 'x', 'y', 'magnitude', each with time as first dimension)
-        Shape: (time, fractions, spatial) or (time, spatial)
-    water_depth: np.ndarray
-        Water depth in meters (with time as first dimension)
-    mean_bed_shear_stress: np.ndarray
-        Mean bed shear stress in pascal (with time as first dimension)
-    max_bed_shear_stress: np.ndarray
-        Max bed shear stress in pascal (with time as first dimension)
-    sediment_concentration: np.ndarray
-        Suspended sediment concentration in kg/m^3 (with time as first dimension)
-        Shape: (time, fractions, spatial) or (time, spatial)
-    nonlinear_wave_velocity: Dict[str, np.ndarray]
-        Nonlinear wave velocity in m/s 
-        (keys: 'x', 'y', 'magnitude', each with time as first dimension)
-    
-    # === PHYSICS FIELDS (added by PhysicsConverter) ===
-    # Note: All physics fields match the structure of transport data
-    # Shape: (time, fractions, spatial) if fractions exist, else (time, spatial)
-    shields_number: np.ndarray = None
-        Shields parameter (dimensionless bed shear stress) [-]
-    bed_load_layer_thickness: np.ndarray = None
-        Representative thickness of bed load transport layer [m]
-    suspended_layer_thickness: np.ndarray = None
-        Representative thickness of suspended transport layer [m]
-    mixing_layer_thickness: np.ndarray = None
-        Mixing layer thickness [m]
-    bed_load_velocity: Dict[str, np.ndarray] = None
-        Bed load velocity components in m/s
-        (keys: 'x', 'y', 'magnitude', each matching transport data structure)
-    suspended_velocity: Dict[str, np.ndarray] = None
-        Suspended sediment velocity components in m/s
-        (keys: 'x', 'y', 'magnitude', each matching transport data structure)
-    """
-    
-    times: np.ndarray
-    reference_date: np.datetime64
-    x: np.ndarray
-    y: np.ndarray
-    bed_level: np.ndarray
-    depth_avg_flow_velocity: Dict[str, np.ndarray]
-    fractions: int
-    bed_load_transport: Dict[str, np.ndarray]
-    suspended_transport: Dict[str, np.ndarray]
-    water_depth: np.ndarray
-    mean_bed_shear_stress: np.ndarray
-    max_bed_shear_stress: np.ndarray
-    sediment_concentration: np.ndarray
-    nonlinear_wave_velocity: Dict[str, np.ndarray]
     
     def __getitem__(self, time_index: int) -> Dict:
         """

--- a/src/sedtrails/transport_converter/physics_converter.py
+++ b/src/sedtrails/transport_converter/physics_converter.py
@@ -1,27 +1,271 @@
 """
-Computes the physics of particles in the simulation based on particle types.
+Physics Converter Module for Sediment Transport
+
+This module adds physics-based calculations to existing SedtrailsData objects
+using the physics library functions and allowing method selection.
+
+References:
+-----------
+van Westen, B., de Schipper, M. A., Pearson, S. G., & Luijendijk, A. P. (2025). 
+Lagrangian modelling reveals sediment pathways at evolving coasts. 
+Scientific Reports, 15(1), 8793.
 """
 
-import importlib
+import numpy as np
+from typing import Optional
+from dataclasses import dataclass
 
-# type of physics plugin to use.
-## the value  of PHYSICS_PLUGINGS can be set based on the
-## modeler's choice in the configuration file.
+# Import physics library
+from sedtrails.transport_converter import physics_lib
 
-
-
-
-PHYSICS_PLUGINS = "plugins.physics.sand"
-
-# import converter dynamically
-physics_converter = importlib.import_module(PHYSICS_PLUGINS, ".")
-
-# this guarantees that we can invoke the convertr
-# independent of its name
-converter = physics_converter.PhysicsPlugin()
-
-# do convertion
-converter.convert()
+class PhysicsMethod:
+    VAN_WESTEN_2025 = "van_westen_2025"
+    SOULSBY_2011 = "soulsby_2011"
 
 
+@dataclass
+class PhysicsConfig:
+    """Configuration parameters for physics calculations."""
+    
+    # Physical constants
+    gravity: float = 9.81  # m/s^2
+    von_karman_constant: float = 0.40  # [-]
+    kinematic_viscosity: float = 1.36e-6  # m^2/s (10°C, 35 ppt)
+    water_density: float = 1027.0  # kg/m^3 (10°C, 35 ppt)
+    particle_density: float = 2650.0  # kg/m^3 (quartz)
+    porosity: float = 0.4  # [-]
+    
+    # Sediment properties
+    grain_diameter: float = 2.5e-4  # m (250 μm)
+    
+    # Morphological acceleration factor
+    morfac: float = 1.0
 
+    # Physics methods
+    tracer_method: str = PhysicsMethod.VAN_WESTEN_2025
+
+    # Methods in physics library
+    suspended_velocity_method: str = physics_lib.SuspendedVelocityMethod.VAN_WESTEN_2025
+    mixing_layer_method: str = physics_lib.MixingLayerMethod.BERTIN_2008
+
+
+class PhysicsConverter:
+    """
+    Add physics calculations to existing SedtrailsData using different methods.
+    
+    Each method (van Westen, Soulsby, etc.) has its own complete workflow.
+    """
+    
+    def __init__(self, config: Optional[PhysicsConfig] = None):
+        """
+        Initialize the physics converter.
+        
+        Parameters:
+        -----------
+        config : PhysicsConfig, optional
+            Configuration for physics calculations. If None, uses defaults.
+        """
+        self.config = config or PhysicsConfig()
+        
+        # Calculate time-independent grain properties using library
+        self._calculate_grain_properties()
+    
+    def _calculate_grain_properties(self):
+        """Calculate time-independent grain properties using physics library."""
+        (self.dimensionless_grain_size, 
+         self.critical_shields, 
+         self.settling_velocity, 
+         self.critical_shear_stress) = physics_lib.compute_grain_properties(
+            self.config.grain_diameter,
+            self.config.gravity,
+            self.config.particle_density,
+            self.config.water_density,
+            self.config.kinematic_viscosity
+        )
+    
+    def add_physics_to_sedtrails_data(self, sedtrails_data, method: Optional[str] = None):
+        """
+        Add physics calculations to existing SedtrailsData object using specified method.
+
+        Parameters:
+        -----------
+        sedtrails_data : SedtrailsData
+            Existing SedtrailsData object to enhance with physics
+        method : str, optional
+            Physics method to use:
+            - "van_westen_2025": van Westen et al. (2025) approach (default)
+            - "soulsby_2011": Soulsby et al. (2011) approach 
+            If None, uses the method from self.config.tracer_method.
+        """
+        chosen_method = method or self.config.tracer_method
+        print(f"Adding physics to SedtrailsData using {chosen_method} method...")
+
+        if chosen_method == PhysicsMethod.VAN_WESTEN_2025:
+            self._add_physics_van_westen(sedtrails_data)
+
+        elif chosen_method == PhysicsMethod.SOULSBY_2011:
+            self._add_physics_soulsby(sedtrails_data)
+
+        else:
+            raise ValueError(f"Unknown physics method: {chosen_method}. "
+                             f"Available methods: '{PhysicsMethod.VAN_WESTEN_2025}', '{PhysicsMethod.SOULSBY_2011}'")
+
+        print(f"Physics calculations complete using {chosen_method} method!")
+
+    def _add_physics_van_westen(self, sedtrails_data):
+        """
+        Add physics using van Westen et al. (2025) approach.
+        
+        This method follows the workflow from van Westen et al. (2025):
+        1. Compute shear velocities and Shields number
+        2. Compute bed load velocity (Soulsby equation)
+        3. Compute suspended velocity using complex ratio formula
+        4. Compute layer thicknesses and mixing layer
+        """
+        print("Using van Westen et al. (2025) to compute transport velocities and add to SedTRAILS data...")
+        
+        # === LOAD: Extract data ===
+        flow_velocity_magnitude = sedtrails_data.depth_avg_flow_velocity['magnitude']
+        mean_bed_shear_stress = sedtrails_data.mean_bed_shear_stress
+        max_bed_shear_stress = sedtrails_data.max_bed_shear_stress
+        
+        bed_load_transport_x = sedtrails_data.bed_load_transport['x']
+        bed_load_transport_y = sedtrails_data.bed_load_transport['y']
+        bed_load_transport_magnitude = sedtrails_data.bed_load_transport['magnitude']
+
+        suspended_transport_x = sedtrails_data.suspended_transport['x']
+        suspended_transport_y = sedtrails_data.suspended_transport['y']
+        suspended_transport_magnitude = sedtrails_data.suspended_transport['magnitude']
+
+        # FIX: Automatically detect and handle fraction dimension
+        # Detect number of fractions from data shape (assuming shape is [time, fractions, spatial])
+        detected_fractions = bed_load_transport_magnitude.shape[1] if len(bed_load_transport_magnitude.shape) > 2 else 1
+        
+        print(f"Detected {detected_fractions} sediment fraction(s)")
+        
+        # Error if more than 1 fraction
+        if detected_fractions > 1:
+            raise NotImplementedError(
+                f"Multiple sediment fractions ({detected_fractions}) are not yet supported. "
+                f"The physics converter currently only handles single-fraction sediment transport. "
+                f"Please aggregate fractions or implement multi-fraction physics calculations."
+            )
+        
+        # For physics calculations, we need to work with squeezed data (no fraction dimension)
+        # but we'll add the dimension back to velocities at the end
+        if len(bed_load_transport_magnitude.shape) > 2:
+            print("Working with squeezed transport data for physics calculations")
+            bed_load_transport_x_calc = bed_load_transport_x.squeeze(axis=1)
+            bed_load_transport_y_calc = bed_load_transport_y.squeeze(axis=1)
+            bed_load_transport_magnitude_calc = bed_load_transport_magnitude.squeeze(axis=1)
+            
+            suspended_transport_x_calc = suspended_transport_x.squeeze(axis=1)
+            suspended_transport_y_calc = suspended_transport_y.squeeze(axis=1)
+            suspended_transport_magnitude_calc = suspended_transport_magnitude.squeeze(axis=1)
+            has_fraction_dim = True
+        else:
+            # Data already doesn't have fraction dimension
+            bed_load_transport_x_calc = bed_load_transport_x
+            bed_load_transport_y_calc = bed_load_transport_y
+            bed_load_transport_magnitude_calc = bed_load_transport_magnitude
+            
+            suspended_transport_x_calc = suspended_transport_x
+            suspended_transport_y_calc = suspended_transport_y
+            suspended_transport_magnitude_calc = suspended_transport_magnitude
+            has_fraction_dim = False
+        
+        # === COMPUTE ===
+
+        # Compute shear velocities
+        mean_shear_velocity = physics_lib.compute_shear_velocity(
+            mean_bed_shear_stress, self.config.water_density)
+        max_shear_velocity = physics_lib.compute_shear_velocity(
+            max_bed_shear_stress, self.config.water_density)
+        
+        # Compute Shields number
+        shields_number = physics_lib.compute_shields(
+            max_bed_shear_stress, self.config.gravity,
+            self.config.particle_density, self.config.water_density, self.config.grain_diameter)
+        
+        # Compute transport velocities (these will have shape [time, spatial])
+        bed_load_velocity = physics_lib.compute_bed_load_velocity(
+            shields_number, self.critical_shields, mean_shear_velocity)
+        
+        suspended_velocity = physics_lib.compute_suspended_velocity(
+            flow_velocity_magnitude, bed_load_velocity, self.settling_velocity,
+            self.config.von_karman_constant, max_shear_velocity,
+            shields_number, self.critical_shields,
+            method=physics_lib.SuspendedVelocityMethod.SOULSBY_2011)
+        
+        # Compute layer thicknesses using squeezed transport data
+        bed_load_layer_thickness = physics_lib.compute_transport_layer_thickness(
+            bed_load_transport_magnitude_calc, bed_load_velocity,
+            self.config.particle_density, self.config.porosity)
+        
+        suspended_layer_thickness = physics_lib.compute_transport_layer_thickness(
+            suspended_transport_magnitude_calc, suspended_velocity,
+            self.config.particle_density, self.config.porosity)
+        
+        # Compute directions from magnitudes using squeezed transport data
+        suspended_velocity_x, suspended_velocity_y = physics_lib.compute_directions_from_magnitude(
+            suspended_velocity, suspended_transport_x_calc, suspended_transport_y_calc, suspended_transport_magnitude_calc)
+        bed_load_velocity_x, bed_load_velocity_y = physics_lib.compute_directions_from_magnitude(
+            bed_load_velocity, bed_load_transport_x_calc, bed_load_transport_y_calc, bed_load_transport_magnitude_calc)
+        
+        # Compute mixing layer thickness using Bertin et al. (2008) method
+        mixing_layer_thickness = physics_lib.compute_mixing_layer_thickness(
+            max_bed_shear_stress, self.critical_shear_stress,
+            method=physics_lib.MixingLayerMethod.BERTIN_2008)
+        
+        # === EXPAND DIMENSIONS TO MATCH ORIGINAL STRUCTURE ===
+        if has_fraction_dim:
+            print("Expanding velocity dimensions to match transport data structure")
+            # Add fraction dimension (axis=1) to all computed physics quantities
+            shields_number = shields_number[:, np.newaxis, :]
+            bed_load_layer_thickness = bed_load_layer_thickness[:, np.newaxis, :]
+            suspended_layer_thickness = suspended_layer_thickness[:, np.newaxis, :]
+            mixing_layer_thickness = mixing_layer_thickness[:, np.newaxis, :]
+            
+            # Expand velocity components
+            bed_load_velocity = bed_load_velocity[:, np.newaxis, :]
+            bed_load_velocity_x = bed_load_velocity_x[:, np.newaxis, :]
+            bed_load_velocity_y = bed_load_velocity_y[:, np.newaxis, :]
+            
+            suspended_velocity = suspended_velocity[:, np.newaxis, :]
+            suspended_velocity_x = suspended_velocity_x[:, np.newaxis, :]
+            suspended_velocity_y = suspended_velocity_y[:, np.newaxis, :]
+        
+        # === STORE ===
+        
+        print("Adding physics fields to SedtrailsData...")
+        
+        # Physics parameters (scalar fields)
+        sedtrails_data.add_physics_field('shields_number', shields_number)
+        sedtrails_data.add_physics_field('bed_load_layer_thickness', bed_load_layer_thickness)
+        sedtrails_data.add_physics_field('suspended_layer_thickness', suspended_layer_thickness)
+        sedtrails_data.add_physics_field('mixing_layer_thickness', mixing_layer_thickness)
+        
+        # Sediment velocities (vector fields)
+        sedtrails_data.add_physics_field('bed_load_velocity', {
+            'x': bed_load_velocity_x, 'y': bed_load_velocity_y, 'magnitude': bed_load_velocity
+        })
+        sedtrails_data.add_physics_field('suspended_velocity', {
+            'x': suspended_velocity_x, 'y': suspended_velocity_y, 'magnitude': suspended_velocity
+        })
+
+    
+    def _add_physics_soulsby(self, sedtrails_data):
+        """
+        Add physics using Soulsby et al. (2011) approach.
+        """
+        
+        # Placeholder for Soulsby calculations
+        raise NotImplementedError(
+            "Soulsby et al. (2011) method not yet implemented. "
+            "This would have a completely different workflow:\n"
+            "1. Focus on individual particle tracking velocities\n"
+            "2. Different approach to settling and resuspension\n"
+            "3. Particle-specific rather than layer-based calculations\n"
+            "See: Soulsby, R. L., et al. (2011). Lagrangian model for simulating "
+            "the dispersal of sand-sized particles in coastal waters."
+        )

--- a/src/sedtrails/transport_converter/physics_lib.py
+++ b/src/sedtrails/transport_converter/physics_lib.py
@@ -1,3 +1,428 @@
 """
-Methods to convert between different units of physics parameters. 
+Physics Library for Sediment Transport Calculations
+
+This module implements physics-based calculations for sediment transport following
+methods from van Westen et al. (2025) and alternative methods from literature.
+
+References:
+-----------
+van Westen, B., de Schipper, M. A., Pearson, S. G., & Luijendijk, A. P. (2025). 
+Lagrangian modelling reveals sediment pathways at evolving coasts. 
+Scientific Reports, 15(1), 8793.
+https://www.nature.com/articles/s41598-025-92910-z#Sec8
+
+Soulsby, R. L., Mead, C. T., Wild, B. R., & Wood, M. J. (2011). 
+Lagrangian model for simulating the dispersal of sand-sized particles in coastal waters. 
+Journal of waterway, port, coastal, and ocean engineering, 137(3), 123-131.
+
+Soulsby, R. (1997). Dynamics of marine sands: a manual for practical applications. 
+Thomas Telford.
+
+Soulsby, R. L., & Whitehouse, R. (1997). Threshold of sediment motion in coastal environments. 
+Pacific Coasts and Ports '97: Proceedings of the 13th Australasian Coastal and Ocean 
+Engineering Conference and the 6th Australasian Port and Harbour Conference; Volume 1.
+
+Fredsoe, J., & Deigaard, R. (1992). Mechanics of coastal sediment transport. 
+World Scientific.
+
+Bertin, X., Bruneau, N., Breilh, J. F., Fortunato, A. B., & Karpytchev, M. (2012). 
+Importance of wave age and resonance in storm surges: The case Xynthia, Bay of Biscay. 
+Ocean Modelling, 42, 16-30.
 """
+
+import numpy as np
+from typing import Tuple
+from enum import Enum
+
+
+class SuspendedVelocityMethod(Enum):
+    """Available methods for computing suspended sediment velocity."""
+    VAN_WESTEN_2025 = "van_westen_2025"  # Main method from van Westen et al. (2025)
+    SOULSBY_2011 = "soulsby_2011"        # Alternative from Soulsby et al. (2011) - placeholder
+
+
+class MixingLayerMethod(Enum):
+    """Available methods for computing mixing layer thickness."""
+    BERTIN_2008 = "bertin_2008"          # Bertin method (current implementation)
+    HARRIS_WIBERG = "harris_wiberg"      # Harris & Wiberg method - placeholder
+
+
+def compute_shear_velocity(bed_shear_stress: np.ndarray, 
+                          water_density: float) -> np.ndarray:
+    """
+    Compute shear velocity from bed shear stress.
+    
+    Parameters:
+    -----------
+    bed_shear_stress : np.ndarray
+        Bed shear stress [N/m²]
+    water_density : float
+        Water density [kg/m³]
+        
+    Returns:
+    --------
+    np.ndarray
+        Shear velocity [m/s]
+        
+    Notes:
+    ------
+    u* = sqrt(τ / ρ_w)
+    
+    Reference: 
+    Soulsby, R. (1997). Dynamics of marine sands: a manual for practical applications. 
+    Thomas Telford. Equation 2.6 (CHECK THIS????)
+    """
+    return np.sqrt(np.abs(bed_shear_stress) / water_density)
+
+
+def compute_shields(bed_shear_stress: np.ndarray,
+                   gravity: float,
+                   sediment_density: float,
+                   water_density: float,
+                   grain_diameter: float) -> np.ndarray:
+    """
+    Compute Shields parameter (dimensionless bed shear stress).
+    
+    Parameters:
+    -----------
+    bed_shear_stress : np.ndarray
+        Bed shear stress [N/m²]
+    gravity : float
+        Gravitational acceleration [m/s²]
+    sediment_density : float
+        Sediment density [kg/m³]
+    water_density : float
+        Water density [kg/m³]
+    grain_diameter : float
+        Grain diameter [m]
+        
+    Returns:
+    --------
+    np.ndarray
+        Shields parameter [-]
+        
+    Notes:
+    ------
+    θ = τ / (g(ρ_s - ρ_w)d)
+    
+    Reference:
+    Soulsby, R. (1997). Dynamics of marine sands: a manual for practical applications. 
+    Thomas Telford. Equation 2.8 (CHECK THIS????)
+    """
+    return (np.abs(bed_shear_stress) / 
+            (gravity * (sediment_density - water_density) * grain_diameter))
+
+
+def compute_bed_load_velocity(shields_number: np.ndarray,
+                             critical_shields: float,
+                             mean_shear_velocity: np.ndarray) -> np.ndarray:
+    """
+    Compute bed load velocity using Soulsby equation 7.
+    
+    Parameters:
+    -----------
+    shields_number : np.ndarray
+        Shields parameter [-]
+    critical_shields : float
+        Critical Shields parameter [-]
+    mean_shear_velocity : np.ndarray
+        Mean shear velocity [m/s]
+        
+    Returns:
+    --------
+    np.ndarray
+        Bed load velocity [m/s]
+        
+    Notes:
+    ------
+    U_bed = 10 * u*_mean * (1 - 0.7 * sqrt(θ_cr / θ_max))
+    
+    Only computed where θ_max > θ_cr (critical conditions).
+    
+    References:  (CHECK THIS????)
+    Fredsoe, J., & Deigaard, R. (1992). Mechanics of coastal sediment transport. 
+    World Scientific.
+    
+    Soulsby, R. L., Mead, C. T., Wild, B. R., & Wood, M. J. (2011). 
+    Lagrangian model for simulating the dispersal of sand-sized particles in coastal waters. 
+    Journal of waterway, port, coastal, and ocean engineering, 137(3), 123-131. Equation 7
+    
+    van Westen, B., de Schipper, M. A., Pearson, S. G., & Luijendijk, A. P. (2025).
+    Lagrangian modelling reveals sediment pathways at evolving coasts. 
+    Scientific Reports, 15(1), 8793. Equation 2
+    """
+
+    with np.errstate(divide='ignore', invalid='ignore'):
+        return np.where(
+            shields_number > critical_shields,
+            10.0 * mean_shear_velocity * (1 - 0.7 * np.sqrt(critical_shields / shields_number)),
+            0.0
+        )
+
+
+def compute_transport_layer_thickness(transport_magnitude: np.ndarray,
+                                    velocity_magnitude: np.ndarray,
+                                    sediment_density: float,
+                                    porosity: float) -> np.ndarray:
+    """
+    Compute representative thickness of transport layer (bed load or suspended).
+    
+    Parameters:
+    -----------
+    transport_magnitude : np.ndarray
+        Magnitude of sediment transport [kg/m/s]
+    velocity_magnitude : np.ndarray
+        Velocity magnitude [m/s]
+    sediment_density : float
+        Sediment density [kg/m³]
+    porosity : float
+        Sediment porosity [-]
+        
+    Returns:
+    --------
+    np.ndarray
+        Transport layer thickness [m]
+        
+    Notes:
+    ------
+    d_layer = Q_layer / U_layer
+    where Q_layer = transport_magnitude / (ρ_s * (1 - n))
+    
+    This function works for both bed load and suspended transport layers.
+    
+    Reference: 
+    van Westen, B., de Schipper, M. A., Pearson, S. G., & Luijendijk, A. P. (2025).
+    Lagrangian modelling reveals sediment pathways at evolving coasts. 
+    Scientific Reports, 15(1), 8793. Equation 7
+    """
+    transport_flux = transport_magnitude / (sediment_density * (1 - porosity))
+    
+    with np.errstate(divide='ignore', invalid='ignore'):
+        return np.where(
+            velocity_magnitude > 0,
+            transport_flux / velocity_magnitude,
+            0.0
+        )
+
+
+def compute_suspended_velocity(flow_velocity_magnitude: np.ndarray,
+                              bed_load_velocity: np.ndarray,
+                              settling_velocity: float,
+                              von_karman_constant: float,
+                              max_shear_velocity: np.ndarray,
+                              shields_number: np.ndarray,
+                              critical_shields: float,
+                              method: SuspendedVelocityMethod = SuspendedVelocityMethod.SOULSBY_2011) -> np.ndarray:
+    """
+    Compute suspended sediment velocity.
+    
+    Parameters:
+    -----------
+    flow_velocity_magnitude : np.ndarray
+        Flow velocity magnitude [m/s]
+    bed_load_velocity : np.ndarray
+        Bed load velocity [m/s]
+    settling_velocity : float
+        Particle settling velocity [m/s]
+    von_karman_constant : float
+        von Kármán constant [-] (typically 0.4)
+    max_shear_velocity : np.ndarray
+        Maximum shear velocity [m/s]
+    shields_number : np.ndarray
+        Shields parameter [-]
+    critical_shields : float
+        Critical Shields parameter [-]
+    method : SuspendedVelocityMethod, optional
+        Method to use for calculation
+        
+    Returns:
+    --------
+    np.ndarray
+        Suspended velocity [m/s]
+        
+    Notes:
+    ------
+    van Westen et al. (2025) method:
+    U_sus = U_c * Rs
+    where Rs = ((Rb*(1-B))/(8/7-B)) * (((8/7*Rb)^(8-7B) - 1) / ((8/7*Rb)^(7-7B) - 1))
+    B = w_s / (κ * u*_max)  (Rouse parameter)
+    Rb = U_bed / U_c  (bed load ratio)
+    
+    Reference: 
+    van Westen, B., de Schipper, M. A., Pearson, S. G., & Luijendijk, A. P. (2025).
+    Lagrangian modelling reveals sediment pathways at evolving coasts. 
+    Scientific Reports, 15(1), 8793.
+    """
+    if method == SuspendedVelocityMethod.SOULSBY_2011:
+
+        # Critical conditions where Shields number exceeds critical threshold
+        critical_conditions = shields_number > critical_shields
+
+        # Compute Rouse parameter internally
+        rouse_parameter = settling_velocity / (von_karman_constant * max_shear_velocity)
+        
+        # Compute bed load ratio
+        bed_load_ratio = bed_load_velocity / flow_velocity_magnitude
+
+        # Compute suspended sediment ratio
+        # Rs = ((Rb*(1-B_rouse))/(8/7-B_rouse)) * (((8/7*Rb)**(8-7*B_rouse) - 1) / ((8/7*Rb)**(7-7*B_rouse) - 1))
+        suspended_ratio = ((bed_load_ratio * (1 - rouse_parameter)) / (8/7 - rouse_parameter)) * \
+            (((8/7 * bed_load_ratio)**(8 - 7 * rouse_parameter) - 1) /
+            ((8/7 * bed_load_ratio)**(7 - 7 * rouse_parameter) - 1))
+        
+        return np.where(
+            critical_conditions,
+            flow_velocity_magnitude * suspended_ratio,
+            0.0
+        )
+
+    else:
+        raise ValueError(f"Unknown suspended velocity method: {method}")
+
+
+def compute_directions_from_magnitude(velocity_magnitude: np.ndarray,
+                                    transport_x: np.ndarray,
+                                    transport_y: np.ndarray,
+                                    transport_magnitude: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Compute velocity direction components from transport components and velocity magnitude.
+    
+    Parameters:
+    -----------
+    velocity_magnitude : np.ndarray
+        Velocity magnitude [m/s]
+    transport_x : np.ndarray
+        X-component of transport [kg/m/s]
+    transport_y : np.ndarray
+        Y-component of transport [kg/m/s]
+    transport_magnitude : np.ndarray
+        Magnitude of transport [kg/m/s]
+        
+    Returns:
+    --------
+    Tuple[np.ndarray, np.ndarray]
+        (velocity_x, velocity_y) components [m/s]
+        
+    Notes:
+    ------
+    U_x = U_magnitude * (transport_x / transport_magnitude)
+    U_y = U_magnitude * (transport_y / transport_magnitude)
+    
+    Reference: 
+    van Westen, B., de Schipper, M. A., Pearson, S. G., & Luijendijk, A. P. (2025).
+    Lagrangian modelling reveals sediment pathways at evolving coasts. 
+    Scientific Reports, 15(1), 8793.
+    """
+    with np.errstate(divide='ignore', invalid='ignore'):
+        velocity_x = np.where(
+            transport_magnitude > 0,
+            velocity_magnitude * transport_x / transport_magnitude,
+            0.0
+        )
+    
+        velocity_y = np.where(
+            transport_magnitude > 0,
+            velocity_magnitude * transport_y / transport_magnitude,
+            0.0
+        )
+    
+    return velocity_x, velocity_y
+
+
+def compute_mixing_layer_thickness(max_bed_shear_stress: np.ndarray,
+                                  critical_shear_stress: float,
+                                  method: MixingLayerMethod = MixingLayerMethod.BERTIN_2008) -> np.ndarray:
+    """
+    Compute mixing layer thickness.
+    
+    Parameters:
+    -----------
+    max_bed_shear_stress : np.ndarray
+        Maximum bed shear stress [N/m²]
+    critical_shear_stress : float
+        Critical shear stress [N/m²]
+    method : MixingLayerMethod, optional
+        Method to use for calculation
+        
+    Returns:
+    --------
+    np.ndarray
+        Mixing layer thickness [m]
+        
+    Notes:
+    ------
+    Bertin (2008) method:
+    d_mix = 0.041 * sqrt(max(τ_max - τ_cr, 0))
+    
+    References:
+    van Westen, B., de Schipper, M. A., Pearson, S. G., & Luijendijk, A. P. (2025).
+    Lagrangian modelling reveals sediment pathways at evolving coasts. 
+    Scientific Reports, 15(1), 8793.
+    
+    Bertin, X., Bruneau, N., Breilh, J. F., Fortunato, A. B., & Karpytchev, M. (2012). 
+    Importance of wave age and resonance in storm surges: The case Xynthia, Bay of Biscay. 
+    Ocean Modelling, 42, 16-30.
+    """
+    if method == MixingLayerMethod.BERTIN_2008:
+        return 0.041 * np.sqrt(np.maximum(max_bed_shear_stress - critical_shear_stress, 0.0))
+    elif method == MixingLayerMethod.HARRIS_WIBERG:
+        # Placeholder for Harris & Wiberg method
+        raise NotImplementedError(
+            "Harris & Wiberg method not yet implemented. "
+            "Please implement based on specific application requirements."
+        )
+    else:
+        raise ValueError(f"Unknown mixing layer method: {method}")
+
+
+# Convenience function for getting all grain properties at once
+def compute_grain_properties(grain_diameter: float,
+                           gravity: float,
+                           sediment_density: float,
+                           water_density: float,
+                           kinematic_viscosity: float) -> Tuple[float, float, float, float]:
+    """
+    Compute all grain-related properties.
+    
+    Parameters:
+    -----------
+    grain_diameter : float
+        Grain diameter [m]
+    gravity : float
+        Gravitational acceleration [m/s²]
+    sediment_density : float
+        Sediment density [kg/m³]
+    water_density : float
+        Water density [kg/m³]
+    kinematic_viscosity : float
+        Kinematic viscosity [m²/s]
+        
+    Returns:
+    --------
+    Tuple[float, float, float, float]
+        (dimensionless_grain_size, critical_shields, settling_velocity, critical_shear_stress)
+        
+    References:
+    -----------
+    Soulsby, R. (1997). Dynamics of marine sands: a manual for practical applications. 
+    Thomas Telford. Equations 75, 15
+    
+    Soulsby, R. L., & Whitehouse, R. (1997). Threshold of sediment motion in coastal environments. 
+    Pacific Coasts and Ports '97: Proceedings of the 13th Australasian Coastal and Ocean 
+    Engineering Conference and the 6th Australasian Port and Harbour Conference; Volume 1. Equation 14
+    """
+    # Dimensionless grain size (Soulsby 1997, Equation 75)
+    dstar = (gravity * (sediment_density/water_density - 1) / kinematic_viscosity**2)**(1/3) * grain_diameter
+    
+    # Critical Shields number (Soulsby & Whitehouse 1997, Equation 14)
+    theta_cr = (0.3 / (1 + 1.2 * dstar) + 
+                0.055 * (1 - np.exp(-0.020 * dstar)))
+    
+    # Settling velocity (Soulsby 1997, Equation 15)
+    settling_velocity = ((kinematic_viscosity / grain_diameter) * 
+                        (np.sqrt(10.36**2 + 1.049 * dstar**3) - 10.36))
+    
+    # Critical shear stress
+    critical_shear_stress = (sediment_density - water_density) * gravity * grain_diameter * theta_cr
+    
+    return dstar, theta_cr, settling_velocity, critical_shear_stress


### PR DESCRIPTION
Implements a physics conversion toolbox that extents flow field data with sediment transport velocities and physical parameters. The system converts hydrodynamic and transport data into sediment transport velocities and equivalent transport thicknesses.

## Key Components Added

### 1. Physics Library (`physics_lib.py`)
- **Core physics calculations**, mainly following van Westen et al. (2025)
- **Modular functions** for:
  - Shear velocity computation from bed shear stress
  - Shields parameter (dimensionless bed shear stress) calculation
  - Bed load velocity using Soulsby equation with critical threshold detection
  - Suspended sediment velocity using complex ratio formulation with Rouse parameter
  - Transport layer thickness calculations for both bed load and suspended layers
  - Mixing layer thickness using Bertin (2008) method
  - Direction component derivation from transport magnitude and direction
  - Complete grain property calculations (dimensionless grain size, critical Shields, settling velocity)

### 2. Physics Converter (`physics_converter.py`)
- **PhysicsConverter class** that dynamically adds physics fields to existing SedtrailsData objects
- **PhysicsConfig dataclass** with default parameters:
  - Physical constants (gravity, von Kármán constant, viscosity)
  - Water/sediment properties (densities, porosity)
  - Grain characteristics (250 μm diameter for sand)
  - Method selection for different calculation approaches
- **Method-specific implementations**:
  - `van_westen_2025`: Complete workflow from van Westen et al. (2025)
  - `soulsby_2011`: Placeholder for alternative Soulsby approach

### 3. Enhanced SedtrailsData Structure
- **Dynamic physics field system** allowing runtime addition of computed parameters
- **New methods**: `add_physics_field()`, `has_physics_field()`, `get_physics_fields()`
- **Backward compatibility** with existing data access patterns
- **Automatic inclusion** of physics fields in time-indexed data retrieval

## Physics Fields Added
When physics conversion is applied, the following fields become available:

### Scalar Fields (shape: [time, fractions, spatial])
- `shields_number`: Dimensionless bed shear stress parameter
- `bed_load_layer_thickness`: Representative thickness of bed load transport layer [m]
- `suspended_layer_thickness`: Representative thickness of suspended transport layer [m]
- `mixing_layer_thickness`: Active mixing layer thickness following Bertin (2008) [m]

### Vector Fields (shape: [time, fractions, spatial] with 'x', 'y', 'magnitude' components)
- `bed_load_velocity`: Bed load sediment velocity [m/s]
- `suspended_velocity`: Suspended sediment velocity [m/s]

## Files Modified/Added
- `sedtrails/transport_converter/physics_lib.py` - Core physics calculation library
- `sedtrails/transport_converter/physics_converter.py` - Main converter class and configuration
- `sedtrails/transport_converter/format_converter.py` - Enhanced SedtrailsData with dynamic fields
- `examples/particle_simulation_numba_example.py` - Demonstration of physics-enhanced particle tracking