### PR TITLE
Implement dump() method to write out simulation results

### DIFF
--- a/src/sedtrails/data_manager/manager.py
+++ b/src/sedtrails/data_manager/manager.py
@@ -35,7 +35,7 @@ class DataManager:
 
         self.output_dir = output_dir
         self.data_buffer = SimulationDataBuffer()
-        self.memory_manager = MemoryManager(max_bytes=max_bytes)
+        self.memory_manager = MemoryManager(output_dir=output_dir, max_bytes=max_bytes)
         self.writer = NetCDFWriter(output_dir)
         self._mesh_info = None
         self.file_counter = 0
@@ -101,4 +101,4 @@ class DataManager:
         merged_filename : str
             Name of the merged output file.
         """
-        SimulationDataBuffer.merge_output_files(self.output_dir, merged_filename)
+        SimulationDataBuffer.merge_output_files(self.writer.output_dir, merged_filename)

--- a/src/sedtrails/data_manager/manager.py
+++ b/src/sedtrails/data_manager/manager.py
@@ -8,7 +8,7 @@ class DataManager:
     and memory checks.
     """
 
-    def __init__(self, output_dir: str):
+    def __init__(self, output_dir: str, max_bytes=512 * 1024 * 1024):
         """
         Initialize the DataManager with a output data directory.
         All other resources are initialized lazily.
@@ -101,4 +101,4 @@ class DataManager:
         merged_filename : str
             Name of the merged output file.
         """
-        self.memory_manager.merge_output_files(merged_filename)        
+        SimulationDataBuffer.merge_output_files(self.output_dir, merged_filename)

--- a/src/sedtrails/data_manager/manager.py
+++ b/src/sedtrails/data_manager/manager.py
@@ -66,7 +66,7 @@ class DataManager:
                 pass
             except Exception as e:
                 # Log warning but don't fail the operation
-                print(f"Warning: Could not delete chunk file {chunk_file}: {e}")
+                logging.warning(f"Could not delete chunk file {chunk_file}: {e}")
 
     def set_mesh(self, node_x, node_y, face_node_connectivity, fill_value=-1):
         """

--- a/src/sedtrails/data_manager/manager.py
+++ b/src/sedtrails/data_manager/manager.py
@@ -1,28 +1,56 @@
-from sedtrails.data_manager import SimulationDataBuffer, MemoryManager
-
+from sedtrails.data_manager.simulation_buffer import SimulationDataBuffer
+from sedtrails.data_manager.memory_manager import MemoryManager
+from sedtrails.data_manager.netcdf_writer import NetCDFWriter
 
 class DataManager:
     """
-    A class to maange data and files produced by SedTrails.
+    A class to manage data and files produced by SedTrails, also simulation data buffering
+    and memory checks.
     """
 
     def __init__(self, output_dir: str):
         """
         Initialize the DataManager with a output data directory.
+        All other resources are initialized lazily.
 
-        Parameters
+        This class acts as the main interface between the simulation and the data management
+        system. It handles adding new simulation data, checking memory usage, and writing
+        data to disk when necessary.
+
+        Attributes
         ----------
         output_dir : str
             Path to the output directory where data will be stored.
+        data_buffer : SimulationDataBuffer
+            Buffer for temporarily storing simulation data.
+        memory_manager : MemoryManager
+            Utility for checking if the buffer exceeds the memory limit.
+        writer : NetCDFWriter
+            Writer instance for outputting NetCDF files.
+        _mesh_info : tuple or None
+            Mesh information (node_x, node_y, face_node_connectivity, fill_value).
+        file_counter : int
+            Counter for naming output files uniquely.
         """
 
         self.output_dir = output_dir
         self.data_buffer = SimulationDataBuffer()
-        self.memory_manager = MemoryManager(output_dir)
+        self.memory_manager = MemoryManager(max_bytes=max_bytes)
+        self.writer = NetCDFWriter(output_dir)
+        self._mesh_info = None
+        self.file_counter = 0
+
+    def set_mesh(self, node_x, node_y, face_node_connectivity, fill_value=-1):
+        """
+        Set or update the mesh information for output.
+        """
+        self._mesh_info = (node_x, node_y, face_node_connectivity, fill_value)
+
 
     def add_data(self, particle_id, time, x, y):
         """
         Add a new data point to the simulation data buffer.
+        If the buffer exceeds the memory limit, write to disk and clear the buffer.
 
         Parameters
         ----------
@@ -36,8 +64,41 @@ class DataManager:
             Y-coordinate of the particle.
         """
         self.data_buffer.add(particle_id, time, x, y)
-        if self.memory_manager.buffer_size_bytes(self.data_buffer.get_data()) > self.memory_manager.max_bytes:
-            self.memory_manager.enforce_limit(self.data_buffer, [], [], [])
+        if self._mesh_info is not None:
+            node_x, node_y, face_node_connectivity, fill_value = self._mesh_info
+            if self.memory_manager.is_limit_exceeded(self.data_buffer.get_data()):
+                filename = f".sim_buffer_{self.file_counter}.nc"
+                self.data_buffer.write_to_disk(
+                    node_x, node_y, face_node_connectivity, fill_value, self.writer, filename
+                )
+                self.file_counter += 1
 
-        # TODO: complete this class
-        pass
+    def write(self, filename=None):
+        """
+        Write out the current buffer to a NetCDF file, even if memory is not exceeded.
+
+        Parameters
+        ----------
+        filename : str or None
+            Name of the output NetCDF file. If None, uses a default naming scheme.
+        """
+        if self._mesh_info is None:
+            raise ValueError("Mesh information must be set before writing data.")
+        node_x, node_y, face_node_connectivity, fill_value = self._mesh_info
+        if filename is None:
+            filename = f".sim_buffer_{self.file_counter}.nc"
+        self.data_buffer.write_to_disk(
+            node_x, node_y, face_node_connectivity, fill_value, self.writer, filename
+        )
+        self.file_counter += 1
+
+    def merge(self, merged_filename="merged_output.nc"):
+        """
+        Merge all chunked NetCDF files into a single file.
+
+        Parameters
+        ----------
+        merged_filename : str
+            Name of the merged output file.
+        """
+        self.memory_manager.merge_output_files(merged_filename)        

--- a/src/sedtrails/data_manager/netcdf_writer.py
+++ b/src/sedtrails/data_manager/netcdf_writer.py
@@ -51,4 +51,3 @@ class NetCDFWriter:
         if not isinstance(ugrid_dataset, xu.UgridDataset):
             raise TypeError("Input must be a xu.UgridDataset.")
         ugrid_dataset.ugrid.to_netcdf(output_path)
-        print(f"NetCDF file written to {output_path}")

--- a/src/sedtrails/data_manager/simulation_buffer.py
+++ b/src/sedtrails/data_manager/simulation_buffer.py
@@ -93,3 +93,26 @@ class SimulationDataBuffer:
         ds['x'] = ('time', data['x'])
         ds['y'] = ('time', data['y'])
         return xu.UgridDataset(ds)
+
+    def write_to_disk(self, node_x, node_y, face_node_connectivity, fill_value, writer, filename):
+        """
+        Write the current buffer to disk as a UGRID NetCDF file and clear the buffer.
+
+        Parameters
+        ----------
+        node_x : np.ndarray
+            Mesh node x-coordinates.
+        node_y : np.ndarray
+            Mesh node y-coordinates.
+        face_node_connectivity : np.ndarray
+            Mesh face connectivity.
+        fill_value : int
+            Fill value for unused nodes.
+        writer : NetCDFWriter
+            Writer instance to handle NetCDF output.
+        filename : str
+            Name of the output NetCDF file.
+        """
+        ugrid_ds = self.to_ugrid_dataset(node_x, node_y, face_node_connectivity, fill_value)
+        writer.write(ugrid_ds, filename)
+        self.clear()

--- a/src/sedtrails/data_manager/simulation_buffer.py
+++ b/src/sedtrails/data_manager/simulation_buffer.py
@@ -1,3 +1,4 @@
+import os
 import xugrid as xu
 import numpy as np
 from pathlib import Path
@@ -135,12 +136,12 @@ class SimulationDataBuffer:
             Name of the merged output file.
         """
         output_dir = Path(output_dir)
-        
-        # Use more permissive pattern or the absolute path with explicit dot
-        files = sorted(output_dir.glob('.sim_buffer*.nc'))  # Removed underscore
-        
+        print("Output dir:", output_dir)
+        files = sorted(
+            output_dir / f for f in os.listdir(output_dir)
+            if f.startswith('.sim_buffer_') and f.endswith('.nc')
+        )
         if not files:
             raise FileNotFoundError('No .sim_buffer_*.nc files found to merge.')
-        
         ds = xu.open_mfdataset(files, combine='by_coords')
         ds.ugrid.to_netcdf(output_dir / merged_filename)

--- a/src/sedtrails/data_manager/simulation_buffer.py
+++ b/src/sedtrails/data_manager/simulation_buffer.py
@@ -135,8 +135,12 @@ class SimulationDataBuffer:
             Name of the merged output file.
         """
         output_dir = Path(output_dir)
-        files = sorted(output_dir.glob('.sim_buffer_*.nc'))
+        
+        # Use more permissive pattern or the absolute path with explicit dot
+        files = sorted(output_dir.glob('.sim_buffer*.nc'))  # Removed underscore
+        
         if not files:
             raise FileNotFoundError('No .sim_buffer_*.nc files found to merge.')
+        
         ds = xu.open_mfdataset(files, combine='by_coords')
-        ds.ugrid.to_netcdf(output_dir / merged_filename)        
+        ds.ugrid.to_netcdf(output_dir / merged_filename)

--- a/tests/data_manager/test_manager.py
+++ b/tests/data_manager/test_manager.py
@@ -1,0 +1,74 @@
+import pytest
+import numpy as np
+import xugrid as xu
+from sedtrails.data_manager.manager import DataManager
+
+def create_test_mesh():
+    """
+    Test mesh creation function for DataManager tests.
+    """
+    node_x = np.array([0, 1, 1, 0])
+    node_y = np.array([0, 0, 1, 1])
+    face_node_connectivity = np.array([[0, 1, 2, 3]])
+    fill_value = -1
+    return node_x, node_y, face_node_connectivity, fill_value
+
+def test_add_data_and_write(tmp_path):
+    """
+    Test that DataManager buffers data and writes to disk when requested.
+    """
+    dm = DataManager(tmp_path)
+    node_x, node_y, face_node_connectivity, fill_value = create_test_mesh()
+    dm.set_mesh(node_x, node_y, face_node_connectivity, fill_value)
+    # Add some data
+    dm.add_data(1, 0.0, 10.0, 20.0)
+    dm.add_data(2, 1.0, 11.0, 21.0)
+    # Write to disk
+    dm.write("test_manager_output.nc")
+    output_dir = dm.writer.output_dir
+    output_file = output_dir / "test_manager_output.nc"
+    assert output_file.exists()
+    ds = xu.open_dataset(output_file)
+    assert "particle_id" in ds
+    assert "x" in ds
+    assert "y" in ds
+    assert len(ds.time) == 2
+
+def test_buffer_limit_triggers_write(tmp_path):
+    """
+    Test that DataManager writes to disk automatically when buffer exceeds memory limit.
+    """
+    # Set a very low memory limit to force a write
+    dm = DataManager(tmp_path, max_bytes=1)
+    node_x, node_y, face_node_connectivity, fill_value = create_test_mesh()
+    dm.set_mesh(node_x, node_y, face_node_connectivity, fill_value)
+    # Add enough data to exceed the limit
+    for i in range(100):
+        dm.add_data(i, float(i), float(i), float(i))
+    # The first file should have been written
+    output_dir = dm.writer.output_dir
+    expected_file = output_dir / ".sim_buffer_0.nc"
+    assert expected_file.exists()
+
+def test_merge(tmp_path):
+    """
+    Test that DataManager.merge merges chunked files into a single file.
+    """
+    dm = DataManager(tmp_path)
+    node_x, node_y, face_node_connectivity, fill_value = create_test_mesh()
+    dm.set_mesh(node_x, node_y, face_node_connectivity, fill_value)
+    # Write two chunks
+    for i in range(5):
+        dm.add_data(i, float(i), float(i), float(i))
+    dm.write()  # .sim_buffer_0.nc
+    for i in range(5, 10):
+        dm.add_data(i, float(i), float(i), float(i))
+    dm.write()  # .sim_buffer_1.nc
+    # Get the output directory from the writer
+    output_dir = dm.writer.output_dir
+    # Merge
+    dm.merge("merged_manager.nc")
+    merged_file = output_dir / "merged_manager.nc"  
+    assert merged_file.exists()
+    ds = xu.open_dataset(merged_file)
+    assert len(ds.time) == 10

--- a/tests/data_manager/test_memory_manager.py
+++ b/tests/data_manager/test_memory_manager.py
@@ -30,67 +30,13 @@ def test_buffer_size_bytes_counts_numpy_and_lists(tmp_path):
     size = mm.buffer_size_bytes(buffer)
     assert size > 0
 
-def test_enforce_limit_writes_file_and_clears(tmp_path):
+def test_is_limit_exceeded(tmp_path):
     """
-    Test that enforce_limit writes a NetCDF file and clears the buffer when over the memory limit.
+    Test that is_limit_exceeded correctly identifies when a buffer exceeds the memory limit.
+    """
+    mm = MemoryManager(tmp_path, max_bytes=100)
+    small_buffer = {"data": np.zeros(10)}  
+    large_buffer = {"data": np.zeros(1000)}  
     
-    The NetCDFWriter may create a timestamped subdirectory, so to make this test more robust to
-    changes in output directory structure we check the MemoryManager's writer.output_dir.
-    This also keeps or code modular and allows us to test the MemoryManager independently of the NetCDFWriter 
-    """
-    node_x, node_y, face_node_connectivity, fill_value = create_test_mesh()
-    mm = MemoryManager(tmp_path, max_bytes=1_000)  # Set a very low limit for test
-    sim_buffer = SimulationDataBuffer()
-    # Add enough data to exceed the limit
-    for i in range(5000):  # Increase to ensure buffer exceeds limit
-        sim_buffer.add(i, float(i), float(i), float(i))
-    print("Buffer size (bytes):", mm.buffer_size_bytes(sim_buffer.buffer))
-    mm.enforce_limit(sim_buffer, node_x, node_y, face_node_connectivity, fill_value)
-    # Find the output_dir directly from the NetCDFWriter object
-    expected_file = mm.writer.output_dir / "sim_buffer_0.nc"
-    assert expected_file.exists()
-    # Buffer should be cleared
-    data = sim_buffer.get_data()
-    for arr in data.values():
-        assert arr.size == 0
-
-def test_enforce_limit_does_not_write_if_under_limit(tmp_path):
-    """
-    Test that enforce_limit does not write a file or clear the buffer if under the memory limit.
-    """    
-    node_x, node_y, face_node_connectivity, fill_value = create_test_mesh()
-    mm = MemoryManager(tmp_path, max_bytes=10_000_000)  # High limit
-    sim_buffer = SimulationDataBuffer()
-    for i in range(10):
-        sim_buffer.add(i, float(i), float(i), float(i))
-    mm.enforce_limit(sim_buffer, node_x, node_y, face_node_connectivity, fill_value)
-    # No file should be written
-    assert not any(f.name.startswith("sim_buffer_") and f.suffix == ".nc" for f in tmp_path.iterdir())
-    # Buffer should not be cleared
-    data = sim_buffer.get_data()
-    assert all(arr.size == 10 for arr in data.values())
-
-def test_merge_output_files(tmp_path):
-    """
-    Test that merge_output_files correctly merges multiple NetCDF chunk files into one.
-    """
-    node_x, node_y, face_node_connectivity, fill_value = create_test_mesh()
-    mm = MemoryManager(tmp_path, max_bytes=1000)  # Low limit to force chunking
-    sim_buffer = SimulationDataBuffer()
-    # Write two chunks with different time values
-    for i in range(10):
-        sim_buffer.add(i, i, float(i), float(i))
-    mm.enforce_limit(sim_buffer, node_x, node_y, face_node_connectivity, fill_value)
-    for i in range(10, 20):
-        sim_buffer.add(i, i, float(i), float(i))
-    mm.enforce_limit(sim_buffer, node_x, node_y, face_node_connectivity, fill_value)
-    # Merge the files
-    mm.merge_output_files("merged_test.nc")
-    merged_file = mm.writer.output_dir / "merged_test.nc"
-    assert merged_file.exists()
-    # Open merged file and check data
-    ds = xu.open_dataset(merged_file)
-    assert "x" in ds
-    assert "y" in ds
-    # Should have 20 unique time values
-    assert len(np.unique(ds["time"].values)) == 20
+    assert not mm.is_limit_exceeded(small_buffer)  # Should be under limit
+    assert mm.is_limit_exceeded(large_buffer)  # Should exceed limit

--- a/tests/data_manager/test_simulation_buffer.py
+++ b/tests/data_manager/test_simulation_buffer.py
@@ -118,7 +118,7 @@ def test_merge_output_files(tmp_path):
         buffer2.add(i, float(i), float(i), float(i))
     buffer2.write_to_disk(node_x, node_y, face_node_connectivity, fill_value, writer, ".sim_buffer_1.nc")
     
-    # Debug: Print directory contents
+    # Make sure we get the correct output directory
     output_dir = writer.output_dir
     # Merge the files
     SimulationDataBuffer.merge_output_files(output_dir, "merged_test.nc")    

--- a/tests/data_manager/test_simulation_buffer.py
+++ b/tests/data_manager/test_simulation_buffer.py
@@ -1,7 +1,9 @@
+import pytest
 import numpy as np
 import xugrid as xu
+from pathlib import Path
 from sedtrails.data_manager.simulation_buffer import SimulationDataBuffer
-
+from sedtrails.data_manager.netcdf_writer import NetCDFWriter 
 
 def test_add_and_get_data():
     """
@@ -46,3 +48,95 @@ def test_to_ugrid_dataset():
     assert 'x' in ugrid_ds
     assert 'y' in ugrid_ds
     assert 'time' in ugrid_ds
+
+def test_write_to_disk(tmp_path):
+    """
+    Test writing buffer to disk using the write_to_disk method.
+    """
+    # Create buffer with test data
+    buffer = SimulationDataBuffer()
+    buffer.add(1, 0.0, 10.0, 20.0)
+    buffer.add(2, 1.0, 11.0, 21.0)
+    
+    # Create test mesh
+    node_x = np.array([0, 1, 1, 0])
+    node_y = np.array([0, 0, 1, 1])
+    face_node_connectivity = np.array([[0, 1, 2, 3]])
+    fill_value = -1
+    
+    # Create writer and filename
+    writer = NetCDFWriter(tmp_path)
+    filename = "test_output.nc"
+    output_dir = writer.output_dir
+    
+    # Get data before write to check clearing
+    before_data = buffer.get_data().copy()
+    assert len(before_data['particle_id']) == 2  # Verify data exists
+    
+    # Write to disk
+    buffer.write_to_disk(node_x, node_y, face_node_connectivity, fill_value, writer, filename)
+    
+    # Check file exists
+    output_file = output_dir / filename
+    assert output_file.exists()
+    
+    # Check file contents
+    ds = xu.open_dataset(output_file)
+    assert 'particle_id' in ds
+    assert 'x' in ds
+    assert 'y' in ds
+    assert len(ds.time) == 2
+    assert ds.particle_id.values.tolist() == [1, 2]
+    
+    # Check buffer was cleared
+    after_data = buffer.get_data()
+    for arr in after_data.values():
+        assert arr.size == 0
+
+
+def test_merge_output_files(tmp_path):
+    """
+    Test that merge_output_files correctly merges multiple NetCDF chunk files into one.
+    """
+    # Create test mesh
+    node_x = np.array([0, 1, 1, 0])
+    node_y = np.array([0, 0, 1, 1])
+    face_node_connectivity = np.array([[0, 1, 2, 3]])
+    fill_value = -1
+    
+    writer = NetCDFWriter(tmp_path)
+    
+    # Create and write first chunk - KEEP the dot prefix
+    buffer1 = SimulationDataBuffer()
+    for i in range(5):
+        buffer1.add(i, float(i), float(i), float(i))
+    buffer1.write_to_disk(node_x, node_y, face_node_connectivity, fill_value, writer, ".sim_buffer_0.nc")
+    
+    # Create and write second chunk
+    buffer2 = SimulationDataBuffer()
+    for i in range(5, 10):
+        buffer2.add(i, float(i), float(i), float(i))
+    buffer2.write_to_disk(node_x, node_y, face_node_connectivity, fill_value, writer, ".sim_buffer_1.nc")
+    
+    # Debug: Print directory contents
+    output_dir = writer.output_dir
+    # Merge the files
+    SimulationDataBuffer.merge_output_files(output_dir, "merged_test.nc")    
+    # Check that merged file exists
+    merged_file = output_dir / "merged_test.nc"
+    assert merged_file.exists()
+    
+    # Open merged file and verify data
+    ds = xu.open_dataset(merged_file)
+    assert "x" in ds
+    assert "y" in ds
+    assert "particle_id" in ds
+    assert len(ds.time) == 10  # Should have 10 time steps total
+
+def test_merge_output_files_no_files(tmp_path):
+    """
+    Test that merge_output_files raises an error when no files are found.
+    """
+    # Use the EXACT error message including the period at the end
+    with pytest.raises(FileNotFoundError, match="No .sim_buffer_\\*.nc files found to merge\\."):
+        SimulationDataBuffer.merge_output_files(tmp_path, "merged_test.nc")


### PR DESCRIPTION
Implemented a  complete data management system for SedTRAILS that handles simulation data buffering, memory management, file I/O operations, and provides a clean abstraction layer for simulation code.

Closes #224 

### Summary of the changes:

- DataManager Class (`manager.py`)
    - Single entry point for all data management operations
    - Automatic memory monitoring with preset limits (default: 512MB)
    - File counter tracking for unique chunk file naming
- SimulationDataBuffer Class (`simulation_buffer.py`)
    - UGRID-compliant NetCDF output with mesh topology
    - Automatic buffer clearing after write operations
    - Merge functionality for combining multiple chunk files
- Memory Management (`memory_manager.py`)
    - Preset memory limits to prevent system overload
    - Automatic buffer size calculation including numpy arrays and Python objects
    - Writing is triggered when adding data to the buffer and the buffer limits are exceeded
    - Integration with NetCDF writer

All 3 of the files have corresponding tests added under `tests/data_manager/` as well.

### Example usage in simulation
```python
# Lazy initialize only with the output directory
dm = DataManager("output_dir/")

node_x = np.array([0, 1, 1, 0])
node_y = np.array([0, 0, 1, 1])
face_node_connectivity = np.array([[0, 1, 2, 3]])
fill_value = -1

dm.set_mesh(node_x, node_y, face_node_connectivity, fill_value)

# During simulation
for timestep in simulation:
    for particle in particles:
        dm.add_data(particle.id, timestep, particle.x, particle.y)
    # Automatic memory management 

# At end of simulation  
final_file = dm.dump()  # Everything handled automatically
```

### Flexible in dump() method
```python
final_file = dm.dump(merge=False)  # Just write, don't merge
final_file = dm.dump(cleanup_chunks=False)  # Keep intermediate files
final_file = dm.dump(merged_filename="results.nc")  # Custom filename
```