### PR TITLE
Implement memory manager

### DIFF
--- a/src/sedtrails/data_manager/memory_manager.py
+++ b/src/sedtrails/data_manager/memory_manager.py
@@ -3,3 +3,84 @@ Memory Manager
 ==============
 Manages memory allocation and deallocation for the simulation data buffer.
 """
+
+import sys
+from sedtrails.data_manager.netcdf_writer import NetCDFWriter
+
+class MemoryManager:
+    """
+    Manages memory usage for the simulation data buffer. If the buffer exceeds the memory limit,
+    writes its contents to a NetCDF file and clears the buffer.
+
+    The current memory limit is set to 512 MB
+
+    Attributes
+    ----------
+    max_bytes : int
+        Maximum allowed memory usage in bytes.
+    writer : NetCDFWriter
+        Writer instance to write buffer to NetCDF when limit is exceeded.
+    file_counter : int
+        Counter for naming output files uniquely.
+    """
+
+    def __init__(self, output_dir, max_bytes=512 * 1024 * 1024):
+        """
+        Initialize the memory manager.
+
+        Parameters
+        ----------
+        output_dir : str or Path
+            Directory to write NetCDF files.
+        max_bytes : int
+            Maximum allowed memory usage in bytes (default: 512 MB).
+        """
+        self.max_bytes = max_bytes
+        self.writer = NetCDFWriter(output_dir)
+        self.file_counter = 0
+
+    def buffer_size_bytes(self, buffer):
+        """
+        Estimate the memory usage of the buffer in bytes.
+
+        Parameters
+        ----------
+        buffer : dict
+            The simulation data buffer (dict of lists or numpy arrays).
+
+        Returns
+        -------
+        int
+            Estimated memory usage in bytes.
+        """
+        size = 0
+        for v in buffer.values():
+            if hasattr(v, 'nbytes'):
+                size += v.nbytes
+            else:
+                size += sys.getsizeof(v)
+                if hasattr(v, '__iter__') and not isinstance(v, (str, bytes)):
+                    size += sum(sys.getsizeof(item) for item in v)
+        return size
+
+    def enforce_limit(self, sim_buffer, node_x, node_y, face_node_connectivity, fill_value=-1):
+        """
+        Enforce the memory limit: if over, write buffer to NetCDF and clear it.
+
+        Currently the output files are split into chunks of 512 MB: sim_buffer_0.nc,
+        sim_buffer_1.nc, etc. This will prevent any data loss due to memory overflow. 
+        In the future we need to check if this creates issues in managing many files.
+
+        Parameters
+        ----------
+        sim_buffer : SimulationDataBuffer
+            The simulation data buffer instance from simulation_buffer.py.
+        node_x, node_y, face_node_connectivity, fill_value : arrays/values
+            Mesh info for NetCDF writing.
+        """
+        if self.buffer_size_bytes(sim_buffer.buffer) > self.max_bytes:
+            filename = f"sim_buffer_{self.file_counter}.nc"
+            ugrid_ds = sim_buffer.to_ugrid_dataset(node_x, node_y, face_node_connectivity, fill_value)
+            self.writer.write(ugrid_ds, filename)
+            sim_buffer.clear()
+            self.file_counter += 1

--- a/src/sedtrails/data_manager/memory_manager.py
+++ b/src/sedtrails/data_manager/memory_manager.py
@@ -5,6 +5,7 @@ Manages memory allocation and deallocation for the simulation data buffer.
 """
 
 import sys
+import xugrid as xu
 from sedtrails.data_manager.netcdf_writer import NetCDFWriter
 
 class MemoryManager:
@@ -103,4 +104,4 @@ class MemoryManager:
         if not files:
             raise FileNotFoundError("No sim_buffer_*.nc files found to merge.")
         ds = xu.open_mfdataset(files, combine="by_coords")
-        ds.to_netcdf(self.writer.output_dir / merged_filename)            
+        ds.ugrid.to_netcdf(self.writer.output_dir / merged_filename)            

--- a/src/sedtrails/data_manager/memory_manager.py
+++ b/src/sedtrails/data_manager/memory_manager.py
@@ -84,3 +84,23 @@ class MemoryManager:
             self.writer.write(ugrid_ds, filename)
             sim_buffer.clear()
             self.file_counter += 1
+
+    def merge_output_files(self, merged_filename="merged_output.nc"):
+        """
+        Merge all sim_buffer_*.nc files in the output directory into a single NetCDF file.
+
+        Merging is based on the assumption that all files have the same structure and can be 
+        combined by coordinates, e.g., time, observation index, etc. This way, the merged 
+        file "merged_output.nc" will contain the entire simulation duration and all particles.
+        Each file chunk should have non-overlapping coordinate values.
+
+        Parameters
+        ----------
+        merged_filename : str
+            Name of the merged output file.
+        """
+        files = sorted(self.writer.output_dir.glob("sim_buffer_*.nc"))
+        if not files:
+            raise FileNotFoundError("No sim_buffer_*.nc files found to merge.")
+        ds = xu.open_mfdataset(files, combine="by_coords")
+        ds.to_netcdf(self.writer.output_dir / merged_filename)            

--- a/src/sedtrails/data_manager/netcdf_writer.py
+++ b/src/sedtrails/data_manager/netcdf_writer.py
@@ -37,6 +37,7 @@ class NetCDFWriter:
     def write(self, ugrid_dataset, filename):
         """
         Write a xu.UgridDataset to a NetCDF file in the output directory.
+        We use the "ugrid.to_netcdf()" method to ensure UGRID compliance.        
 
         Parameters
         ----------
@@ -49,5 +50,5 @@ class NetCDFWriter:
         output_path = self.output_dir / filename
         if not isinstance(ugrid_dataset, xu.UgridDataset):
             raise TypeError("Input must be a xu.UgridDataset.")
-        ugrid_dataset.to_netcdf(output_path)
+        ugrid_dataset.ugrid.to_netcdf(output_path)
         print(f"NetCDF file written to {output_path}")

--- a/src/sedtrails/data_manager/simulation_buffer.py
+++ b/src/sedtrails/data_manager/simulation_buffer.py
@@ -89,8 +89,9 @@ class SimulationDataBuffer:
         )
         ds = mesh.to_dataset()
         data = self.get_data()
-        ds["particle_id"] = (("obs",), data["particle_id"])
-        ds["time"] = (("obs",), data["time"])
-        ds["x"] = (("obs",), data["x"])
-        ds["y"] = (("obs",), data["y"])
+        # Use 'time' as the coordinate and dimension
+        ds = ds.assign_coords(time=("time", data["time"]))
+        ds["particle_id"] = ("time", data["particle_id"])
+        ds["x"] = ("time", data["x"])
+        ds["y"] = ("time", data["y"])
         return xu.UgridDataset(ds)

--- a/tests/data_manager/test_memory_manager.py
+++ b/tests/data_manager/test_memory_manager.py
@@ -33,6 +33,10 @@ def test_buffer_size_bytes_counts_numpy_and_lists(tmp_path):
 def test_enforce_limit_writes_file_and_clears(tmp_path):
     """
     Test that enforce_limit writes a NetCDF file and clears the buffer when over the memory limit.
+    
+    The NetCDFWriter may create a timestamped subdirectory, so to make this test more robust to
+    changes in output directory structure we check the MemoryManager's writer.output_dir.
+    This also keeps or code modular and allows us to test the MemoryManager independently of the NetCDFWriter 
     """
     node_x, node_y, face_node_connectivity, fill_value = create_test_mesh()
     mm = MemoryManager(tmp_path, max_bytes=1_000)  # Set a very low limit for test
@@ -42,9 +46,7 @@ def test_enforce_limit_writes_file_and_clears(tmp_path):
         sim_buffer.add(i, float(i), float(i), float(i))
     print("Buffer size (bytes):", mm.buffer_size_bytes(sim_buffer.buffer))
     mm.enforce_limit(sim_buffer, node_x, node_y, face_node_connectivity, fill_value)
-    # The NetCDFWriter may create a timestamped subdirectory, so check mm.writer.output_dir
-    # This makes the test more robust to changes in output directory structure and
-    # keeps our code modular
+    # Find the output_dir directly from the NetCDFWriter object
     expected_file = mm.writer.output_dir / "sim_buffer_0.nc"
     assert expected_file.exists()
     # Buffer should be cleared

--- a/tests/data_manager/test_memory_manager.py
+++ b/tests/data_manager/test_memory_manager.py
@@ -1,0 +1,69 @@
+import numpy as np
+import xugrid as xu
+from sedtrails.data_manager.memory_manager import MemoryManager
+from sedtrails.data_manager.simulation_buffer import SimulationDataBuffer
+
+def create_test_mesh():
+    """
+    Create a minimal mesh for testing purposes.
+
+    Returns
+    -------
+    tuple
+        node_x, node_y, face_node_connectivity, fill_value
+    """    
+    node_x = np.array([0, 1, 1, 0])
+    node_y = np.array([0, 0, 1, 1])
+    face_node_connectivity = np.array([[0, 1, 2, 3]])
+    fill_value = -1
+    return node_x, node_y, face_node_connectivity, fill_value
+
+def test_buffer_size_bytes_counts_numpy_and_lists(tmp_path):
+    """
+    Test that buffer_size_bytes correctly counts memory for numpy arrays and lists.
+    """    
+    mm = MemoryManager(tmp_path)
+    buffer = {
+        "a": np.zeros(100, dtype=np.float64),
+        "b": [1] * 100
+    }
+    size = mm.buffer_size_bytes(buffer)
+    assert size > 0
+
+def test_enforce_limit_writes_file_and_clears(tmp_path):
+    """
+    Test that enforce_limit writes a NetCDF file and clears the buffer when over the memory limit.
+    """
+    node_x, node_y, face_node_connectivity, fill_value = create_test_mesh()
+    mm = MemoryManager(tmp_path, max_bytes=1_000)  # Set a very low limit for test
+    sim_buffer = SimulationDataBuffer()
+    # Add enough data to exceed the limit
+    for i in range(5000):  # Increase to ensure buffer exceeds limit
+        sim_buffer.add(i, float(i), float(i), float(i))
+    print("Buffer size (bytes):", mm.buffer_size_bytes(sim_buffer.buffer))
+    mm.enforce_limit(sim_buffer, node_x, node_y, face_node_connectivity, fill_value)
+    # The NetCDFWriter may create a timestamped subdirectory, so check mm.writer.output_dir
+    # This makes the test more robust to changes in output directory structure and
+    # keeps our code modular
+    expected_file = mm.writer.output_dir / "sim_buffer_0.nc"
+    assert expected_file.exists()
+    # Buffer should be cleared
+    data = sim_buffer.get_data()
+    for arr in data.values():
+        assert arr.size == 0
+
+def test_enforce_limit_does_not_write_if_under_limit(tmp_path):
+    """
+    Test that enforce_limit does not write a file or clear the buffer if under the memory limit.
+    """    
+    node_x, node_y, face_node_connectivity, fill_value = create_test_mesh()
+    mm = MemoryManager(tmp_path, max_bytes=10_000_000)  # High limit
+    sim_buffer = SimulationDataBuffer()
+    for i in range(10):
+        sim_buffer.add(i, float(i), float(i), float(i))
+    mm.enforce_limit(sim_buffer, node_x, node_y, face_node_connectivity, fill_value)
+    # No file should be written
+    assert not any(f.name.startswith("sim_buffer_") and f.suffix == ".nc" for f in tmp_path.iterdir())
+    # Buffer should not be cleared
+    data = sim_buffer.get_data()
+    assert all(arr.size == 10 for arr in data.values())


### PR DESCRIPTION
- Implemented memory manager in `memory_manager.py` as the MemoryManager class. 
    - This class checks the size of the SimulationDataBuffer object, and if it exceeds 512MB it calls the NetCDFWriter to write out the simulation results in chunks
    - This way we can avoid losing any simulation data in case the simulation crashes or ends prematurely
    - In the future, we can implement the simulation recovery module to restart simulation from where it ended
- MemoryManager class also includes a method to merge all output files (if there are multiple files, that is) 
    - A single file is more convenient for downstream analysis and it is easier to store, transfer and keep track of simulations
    - We assume that each chunk written out to the filesystem covers a specific timespan within the simulation, so the merging is done based on the "time" coordinates of the xugrid dataset
    - I modified the SimulationDataBuffer object to have "time" as both a coordinate and dimension to allow us to merge based on the time coordinate
    - We assume that time coordinate is non-overlapping between different chunks of files

I also implemented tests for the MemoryManager class in `tests/data_manager/test_memory_manager.py`, while doing so I noticed a shortcoming in the NetCDFWriter class:
-  I modified the class to make sure we have an XUGRID compliant data structure as output
-  When testing the MemoryManager, the output_dir variable is extracted from the NetCDFWriter class, this decouples the two components and makes our code modular

### Relevant files:
- `src/sedtrails/data_manager/memory_manager.py`
- `src/sedtrails/data_manager/simulation_buffer.py`
- `src/sedtrails/data_manager/netcdf_writer.py`
- `tests/data_manager/test_memory_manager.py`

Closes #217 