### PR TITLE
Update simulation buffer to connect NetCDF writer to the simulation loop

### DIFF
--- a/src/sedtrails/data_manager/simulation_buffer.py
+++ b/src/sedtrails/data_manager/simulation_buffer.py
@@ -1,5 +1,96 @@
-"""
-Simulation Data Buffer
-======================
-Temporarily stores chunks of simulation data in memory, while they wait to be written to a simulation file.
-"""
+import xugrid as xu
+import numpy as np
+
+class SimulationDataBuffer:
+    """
+    Temporarily stores chunks of simulation data in memory, while they wait to be written to a simulation file.
+
+    Attributes
+    ----------
+    buffer : dict
+        Dictionary holding simulation data arrays (particle ID, positions, and times at the moment).
+    """
+
+    def __init__(self):
+        """
+        Initialize an empty simulation data buffer.
+        """
+        self.buffer = {
+            "particle_id": [],
+            "time": [],
+            "x": [],
+            "y": [],
+            # Add other fields as needed (e.g., velocity, status, etc.)
+        }
+
+    def add(self, particle_id, time, x, y):
+        """
+        Add a new data point to the buffer.
+
+        Parameters
+        ----------
+        particle_id : int
+            Unique identifier for the particle.
+        time : float or int
+            Simulation time or time step.
+        x : float
+            X-coordinate of the particle.
+        y : float
+            Y-coordinate of the particle.
+        """
+        self.buffer["particle_id"].append(particle_id)
+        self.buffer["time"].append(time)
+        self.buffer["x"].append(x)
+        self.buffer["y"].append(y)
+
+    def clear(self):
+        """
+        Clear the buffer.
+        """
+        for key in self.buffer:
+            self.buffer[key] = []
+
+    def get_data(self):
+        """
+        Return the buffer as a dictionary of numpy arrays.
+
+        Returns
+        -------
+        dict
+            Dictionary with keys as field names and values as numpy arrays.
+        """
+        return {k: np.array(v) for k, v in self.buffer.items()}
+
+    def to_ugrid_dataset(self, node_x, node_y, face_node_connectivity, fill_value=-1):
+        """
+        Convert the buffer contents to a xu.UgridDataset for writing.
+
+        Parameters
+        ----------
+        node_x : np.ndarray
+            Mesh node x-coordinates.
+        node_y : np.ndarray
+            Mesh node y-coordinates.
+        face_node_connectivity : np.ndarray
+            Mesh face connectivity.
+        fill_value : int, optional
+            Fill value for unused nodes (default: -1).
+
+        Returns
+        -------
+        xu.UgridDataset
+            UGRID-compliant dataset containing the buffered simulation data.
+        """
+        mesh = xu.Ugrid2d(
+            node_x=node_x,
+            node_y=node_y,
+            face_node_connectivity=face_node_connectivity,
+            fill_value=fill_value
+        )
+        ds = mesh.to_dataset()
+        data = self.get_data()
+        ds["particle_id"] = (("obs",), data["particle_id"])
+        ds["time"] = (("obs",), data["time"])
+        ds["x"] = (("obs",), data["x"])
+        ds["y"] = (("obs",), data["y"])
+        return xu.UgridDataset(ds)

--- a/tests/data_manager/test_netcdf_writer.py
+++ b/tests/data_manager/test_netcdf_writer.py
@@ -1,7 +1,6 @@
 import pytest
 import xugrid as xu
 import numpy as np
-from pathlib import Path
 from sedtrails.data_manager.netcdf_writer import NetCDFWriter
 
 @pytest.fixture

--- a/tests/data_manager/test_simulation_buffer.py
+++ b/tests/data_manager/test_simulation_buffer.py
@@ -1,0 +1,46 @@
+import numpy as np
+import xugrid as xu
+import pytest
+from sedtrails.data_manager.simulation_buffer import SimulationDataBuffer
+
+def test_add_and_get_data():
+    """
+    Test adding data to the buffer and retrieving it as numpy arrays.
+    """
+    buffer = SimulationDataBuffer()
+    buffer.add(1, 0.0, 10.0, 20.0)
+    buffer.add(2, 1.0, 11.0, 21.0)
+    data = buffer.get_data()
+    assert np.array_equal(data["particle_id"], np.array([1, 2]))
+    assert np.array_equal(data["time"], np.array([0.0, 1.0]))
+    assert np.array_equal(data["x"], np.array([10.0, 11.0]))
+    assert np.array_equal(data["y"], np.array([20.0, 21.0]))
+
+def test_clear():
+    """
+    Test clearing the buffer.
+    """
+    buffer = SimulationDataBuffer()
+    buffer.add(1, 0.0, 10.0, 20.0)
+    buffer.clear()
+    data = buffer.get_data()
+    for arr in data.values():
+        assert arr.size == 0
+
+def test_to_ugrid_dataset():
+    """
+    Test converting the buffer to a xu.UgridDataset.
+    """
+    buffer = SimulationDataBuffer()
+    buffer.add(1, 0.0, 10.0, 20.0)
+    buffer.add(2, 1.0, 11.0, 21.0)
+    node_x = np.array([0, 1])
+    node_y = np.array([0, 1])
+    face_node_connectivity = np.array([[0, 1]])
+    fill_value = -1
+    ugrid_ds = buffer.to_ugrid_dataset(node_x, node_y, face_node_connectivity, fill_value)
+    assert isinstance(ugrid_ds, xu.UgridDataset)
+    assert "particle_id" in ugrid_ds
+    assert "x" in ugrid_ds
+    assert "y" in ugrid_ds
+    assert "time" in ugrid_ds


### PR DESCRIPTION
Implemented simulation buffer in `simulation_buffer.py` which we can call inside the simulation loop. It is consistent with the `netcdf_writer.py` file. I also added unit tests for the `simulation_buffer.py`.

Important points to note:
- Stores all relevant simulation data in memory, at the moment this is position (x and y), particle ID and time
- Allows us to add new data per time step/particle
- Can clear/reset for new runs (wrote a `clear` method for this)
- Exports to a `xu.UgridDataset` which is compatible with the `NetCDFWriter` class in `netcdf_writer.py`

I followed Bart's examples to try to get a sense of what we should store in the buffer. With the current implementation, we can call it as follows:
```python
buffer = SimulationDataBuffer()
for step in range(NUM_STEPS):
    buffer.add(particle_id, current_time, pos_x, pos_y)
```

### Relevant files
- `simulation_buffer.py`
- `test_simulation_buffer.py`

Closes #212 

PS: I realized the ruff error @manuGil pointed about the Path variable was in the `tests/data_manager/test_netcdf_writer.py` file but I did not notice it at the time. So I also fixed that in this PR. 

