### PR TITLE
Implement logger in the simulation

### DIFF
--- a/examples/log_example.txt
+++ b/examples/log_example.txt
@@ -1,0 +1,28 @@
+2025-07-22 15:13:40,019 - INFO - === LOGGING INITIALIZED ===
+2025-07-22 15:13:40,020 - INFO - Log file: log.txt
+2025-07-22 15:13:40,020 - INFO - Location: /home/aurhan/Work/Projects/SedTRAILS/sedtrails/results
+2025-07-22 15:13:40,020 - INFO - === SIMULATION START ===
+2025-07-22 15:13:40,020 - INFO - Command: src/sedtrails/simulation.py
+2025-07-22 15:13:40,020 - INFO - Python: 3.13.2
+2025-07-22 15:13:40,020 - INFO - Config: examples/config.example.yaml
+2025-07-22 15:13:40,020 - INFO - Working directory: /home/aurhan/Work/Projects/SedTRAILS/sedtrails
+2025-07-22 15:13:40,020 - INFO - Loading configuration: examples/config.example.yaml
+2025-07-22 15:13:40,562 - INFO - --- Data Conversion Complete ---
+2025-07-22 15:13:40,562 - INFO - Timesteps: 290
+2025-07-22 15:13:40,563 - INFO - Flow field: suspended_velocity
+2025-07-22 15:13:40,563 - INFO - Duration: 22698s
+2025-07-22 15:13:40,563 - INFO - Time step: 30s
+2025-07-22 15:13:40,563 - INFO - Created 1 particle(s)
+2025-07-22 15:13:40,563 - INFO - Starting position: unknown
+2025-07-22 15:13:40,563 - INFO - Seeding method: single point at 40000,17000, transect seeding, grid seeding
+2025-07-22 15:13:40,564 - INFO - Compiling calculator for 3213x3213 grid
+2025-07-22 15:13:40,637 - INFO - Calculator compiled in 0.07 seconds
+2025-07-22 15:13:40,638 - INFO - Status: Warming Up Jit
+2025-07-22 15:13:42,545 - INFO - JIT warmed up in 1.91 seconds
+2025-07-22 15:13:42,895 - INFO - === SIMULATION COMPLETE ===
+2025-07-22 15:13:42,895 - INFO - Total steps: 756
+2025-07-22 15:13:42,895 - INFO - Runtime: 2.33s
+2025-07-22 15:13:42,895 - INFO - Final position: (38516.48, 16461.79)
+2025-07-22 15:13:43,178 - INFO - Creating visualization with 757 trajectory points
+2025-07-22 15:13:44,552 - INFO - Status: Visualization Complete
+2025-07-22 15:13:44,553 - INFO -   output_plot_path: ./results/trajectory_plot.png

--- a/examples/log_example.txt
+++ b/examples/log_example.txt
@@ -1,28 +1,28 @@
-2025-07-22 15:13:40,019 - INFO - === LOGGING INITIALIZED ===
-2025-07-22 15:13:40,020 - INFO - Log file: log.txt
-2025-07-22 15:13:40,020 - INFO - Location: /home/aurhan/Work/Projects/SedTRAILS/sedtrails/results
-2025-07-22 15:13:40,020 - INFO - === SIMULATION START ===
-2025-07-22 15:13:40,020 - INFO - Command: src/sedtrails/simulation.py
-2025-07-22 15:13:40,020 - INFO - Python: 3.13.2
-2025-07-22 15:13:40,020 - INFO - Config: examples/config.example.yaml
-2025-07-22 15:13:40,020 - INFO - Working directory: /home/aurhan/Work/Projects/SedTRAILS/sedtrails
-2025-07-22 15:13:40,020 - INFO - Loading configuration: examples/config.example.yaml
-2025-07-22 15:13:40,562 - INFO - --- Data Conversion Complete ---
-2025-07-22 15:13:40,562 - INFO - Timesteps: 290
-2025-07-22 15:13:40,563 - INFO - Flow field: suspended_velocity
-2025-07-22 15:13:40,563 - INFO - Duration: 22698s
-2025-07-22 15:13:40,563 - INFO - Time step: 30s
-2025-07-22 15:13:40,563 - INFO - Created 1 particle(s)
-2025-07-22 15:13:40,563 - INFO - Starting position: unknown
-2025-07-22 15:13:40,563 - INFO - Seeding method: single point at 40000,17000, transect seeding, grid seeding
-2025-07-22 15:13:40,564 - INFO - Compiling calculator for 3213x3213 grid
-2025-07-22 15:13:40,637 - INFO - Calculator compiled in 0.07 seconds
-2025-07-22 15:13:40,638 - INFO - Status: Warming Up Jit
-2025-07-22 15:13:42,545 - INFO - JIT warmed up in 1.91 seconds
-2025-07-22 15:13:42,895 - INFO - === SIMULATION COMPLETE ===
-2025-07-22 15:13:42,895 - INFO - Total steps: 756
-2025-07-22 15:13:42,895 - INFO - Runtime: 2.33s
-2025-07-22 15:13:42,895 - INFO - Final position: (38516.48, 16461.79)
-2025-07-22 15:13:43,178 - INFO - Creating visualization with 757 trajectory points
-2025-07-22 15:13:44,552 - INFO - Status: Visualization Complete
-2025-07-22 15:13:44,553 - INFO -   output_plot_path: ./results/trajectory_plot.png
+2025-07-22 15:42:52,727 - INFO - === LOGGING INITIALIZED ===
+2025-07-22 15:42:52,727 - INFO - Log file: log.txt
+2025-07-22 15:42:52,727 - INFO - Location: /home/aurhan/Work/Projects/SedTRAILS/sedtrails/results
+2025-07-22 15:42:52,727 - INFO - === SIMULATION START ===
+2025-07-22 15:42:52,727 - INFO - Command: src/sedtrails/simulation.py
+2025-07-22 15:42:52,727 - INFO - Python: 3.13.2
+2025-07-22 15:42:52,727 - INFO - Config: examples/config.example.yaml
+2025-07-22 15:42:52,727 - INFO - Working directory: /home/aurhan/Work/Projects/SedTRAILS/sedtrails
+2025-07-22 15:42:52,727 - INFO - Loading configuration: examples/config.example.yaml
+2025-07-22 15:42:53,169 - INFO - --- Data Conversion Complete ---
+2025-07-22 15:42:53,170 - INFO - Timesteps: 290
+2025-07-22 15:42:53,170 - INFO - Flow field: suspended_velocity
+2025-07-22 15:42:53,170 - INFO - Duration: 22698s
+2025-07-22 15:42:53,170 - INFO - Time step: 30s
+2025-07-22 15:42:53,170 - INFO - Created 1 particle(s)
+2025-07-22 15:42:53,170 - INFO - Starting position: unknown
+2025-07-22 15:42:53,170 - INFO - Seeding method: single point at 40000,17000, transect seeding, grid seeding
+2025-07-22 15:42:53,170 - INFO - Compiling calculator for 3213x3213 grid
+2025-07-22 15:42:53,212 - INFO - Calculator compiled in 0.04 seconds
+2025-07-22 15:42:53,212 - INFO - Status: Warming Up Jit
+2025-07-22 15:42:55,355 - INFO - JIT warmed up in 2.14 seconds
+2025-07-22 15:42:55,723 - INFO - === SIMULATION COMPLETE ===
+2025-07-22 15:42:55,723 - INFO - Total steps: 756
+2025-07-22 15:42:55,723 - INFO - Runtime: 2.55s
+2025-07-22 15:42:55,723 - INFO - Final position: (38516.48, 16461.79)
+2025-07-22 15:42:56,007 - INFO - Creating visualization with 757 trajectory points
+2025-07-22 15:42:57,617 - INFO - Status: Visualization Complete
+2025-07-22 15:42:57,617 - INFO -   output_plot_path: ./results/trajectory_plot.png

--- a/src/sedtrails/exceptions/exceptions.py
+++ b/src/sedtrails/exceptions/exceptions.py
@@ -13,6 +13,8 @@ class SedtrailsException(Exception):
     pass
 
 
+# === YAML/Configuration Exceptions ===
+
 class YamlParsingError(SedtrailsException):
     """
     Exception raised when there is an error parsing a YAML file.
@@ -37,6 +39,15 @@ class YamlOutputError(SedtrailsException):
     pass
 
 
+class ConfigurationError(SedtrailsException):
+    """
+    Exception raised when configuration is invalid or cannot be loaded.
+    """
+    pass
+
+
+# === Time/Date Exceptions ===
+
 class DateFormatError(ValueError):
     """
     Exception raised when the date string does not match the required
@@ -60,4 +71,47 @@ class DurationFormatError(ValueError):
     Exception raised when the duration string does not match the required format '3D 2H1M3S'.
     """
 
+    pass
+
+# === Simulation Exceptions ===
+
+class DataConversionError(SedtrailsException):
+    """
+    Exception raised when data conversion or processing fails.
+    """
+    pass
+
+
+class ParticleInitializationError(SedtrailsException):
+    """
+    Exception raised when particle initialization fails.
+    """
+    pass
+
+
+class NumbaCompilationError(SedtrailsException):
+    """
+    Exception raised when Numba JIT compilation fails.
+    """
+    pass
+
+
+class SimulationExecutionError(SedtrailsException):
+    """
+    Exception raised during simulation loop execution.
+    """
+    pass
+
+
+class VisualizationError(SedtrailsException):
+    """
+    Exception raised when visualization generation fails (typically non-critical).
+    """
+    pass
+
+
+class OutputError(SedtrailsException):
+    """
+    Exception raised when output file generation fails.
+    """
     pass

--- a/src/sedtrails/logger/logger.py
+++ b/src/sedtrails/logger/logger.py
@@ -8,24 +8,54 @@ import logging
 import os
 import datetime
 
-# Create logs directory if not exists
-LOG_DIR = "logs"
-os.makedirs(LOG_DIR, exist_ok=True)
+class LoggerManager:
+    def __init__(self):
+        self.logger = None
+        self.log_dir = "logs"
+    
+    def setup_logger(self):
+        """Set up the logger with timestamped file."""
+        if self.logger is not None:
+            return self.logger
+            
+        # Create logs directory if not exists
+        os.makedirs(self.log_dir, exist_ok=True)
+        
+        # Generate log filename based on timestamp
+        log_filename = os.path.join(self.log_dir, f"simulation_{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}.log")
+        
+        # Create logger directly (avoid basicConfig)
+        self.logger = logging.getLogger("simulation_logger")
+        
+        # Only configure if not already configured
+        if not self.logger.handlers:
+            # Set logging level
+            self.logger.setLevel(logging.DEBUG)
+            
+            # Create formatter
+            formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+            
+            # Create file handler
+            file_handler = logging.FileHandler(log_filename)
+            file_handler.setLevel(logging.DEBUG)
+            file_handler.setFormatter(formatter)
+            
+            # Create console handler
+            console_handler = logging.StreamHandler()
+            console_handler.setLevel(logging.INFO)
+            console_handler.setFormatter(formatter)
+            
+            # Add handlers to logger
+            self.logger.addHandler(file_handler)
+            self.logger.addHandler(console_handler)
+            
+            # Prevent propagation to root logger
+            self.logger.propagate = False
+        
+        return self.logger
 
-# Generate log filename based on timestamp
-log_filename = os.path.join(LOG_DIR, f"simulation_{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}.log")
-
-# Configure logger
-logging.basicConfig(
-    level=logging.DEBUG,
-    format="%(asctime)s - %(levelname)s - %(message)s",
-    handlers=[
-        logging.FileHandler(log_filename),
-        logging.StreamHandler()  # Optional: Print logs to console
-    ]
-)
-
-logger = logging.getLogger("simulation_logger")
+# Module instance
+_logger_manager = LoggerManager()
 
 def log_simulation_state(state: dict, level=logging.INFO) -> None:
     """
@@ -34,9 +64,11 @@ def log_simulation_state(state: dict, level=logging.INFO) -> None:
     :param state: Dictionary containing relevant simulation data.
     :param level: Logging level (e.g., logging.INFO, logging.DEBUG)
     """
+    logger = _logger_manager.setup_logger()    
     message = ", ".join(f"{key}={value}" for key, value in state.items())
     logger.log(level, f"Simulation State: {message}")
 
 def log_exception(e: Exception) -> None:
     """Logs exceptions with stack trace."""
+    logger = _logger_manager.setup_logger()
     logger.error("Simulation encountered an error!", exc_info=True)

--- a/src/sedtrails/logger/logger.py
+++ b/src/sedtrails/logger/logger.py
@@ -57,7 +57,7 @@ class LoggerManager:
             self.logger.info("=== LOGGING INITIALIZED ===")
             self.logger.info(f"Log file: {os.path.basename(absolute_path)}")
             self.logger.info(f"Location: {os.path.dirname(absolute_path)}")
-            
+
         return self.logger
 
 # Module instance
@@ -228,7 +228,26 @@ def log_simulation_state(state: dict, level=logging.INFO) -> None:
             param_str = ', '.join(f"{k}: {v}" for k, v in params.items())
             logger.log(level, f"  {param_str}")
 
-def log_exception(e: Exception) -> None:
-    """Logs exceptions with stack trace."""
+def log_exception(e: Exception, context: str = None) -> None:
+    """
+    Logs exceptions with stack trace and context information.
+    
+    Parameters
+    ----------
+    e : Exception
+        The exception that occurred
+    context : str, optional
+        Additional context about where/when the exception occurred
+    """
     logger = _logger_manager.setup_logger()
-    logger.error("Simulation encountered an error!", exc_info=True)
+    
+    # Log exception with context
+    if context:
+        logger.error(f"=== ERROR: {context} ===")
+    else:
+        logger.error("=== SIMULATION ERROR ===")
+    
+    logger.error(f"Exception type: {type(e).__name__}")
+    logger.error(f"Exception message: {str(e)}")
+    logger.error("Stack trace:", exc_info=True)
+    logger.error("=" * 50)

--- a/src/sedtrails/logger/logger.py
+++ b/src/sedtrails/logger/logger.py
@@ -213,6 +213,15 @@ def log_simulation_state(state: dict, level=logging.INFO) -> None:
     elif status == 'creating_visualization':
         points = state.get('trajectory_points', 'unknown')
         logger.log(level, f"Creating visualization with {points} trajectory points")
+
+    elif status == 'simulation_failed':
+        error_type = state.get('error_type', 'unknown')
+        error_message = state.get('error_message', 'unknown')
+        
+        logger.log(level, "=== SIMULATION FAILED ===")
+        logger.log(level, f"Error type: {error_type}")
+        logger.log(level, f"Error message: {error_message}")
+        logger.log(level, "Check log above for full stack trace")
         
     else:
         # Fallback for unmapped states

--- a/src/sedtrails/logger/logger.py
+++ b/src/sedtrails/logger/logger.py
@@ -59,14 +59,50 @@ _logger_manager = LoggerManager()
 
 def log_simulation_state(state: dict, level=logging.INFO) -> None:
     """
-    Logs the current state of the simulation.
-    
-    :param state: Dictionary containing relevant simulation data.
-    :param level: Logging level (e.g., logging.INFO, logging.DEBUG)
+    Logs the current state of the simulation with human-readable sentences.
     """
-    logger = _logger_manager.setup_logger()    
-    message = ", ".join(f"{key}={value}" for key, value in state.items())
-    logger.log(level, f"Simulation State: {message}")
+    logger = _logger_manager.setup_logger()
+    
+    status = state.get('status', state.get('state', 'unknown'))
+    
+    # Create full sentence messages
+    if status == 'particles_created' or status == 'particles_initialized':
+        count = state.get('count', 1)
+        position = state.get('start_position', state.get('position', 'unknown'))
+        message = f"Created {count} particle(s) starting at position {position}"
+        
+    elif status == 'compilation_complete':
+        time_sec = state.get('time_sec', 'unknown')
+        message = f"Particle calculator compiled successfully in {time_sec} seconds"
+        
+    elif status == 'warmup_complete':
+        time_sec = state.get('time_sec', 'unknown')
+        message = f"JIT compiler warmed up in {time_sec} seconds"
+        
+    elif status == 'simulation_progress':
+        progress = state.get('progress_pct', 0)
+        step = state.get('step', 0)
+        position = state.get('position', 'unknown')
+        message = f"Simulation {progress}% complete (step {step}) - particle at {position}"
+        
+    elif status == 'simulation_complete' or status == 'simulation_completed':
+        steps = state.get('total_steps', 'unknown')
+        time_sec = state.get('total_time_sec', 'unknown')
+        final_pos = state.get('final_position', 'unknown')
+        message = f"Simulation completed! {steps} steps in {time_sec}s, final position: {final_pos}"
+        
+    elif status == 'visualization_saved':
+        filename = state.get('file', 'trajectory plot')
+        message = f"Trajectory visualization saved as {filename}"
+        
+    else:
+        # Fallback for unmapped states
+        message = f"{status.replace('_', ' ').title()}"
+        details = [f"{k}: {v}" for k, v in state.items() if k not in ['status', 'state']]
+        if details:
+            message += f" ({', '.join(details)})"
+    
+    logger.log(level, message)
 
 def log_exception(e: Exception) -> None:
     """Logs exceptions with stack trace."""

--- a/src/sedtrails/logger/logger.py
+++ b/src/sedtrails/logger/logger.py
@@ -21,8 +21,8 @@ class LoggerManager:
         # Create logs directory if not exists
         os.makedirs(self.log_dir, exist_ok=True)
         
-        # Generate log filename based on timestamp
-        log_filename = os.path.join(self.log_dir, f"simulation_{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}.log")
+        # Simple log file name
+        log_filename = os.path.join(self.log_dir, "log.txt")
         
         # Create logger directly (avoid basicConfig)
         self.logger = logging.getLogger("simulation_logger")

--- a/src/sedtrails/logger/logger.py
+++ b/src/sedtrails/logger/logger.py
@@ -66,7 +66,25 @@ def log_simulation_state(state: dict, level=logging.INFO) -> None:
     status = state.get('status', state.get('state', 'unknown'))
     
     # Create full sentence messages
-    if status == 'particles_created' or status == 'particles_initialized':
+    if status == 'simulation_started':
+        command = state.get('command', 'unknown')
+        config = state.get('config_file', 'unknown')
+        python_ver = state.get('python_version', 'unknown')
+        message = f"Starting SedTRAILS simulation with command: '{command}' using Python {python_ver} and config: {config}"
+        
+    elif status == 'config_loading':
+        config_path = state.get('config_file_path', 'unknown')
+        message = f"Loading configuration from: {config_path}"
+        
+    elif status == 'simulation_parameters':
+        duration = state.get('duration', 'unknown')
+        timestep = state.get('timestep', 'unknown')
+        start_time = state.get('start_time', 'unknown')
+        strategy = state.get('seeding_strategy', 'unknown')
+        output_dir = state.get('output_dir', 'unknown')
+        message = f"Simulation parameters: duration={duration}, timestep={timestep}, start_time={start_time}, seeding={strategy}, output={output_dir}"
+        
+    elif status == 'particles_created' or status == 'particles_initialized':
         count = state.get('count', 1)
         position = state.get('start_position', state.get('position', 'unknown'))
         message = f"Created {count} particle(s) starting at position {position}"

--- a/src/sedtrails/logger/logger.py
+++ b/src/sedtrails/logger/logger.py
@@ -54,8 +54,10 @@ class LoggerManager:
 
             # Log the file location immediately
             absolute_path = os.path.abspath(log_filename)
-            self.logger.info(f"Simulation logs are being saved to: {absolute_path}")
-        
+            self.logger.info("=== LOGGING INITIALIZED ===")
+            self.logger.info(f"Log file: {os.path.basename(absolute_path)}")
+            self.logger.info(f"Location: {os.path.dirname(absolute_path)}")
+            
         return self.logger
 
 # Module instance

--- a/src/sedtrails/logger/logger.py
+++ b/src/sedtrails/logger/logger.py
@@ -51,6 +51,10 @@ class LoggerManager:
             
             # Prevent propagation to root logger
             self.logger.propagate = False
+
+            # Log the file location immediately
+            absolute_path = os.path.abspath(log_filename)
+            self.logger.info(f"Simulation logs are being saved to: {absolute_path}")
         
         return self.logger
 

--- a/src/sedtrails/simulation.py
+++ b/src/sedtrails/simulation.py
@@ -11,7 +11,7 @@ from sedtrails.particle_tracer.position_calculator_numba import create_numba_par
 from sedtrails.configuration_interface.configuration_controller import ConfigurationController
 from sedtrails.data_manager import DataManager
 from sedtrails.particle_tracer.timer import Time, Duration, Timer
-from sedtrails.logger.logger import log_simulation_state
+from sedtrails.logger.logger import log_simulation_state, _logger_manager
 from typing import Any
 
 
@@ -37,6 +37,9 @@ class Simulation:
         self.format_converter = FormatConverter(self._get_format_config())
         self.physics_converter = PhysicsConverter(self._get_physics_config())
         self.data_manager = DataManager(self._get_output_dir())
+
+        # Initialize logger with correct output directory
+        _logger_manager.log_dir = self.data_manager.output_dir
 
         # set mesh
         self.data_manager.set_mesh()

--- a/src/sedtrails/simulation.py
+++ b/src/sedtrails/simulation.py
@@ -1,4 +1,6 @@
 import time
+import os
+import sys
 import numpy as np
 
 from sedtrails.transport_converter.format_converter import FormatConverter, SedtrailsData
@@ -158,6 +160,15 @@ class Simulation:
         """
 
         from tqdm import tqdm
+
+        # Log the command that started the simulation
+        log_simulation_state({
+            "status": "simulation_started",
+            "command": " ".join(sys.argv),
+            "config_file": self._config_file,
+            "working_directory": os.getcwd(),
+            "python_version": sys.version.split()[0]
+        })
 
         if not self._config_is_read:  # assure config is read only once
             log_simulation_state({

--- a/src/sedtrails/simulation.py
+++ b/src/sedtrails/simulation.py
@@ -131,7 +131,7 @@ class Simulation:
         Parameters
         ----------
         key : str
-            The dot-separted key to retrieve.
+            The dot-separated key to retrieve.
 
         Returns
         -------

--- a/src/sedtrails/simulation.py
+++ b/src/sedtrails/simulation.py
@@ -11,7 +11,7 @@ from sedtrails.particle_tracer.position_calculator_numba import create_numba_par
 from sedtrails.configuration_interface.configuration_controller import ConfigurationController
 from sedtrails.data_manager import DataManager
 from sedtrails.particle_tracer.timer import Time, Duration, Timer
-from sedtrails.logger.logger import log_simulation_state, log_exception
+from sedtrails.logger.logger import log_simulation_state
 from typing import Any
 
 


### PR DESCRIPTION
Implemented a logging system for simulations, replacing the print statements in `simulation.py`. We now have human-readable logs that provide insight into the simulation parameters, command used to run it, simulation status and performance (time).

Closes #233 

## Relevant files
- `src/sedtrails/logger/logger.py`
    - We now create a single log file per simulation run with timestamp: logs/simulation_YYYYMMDD_HHMMSS.log
    - Human readable messages in the log files
    - Automatic log directory is created (if it doesn't exist)
    - Prevents duplicate log files 

- `src/sedtrails/simulation.py`
    - Loging startup, configuration, data processing, particles, progress, and simulation output


## Example log file generated
```bash
2025-07-22 14:07:56,468 - INFO - Simulation logs are being saved to: /home/aurhan/Work/Projects/SedTRAILS/sedtrails/logs/simulation_20250722_140756.log
2025-07-22 14:07:56,468 - INFO - Starting SedTRAILS simulation with command: 'src/sedtrails/simulation.py' using Python 3.13.2 and config: examples/config.example.yaml
2025-07-22 14:07:56,468 - INFO - Loading configuration from: examples/config.example.yaml
2025-07-22 14:07:57,200 - INFO - Data Conversion Completed (num_timesteps: 290, flow_field_name: suspended_velocity, start_time: 2016-09-21 19:30:00, simulation_duration_seconds: 22698, simulation_timestep_seconds: 30)
2025-07-22 14:07:57,201 - INFO - Created 1 particle(s) starting at position unknown
2025-07-22 14:07:57,202 - INFO - Numba Compilation Started (grid_size_x: 3213, grid_size_y: 3213)
2025-07-22 14:07:57,261 - INFO - Particle calculator compiled successfully in 0.06 seconds
2025-07-22 14:07:57,262 - INFO - Warming Up Jit
2025-07-22 14:07:59,281 - INFO - JIT compiler warmed up in 2.02 seconds
2025-07-22 14:07:59,634 - INFO - Simulation completed! 756 steps in 2.43s, final position: (38516.48, 16461.79)
2025-07-22 14:07:59,910 - INFO - Creating Visualization (trajectory_points: 757)
2025-07-22 14:08:01,277 - INFO - Visualization Complete (output_plot_path: ./results/trajectory_plot.png)
```