### PR TITLE
Implement integrations test for physics plugins

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -43,7 +43,7 @@ jobs:
         pytest tests/ -v --tb=short -m "not integration"
 
   integration:
-    name: Integration Tests
+    name: Run Integration Tests
     runs-on: ubuntu-latest
     needs: unit
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -10,7 +10,8 @@ on:
       - dev
 
 jobs:
-  test:
+  unit:
+    name: Run Unit Tests
     runs-on: ubuntu-latest
     
     steps:
@@ -39,5 +40,36 @@ jobs:
         
     - name: Run pytest
       run: |
-        pytest tests/ -v --tb=short
+        pytest tests/ -v --tb=short -m "not integration"
 
+  integration:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    needs: unit
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.13"
+
+    - name: Cache pip dependencies
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-python3.13-pip-${{ hashFiles('pyproject.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-python3.13-pip-
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e ".[dev]"
+        pip list | grep typer
+
+    - name: Run integration tests only
+      run: |
+        pytest tests/ -v --tb=short -m integration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,3 +70,6 @@ sedtrails = "sedtrails.configuration_interface.cli:app"
 [tool.pytest.ini_options]
 pythonpath = "src"
 addopts = ["--import-mode=importlib"]
+markers = [
+    "integration: mark a test as an integration test."
+]

--- a/tests/transport_converter/plugins/test_physics_plugin.py
+++ b/tests/transport_converter/plugins/test_physics_plugin.py
@@ -60,4 +60,22 @@ def test_plugin_add_physics_callable(plugin_class):
     method = getattr(plugin_class, "add_physics", None)
     assert callable(method), (
         f"{plugin_class.__name__}.add_physics is not callable"
-    )    
+    )
+
+@pytest.mark.integration
+@pytest.mark.parametrize("plugin_class", get_plugin_classes())
+def test_plugin_add_physics_accepts_sedtrails_data(plugin_class):
+    """
+    Integration test to ensure each plugin's add_physics method accepts sedtrails_data as parameter.
+    """
+    method = getattr(plugin_class, "add_physics", None)
+    assert method is not None, f"{plugin_class.__name__} does not have an add_physics method"
+    
+    sig = inspect.signature(method)
+    param_names = list(sig.parameters.keys())
+    
+    # Should we check the position of the sedtrails_data as well?
+    assert "sedtrails_data" in param_names, (
+        f"{plugin_class.__name__}.add_physics should have 'sedtrails_data' parameter. "
+        f"Found parameters: {param_names}"
+    )

--- a/tests/transport_converter/plugins/test_physics_plugin.py
+++ b/tests/transport_converter/plugins/test_physics_plugin.py
@@ -72,10 +72,12 @@ def test_plugin_add_physics_accepts_sedtrails_data(plugin_class):
     assert method is not None, f"{plugin_class.__name__} does not have an add_physics method"
     
     sig = inspect.signature(method)
-    param_names = list(sig.parameters.keys())
+    params = list(sig.parameters.values())
     
-    # Should we check the position of the sedtrails_data as well?
-    assert "sedtrails_data" in param_names, (
-        f"{plugin_class.__name__}.add_physics should have 'sedtrails_data' parameter. "
-        f"Found parameters: {param_names}"
+    # The first parameter should be 'self', the second should be 'sedtrails_data'
+    assert len(params) >= 2, (
+        f"{plugin_class.__name__}.add_physics should accept at least 'self' and 'sedtrails_data' as arguments"
+    )
+    assert params[1].name == "sedtrails_data", (
+        f"{plugin_class.__name__}.add_physics: second parameter should be 'sedtrails_data', got '{params[1].name}'"
     )

--- a/tests/transport_converter/plugins/test_physics_plugin.py
+++ b/tests/transport_converter/plugins/test_physics_plugin.py
@@ -37,8 +37,15 @@ def test_plugin_inherits_base(plugin_class):
     """
     Integration test to ensure each plugin inherits from BasePhysicsPlugin.
     """
+    plugin_module = plugin_class.__module__
+    if hasattr(plugin_module, '__file__') and plugin_module.__file__:
+        plugin_file = os.path.basename(plugin_module.__file__)
+    else:
+        # Try to extract from module name
+        module_parts = plugin_module.split('.')
+        plugin_file = f"{module_parts[-1]}.py" if module_parts else "unknown"
     assert issubclass(plugin_class, BasePhysicsPlugin), (
-        f"{plugin_class.__name__} does not inherit from BasePhysicsPlugin"
+        f"{plugin_file} does not inherit from BasePhysicsPlugin"
     )
 
 @pytest.mark.integration
@@ -47,8 +54,15 @@ def test_plugin_has_add_physics(plugin_class):
     """
     Integration test to ensure each plugin has an add_physics method.
     """
+    plugin_module = plugin_class.__module__
+    if hasattr(plugin_module, '__file__') and plugin_module.__file__:
+        plugin_file = os.path.basename(plugin_module.__file__)
+    else:
+        # Try to extract from module name
+        module_parts = plugin_module.split('.')
+        plugin_file = f"{module_parts[-1]}.py" if module_parts else "unknown"
     assert hasattr(plugin_class, "add_physics"), (
-        f"{plugin_class.__name__} does not have an add_physics method"
+        f"{plugin_file} does not have an add_physics method"
     )
 
 @pytest.mark.integration
@@ -57,9 +71,16 @@ def test_plugin_add_physics_callable(plugin_class):
     """
     Integration test to ensure each plugin's add_physics method is callable.
     """
+    plugin_module = plugin_class.__module__
+    if hasattr(plugin_module, '__file__') and plugin_module.__file__:
+        plugin_file = os.path.basename(plugin_module.__file__)
+    else:
+        # Try to extract from module name
+        module_parts = plugin_module.split('.')
+        plugin_file = f"{module_parts[-1]}.py" if module_parts else "unknown"
     method = getattr(plugin_class, "add_physics", None)
     assert callable(method), (
-        f"{plugin_class.__name__}.add_physics is not callable"
+        f"add_physics method in {plugin_file} is not callable"
     )
 
 @pytest.mark.integration
@@ -68,16 +89,24 @@ def test_plugin_add_physics_accepts_sedtrails_data(plugin_class):
     """
     Integration test to ensure each plugin's add_physics method accepts sedtrails_data as parameter.
     """
+    plugin_module = plugin_class.__module__
+    if hasattr(plugin_module, '__file__') and plugin_module.__file__:
+        plugin_file = os.path.basename(plugin_module.__file__)
+    else:
+        # Try to extract from module name
+        module_parts = plugin_module.split('.')
+        plugin_file = f"{module_parts[-1]}.py" if module_parts else "unknown"
+    
     method = getattr(plugin_class, "add_physics", None)
-    assert method is not None, f"{plugin_class.__name__} does not have an add_physics method"
+    assert method is not None, f"{plugin_file} does not have an add_physics method"
     
     sig = inspect.signature(method)
     params = list(sig.parameters.values())
     
     # The first parameter should be 'self', the second should be 'sedtrails_data'
     assert len(params) >= 2, (
-        f"{plugin_class.__name__}.add_physics should accept at least 'self' and 'sedtrails_data' as arguments"
+        f"add_physics method in {plugin_file} should accept at least 'self' and 'sedtrails_data' as arguments"
     )
     assert params[1].name == "sedtrails_data", (
-        f"{plugin_class.__name__}.add_physics: second parameter should be 'sedtrails_data', got '{params[1].name}'"
+        f"add_physics method in {plugin_file} should take `sedtrails_data` as second parameter, got '{params[1].name}'"
     )

--- a/tests/transport_converter/plugins/test_physics_plugin.py
+++ b/tests/transport_converter/plugins/test_physics_plugin.py
@@ -32,16 +32,32 @@ def get_plugin_classes():
     return plugin_classes
 
 @pytest.mark.integration
-def test_all_plugins_inherit_base_and_implement_add_physics():
+@pytest.mark.parametrize("plugin_class", get_plugin_classes())
+def test_plugin_inherits_base(plugin_class):
     """
-    Integration test to ensure all plugins in the physics plugin directory:
-    - Inherit from BasePhysicsPlugin
-    - Implement a callable add_physics method
-    """    
-    plugin_classes = get_plugin_classes()
-    assert plugin_classes, "No plugin classes found in the plugins directory."
-    for cls in plugin_classes:
-        assert issubclass(cls, BasePhysicsPlugin), f"{cls.__name__} does not inherit from BasePhysicsPlugin"
-        assert hasattr(cls, "add_physics"), f"{cls.__name__} does not have an add_physics method"
-        method = cls.add_physics
-        assert callable(method), f"{cls.__name__}.add_physics is not callable"
+    Integration test to ensure each plugin inherits from BasePhysicsPlugin.
+    """
+    assert issubclass(plugin_class, BasePhysicsPlugin), (
+        f"{plugin_class.__name__} does not inherit from BasePhysicsPlugin"
+    )
+
+@pytest.mark.integration
+@pytest.mark.parametrize("plugin_class", get_plugin_classes())
+def test_plugin_has_add_physics(plugin_class):
+    """
+    Integration test to ensure each plugin has an add_physics method.
+    """
+    assert hasattr(plugin_class, "add_physics"), (
+        f"{plugin_class.__name__} does not have an add_physics method"
+    )
+
+@pytest.mark.integration
+@pytest.mark.parametrize("plugin_class", get_plugin_classes())
+def test_plugin_add_physics_callable(plugin_class):
+    """
+    Integration test to ensure each plugin's add_physics method is callable.
+    """
+    method = getattr(plugin_class, "add_physics", None)
+    assert callable(method), (
+        f"{plugin_class.__name__}.add_physics is not callable"
+    )    

--- a/tests/transport_converter/plugins/test_physics_plugin.py
+++ b/tests/transport_converter/plugins/test_physics_plugin.py
@@ -1,0 +1,47 @@
+import os
+import importlib.util
+import inspect
+import pytest
+from sedtrails.transport_converter.plugins.physics.plugin import BasePhysicsPlugin
+
+# TODO: Is there a better way to get the plugin directory?
+PLUGIN_DIR = os.path.dirname(__file__).replace(
+    'tests/transport_converter/plugins', 'src/sedtrails/transport_converter/plugins/physics'
+    )
+
+def get_plugin_classes():
+    """
+    Dynamically discovers and imports all plugin classes in the physics plugin directory,
+    excluding the base plugin and dunder files.
+
+    Returns:
+        list: List of plugin classes found in the directory.
+    """    
+    plugin_classes = []
+    for fname in os.listdir(PLUGIN_DIR):
+        if fname.endswith('.py') and fname != 'plugin.py' and not fname.startswith('__'):
+            module_path = os.path.join(PLUGIN_DIR, fname)
+            module_name = f"sedtrails.transport_converter.plugins.physics.{fname[:-3]}"
+            spec = importlib.util.spec_from_file_location(module_name, module_path)
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            for _, obj in inspect.getmembers(module, inspect.isclass):
+                # Only consider classes defined in this module (not imported ones)
+                if obj.__module__ == module_name:
+                    plugin_classes.append(obj)
+    return plugin_classes
+
+@pytest.mark.integration
+def test_all_plugins_inherit_base_and_implement_add_physics():
+    """
+    Integration test to ensure all plugins in the physics plugin directory:
+    - Inherit from BasePhysicsPlugin
+    - Implement a callable add_physics method
+    """    
+    plugin_classes = get_plugin_classes()
+    assert plugin_classes, "No plugin classes found in the plugins directory."
+    for cls in plugin_classes:
+        assert issubclass(cls, BasePhysicsPlugin), f"{cls.__name__} does not inherit from BasePhysicsPlugin"
+        assert hasattr(cls, "add_physics"), f"{cls.__name__} does not have an add_physics method"
+        method = cls.add_physics
+        assert callable(method), f"{cls.__name__}.add_physics is not callable"


### PR DESCRIPTION
Implemented integration tests for the physics plugin system in `src/sedtrails/transport_converter/plugins/physics/`  to ensure new plugins are compliant with the existing structure.

Closes #253 

### Relevant files:
- `tests/transport_converter/plugins/test_physics_plugin.py`:
    - Each plugin inherits from the BasePhysicsPlugin class.
    - Each plugin has an `add_physics` method.
    - Each plugin's `add_physics` method is callable.
    - Each plugin has `sedtrails_data` as parameter. 

- `pyproject.toml`
    - I added a custom marker (called "integration") to mark these tests, so that we can run them separately from the unit tests using `pytest -m integration`.

- `.github/workflows/pytest.yml`
   - Split the pytest action into 2 jobs: unit test and integration test
   - Integration job needs the unit job to run first


