### PR TITLE
Particle seeding

### DIFF
--- a/src/sedtrails/config/population.schema.json
+++ b/src/sedtrails/config/population.schema.json
@@ -279,18 +279,17 @@
                                     "type": "string",
                                     "description": "path to Deltares '.pol; file with list of transects (line segments) to release particles from"
                                 },
-                                "lines": {
+                                "segments": {
                                     "type": "array",
                                     "items": {
                                         "type": "string"
                                     },
-                                    "default": [],
-                                    "description": "the enpoints (X,Y coordinates) of a list of line segments to where particles will be released, e.g., '1000,2000 3000,4000'"
+                                    "description": "a list of line segments along which particles are released, e.g., '1000,2000 3000,4000'"
                                 },
                                 "k": {
                                     "type": "number",
                                     "default": 100.0,
-                                    "description": "number of release points to create per transect"
+                                    "description": "number of release points to create per segment"
                                 },
                                 "show_check_plots": {
                                     "type": "boolean",
@@ -311,7 +310,43 @@
                                 },
                                 {
                                     "required": [
-                                        "lines"
+                                        "segments"
+                                    ]
+                                }
+                            ]
+                        },
+                        "random": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "pol_file": {
+                                    "type": "string",
+                                    "description": "path to Deltares '.pol' file with bounding polygon for random point generation"
+                                },
+                                "bbox": {
+                                    "type": "string",
+                                    "description": "bounding box for random point generation, as 'xmin,ymin xmax,ymax'"
+                                },
+                                "show_check_plots": {
+                                    "type": "boolean",
+                                    "default": false,
+                                    "description": "Do you want to show cluster check plots?"
+                                },
+                                "save_check_plots": {
+                                    "type": "boolean",
+                                    "default": false,
+                                    "description": "Do you want to save cluster check plots?"
+                                }
+                            },
+                            "oneOf": [
+                                {
+                                    "required": [
+                                        "bbox"
+                                    ]
+                                },
+                                {
+                                    "required": [
+                                        "pol_file"
                                     ]
                                 }
                             ]
@@ -323,7 +358,7 @@
                                     "type": "string",
                                     "description": "path to Deltares '.pol' file with bounding polygon for cluster analysis"
                                 },
-                                "regular": {
+                                "separation": {
                                     "type": "object",
                                     "properties": {
                                         "dx": {
@@ -356,7 +391,19 @@
                                     "type": "boolean",
                                     "default": false,
                                     "description": "Do you want to save cluster check plots?"
-                                }
+                                },
+                                "oneOf": [
+                                    {
+                                        "required": [
+                                            "pol_file"
+                                        ]
+                                    },
+                                    {
+                                        "required": [
+                                            "separation"
+                                        ]
+                                    }
+                                ]
                             }
                         }
                     },

--- a/src/sedtrails/config/population.schema.json
+++ b/src/sedtrails/config/population.schema.json
@@ -327,6 +327,11 @@
                                     "type": "string",
                                     "description": "bounding box for random point generation, as 'xmin,ymin xmax,ymax'"
                                 },
+                                "seed": {
+                                    "type": "number",
+                                    "default": 1,
+                                    "description": "seed for random number generator"
+                                },
                                 "show_check_plots": {
                                     "type": "boolean",
                                     "default": false,

--- a/src/sedtrails/config/population.schema.json
+++ b/src/sedtrails/config/population.schema.json
@@ -238,7 +238,7 @@
                             "properties": {
                                 "pol_file": {
                                     "type": "string",
-                                    "description": "path to Deltares '.pol; file with list of transects and points to release particles from"
+                                    "description": "path to Deltares '.pol; file with list of points to release particles from"
                                 },
                                 "locations": {
                                     "type": "array",

--- a/src/sedtrails/configuration_interface/configuration_controller.py
+++ b/src/sedtrails/configuration_interface/configuration_controller.py
@@ -8,6 +8,7 @@ and provides configurations to other components.
 
 from abc import ABC, abstractmethod
 from sedtrails.configuration_interface.validator import YAMLConfigValidator
+from sedtrails.configuration_interface.find import find_value
 from typing import Dict, Any
 
 
@@ -140,8 +141,4 @@ class ConfigurationController(Controller):
 
         config_data = deepcopy(self.get_config())
 
-        for key in keys.split('.'):
-            config_data = config_data.get(key, default)
-            if not isinstance(config_data, dict):
-                return config_data
-        return config_data
+        return find_value(config_data, keys, default)

--- a/src/sedtrails/configuration_interface/find.py
+++ b/src/sedtrails/configuration_interface/find.py
@@ -1,0 +1,48 @@
+"""
+A convenience function to find a value in the configuration data using a dot-separated key.
+"""
+
+from typing import Any, Dict, Union
+
+
+def find_value(data: Dict, keys: str, default=None) -> Any:
+    """
+    Retrieves a value from a dictionary using a dot-separated notation for nested dictionaries.
+
+    Parameters
+    ----------
+    data : Dict
+        The dictionary to search in.
+    key : str
+        The dot-separated key to retrieve from the configuration.
+    default : any, optional
+        The default value to return if the key is not found.
+
+    Returns
+    -------
+    any
+        The value associated with the key or the default value. None if the key is not found.
+
+    Example
+    --------
+    >>> config = {
+            'population': {
+                'seeding': {
+                    'strategy': {'point': {'locations': ['1.0,2.0', '3.0,4.0']}},
+                    'quantity': 10,
+                }
+            }
+        }
+    >>> point = find('population.seeding.strategy.point')
+    >>> print(point))  # Outputs `{'locations': ['1.0,2.0', '3.0,4.0']}`
+
+    """
+
+    current: Union[Dict, Any] = data
+    for key in keys.split('.'):
+        if not isinstance(current, dict):
+            return default
+        current = current.get(key, default)
+        if not isinstance(current, dict):
+            return current
+    return current

--- a/src/sedtrails/exceptions/__init__.py
+++ b/src/sedtrails/exceptions/__init__.py
@@ -5,6 +5,7 @@ from .exceptions import (
     YamlParsingError,
     YamlOutputError,
     YamlValidationError,
+    MissingConfigurationParameter,
 )
 
 __all__ = [
@@ -12,4 +13,5 @@ __all__ = [
     'YamlParsingError',
     'YamlOutputError',
     'YamlValidationError',
+    'MissingConfigurationParameter',
 ]

--- a/src/sedtrails/exceptions/exceptions.py
+++ b/src/sedtrails/exceptions/exceptions.py
@@ -15,6 +15,7 @@ class SedtrailsException(Exception):
 
 # === YAML/Configuration Exceptions ===
 
+
 class YamlParsingError(SedtrailsException):
     """
     Exception raised when there is an error parsing a YAML file.
@@ -43,15 +44,27 @@ class ConfigurationError(SedtrailsException):
     """
     Exception raised when configuration is invalid or cannot be loaded.
     """
+
     pass
 
 
 # === Time/Date Exceptions ===
 
+
 class DateFormatError(ValueError):
     """
     Exception raised when the date string does not match the required
     format 'YYYY-MM-DD 00:00:00'.
+    """
+
+    pass
+
+
+class MissingConfigurationParameter(SedtrailsException):
+    """
+    Exception raised when a required configuration parameter is missing.
+    This can occur if a necessary parameter is not provided in the configuration file,
+    or an operation fails to fetch a required configuration value.
     """
 
     pass
@@ -73,12 +86,15 @@ class DurationFormatError(ValueError):
 
     pass
 
+
 # === Simulation Exceptions ===
+
 
 class DataConversionError(SedtrailsException):
     """
     Exception raised when data conversion or processing fails.
     """
+
     pass
 
 
@@ -86,6 +102,7 @@ class ParticleInitializationError(SedtrailsException):
     """
     Exception raised when particle initialization fails.
     """
+
     pass
 
 
@@ -93,6 +110,7 @@ class NumbaCompilationError(SedtrailsException):
     """
     Exception raised when Numba JIT compilation fails.
     """
+
     pass
 
 
@@ -100,6 +118,7 @@ class SimulationExecutionError(SedtrailsException):
     """
     Exception raised during simulation loop execution.
     """
+
     pass
 
 
@@ -107,6 +126,7 @@ class VisualizationError(SedtrailsException):
     """
     Exception raised when visualization generation fails (typically non-critical).
     """
+
     pass
 
 
@@ -114,4 +134,5 @@ class OutputError(SedtrailsException):
     """
     Exception raised when output file generation fails.
     """
+
     pass

--- a/src/sedtrails/particle_tracer/particle.py
+++ b/src/sedtrails/particle_tracer/particle.py
@@ -40,7 +40,7 @@ class Particle(ABC):
     id: int = field(init=False)  # Unique identifier for the particle
     _x: float = field(init=False)  # initial position
     _y: float = field(init=False)  # initial position
-    _release_time: int | float = field(init=False)  # release time of the particle
+    _release_time: str = field(init=False)  # release time of the particle
     _is_mobile: bool = field(default=True)  # whether the particle is mobile or not
     name: Optional[str] = field(default='')  # name of the particle
     trace: Dict = field(default_factory=dict)  # trace of the particle
@@ -89,19 +89,17 @@ class Particle(ABC):
         self._y = value
 
     @property
-    def release_time(self) -> int | float:
+    def release_time(self) -> str:
         return self._release_time
 
     @release_time.setter
-    def release_time(self, value: int) -> None:
-        if not isinstance(value, int):
-            raise TypeError(f"Expected 'release_time' to be an integer, got {type(value).__name__}")
-        if value < 0:
-            raise ValueError(f"Expected 'release_time' to be a non-negative integer, got {value}")
+    def release_time(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError(f"Expected 'release_time' to be a string, got {type(value).__name__}")
         self._release_time = value
 
     @release_time.getter
-    def release_time(self) -> int | float:
+    def release_time(self) -> str:
         return self._release_time
 
     @property

--- a/src/sedtrails/particle_tracer/particle_seeder.py
+++ b/src/sedtrails/particle_tracer/particle_seeder.py
@@ -4,10 +4,10 @@ Particle Seeding Tool
 Manage the creation of particles, their positions (x,y) and distribution.
 using various release strategies.
 Seeding strategies for positions include:
-- At location: Release particles at a specific locations (x,y).
-- Regular grid: Release particles in a regular grid pattern based
+- Point: Release particles at a specific locations (x,y).
+- Regular Grid: Release particles in a regular grid pattern based
     on distances between particles in x and y directions, and the
-    simulation domain size. A mask can be applied to restrict the area of seeding.
+    simulation. A mask can be applied to restrict the area of seeding.
 - Transect: release particle along line segments  defined by two points(x1,y1) and (x2,y2).
 - Random: Release particles at random locations (x,y) within an area
     constrained by a bounding box (xmin, xmax, ymin, ymax).
@@ -16,7 +16,7 @@ Seeding strategies for positions include:
 from abc import ABC, abstractmethod
 from sedtrails.particle_tracer.particle import Particle
 from sedtrails.exceptions import MissingConfigurationParameter
-from typing import List, Tuple, Optional, Dict
+from typing import List, Tuple, Dict
 import random
 from dataclasses import dataclass, field
 from sedtrails.configuration_interface.find import find_value
@@ -123,7 +123,8 @@ class PointStrategy(SeedingStrategy):
 
 class RandomStrategy(SeedingStrategy):
     """
-    Seeding strategy to release particles at at random locations (x,y) within an area constraint by a bounding box 'xmin,ymin xmax,ymax'.
+    Seeding strategy to release particles at at random locations (x,y) within an area constraint by a
+    bounding box 'xmin,ymin xmax,ymax'.
     """
 
     def seed(self, config: SeedingConfig) -> list[Tuple[int, float, float]]:
@@ -145,7 +146,9 @@ class RandomStrategy(SeedingStrategy):
 
 class GridStrategy(SeedingStrategy):
     """
-    Seeding strategy to release particles that follows regular grid pattern. The grid is defined by the distance between particles (dx, dy) and the simulation domain size. If dx and dy have the same value, a square grid is created.
+    Seeding strategy to release particles that follows regular grid pattern.
+    The grid is defined by the distance between particles (dx, dy) and the simulation domain size.
+    If dx and dy have the same value, a square grid is created.
     The origin of the grid is at the bottom left corner of the bounding box
     """
 
@@ -192,7 +195,8 @@ class TransectStrategy(SeedingStrategy):
     """
     Seeding strategy to release particles along straight line segments.
     A line segment is defined by two points (x1, y1) and (x2, y2).
-    Particles along each segment are equally spaced, and the distance between particles is defined by the number of release locations per segment (k).
+    Particles along each segment are equally spaced, and the distance between particles is defined by
+    the number of release locations per segment (k).
     """
 
     def seed(self, config: SeedingConfig) -> list[Tuple[int, float, float]]:
@@ -311,12 +315,4 @@ if __name__ == '__main__':
     )
 
     particles = ParticleFactory.create_particles(config_point)
-    print(
-        'Created particles:', particles[-5:]
-    )  # Should print the created particles with their positions and release times
-
-    # # Measure memory size of particles
-    # import sys
-
-    # total_memory = sum(sys.getsizeof(particle) for particle in particles)
-    # print(f'Total memory size of {len(particles)} particles: {total_memory} bytes ({total_memory / 1024:.2f} KB)')
+    print('Created particles:', particles)  # Should print the created particles with their positions and release times

--- a/src/sedtrails/particle_tracer/particle_seeder.py
+++ b/src/sedtrails/particle_tracer/particle_seeder.py
@@ -128,9 +128,16 @@ class RandomStrategy(SeedingStrategy):
     """
 
     def seed(self, config: SeedingConfig) -> list[Tuple[int, float, float]]:
-        bbox = getattr(config, 'strategy_settings', {}).get('bbox', [])
+        # expects strategy_settings to contain 'bbox' and 'seed'
+        bbox = getattr(config, 'strategy_settings', {}).get('bbox', None)
         if not bbox:
             raise MissingConfigurationParameter('"bbox" must be provided for RandomStrategy.')
+
+        seed = getattr(config, 'strategy_settings', {}).get('seed', None)
+        if not seed:
+            raise MissingConfigurationParameter('"seed" must be provided for RandomStrategy.')
+        random.seed(seed)
+
         if config.quantity is None:
             raise MissingConfigurationParameter('"quantity" must be an integer for RandomStrategy.')
         quantity = int(config.quantity)
@@ -328,5 +335,18 @@ if __name__ == '__main__':
         }
     )
 
-    particles = ParticleFactory.create_particles(config_transect)
+    config_random = SeedingConfig(
+        {
+            'population': {
+                'particle_type': 'sand',
+                'seeding': {
+                    'strategy': {'random': {'bbox': '1.0,2.0, 3.0,4.0', 'seed': 42}},
+                    'quantity': 5,
+                    'release_start': '2025-06-18 13:00:00',
+                },
+            }
+        }
+    )
+
+    particles = ParticleFactory.create_particles(config_random)
     print('Created particles:', particles)  # Should print the created particles with their positions and release times

--- a/tests/particle_tracer/test_particle_seeder.py
+++ b/tests/particle_tracer/test_particle_seeder.py
@@ -1,70 +1,280 @@
 """
-Unit tests for data classes in the particle.py module of the sedtrails package.
+Unit tests for particle seeding strategies.
 """
 
 import pytest
-from sedtrails.particle_tracer.particle_seeder import PointStrategy, RandomStrategy
+from sedtrails.particle_tracer.particle_seeder import (
+    SeedingConfig,
+    PointStrategy,
+    RandomStrategy,
+    GridStrategy,
+    TransectStrategy,
+)
+from sedtrails.exceptions import MissingConfigurationParameter
 
 
-@pytest.fixture
-def xy_seeder():
-    """
-    Fixture for creating an instance of XYSeeding.
-    """
-    return PointStrategy()
+class TestPointStrategy:
+    """Test cases for PointStrategy."""
+
+    def test_point_strategy(self):
+        """Test basic point strategy functionality."""
+        config = SeedingConfig(
+            {
+                'population': {
+                    'seeding': {
+                        'strategy': {'point': {'locations': ['1.0,2.0', '3.0,4.0']}},
+                        'quantity': 10,
+                    }
+                }
+            }
+        )
+        strategy = PointStrategy()
+        result = strategy.seed(config)
+
+        assert len(result) == 2
+        assert result[0] == (10, 1.0, 2.0)
+        assert result[1] == (10, 3.0, 4.0)
+
+    def test_point_strategy_missing_locations(self):
+        """Test point strategy with missing locations."""
+        config = SeedingConfig(
+            {
+                'population': {
+                    'seeding': {
+                        'strategy': {'point': {}},
+                        'quantity': 10,
+                    }
+                }
+            }
+        )
+        strategy = PointStrategy()
+
+        with pytest.raises(MissingConfigurationParameter, match='"locations" must be provided'):
+            strategy.seed(config)
+
+    def test_point_strategy_invalid_location_format(self):
+        """Test point strategy with invalid location format."""
+        config = SeedingConfig(
+            {
+                'population': {
+                    'seeding': {
+                        'strategy': {'point': {'locations': ['invalid_format']}},
+                        'quantity': 10,
+                    }
+                }
+            }
+        )
+        strategy = PointStrategy()
+
+        with pytest.raises(ValueError, match='Invalid location string'):
+            strategy.seed(config)
 
 
-@pytest.fixture
-def random_seeder():
-    """
-    Fixture for creating an instance of RandomSeeding.
-    """
-    return RandomStrategy()
+class TestRandomStrategy:
+    """Test cases for RandomStrategy."""
+
+    def test_random_strategy(self):
+        """Test basic random strategy functionality."""
+        config = SeedingConfig(
+            {
+                'population': {
+                    'seeding': {
+                        'strategy': {'random': {'bbox': '1.0,2.0, 3.0,4.0'}},
+                        'quantity': 5,
+                    }
+                }
+            }
+        )
+        strategy = RandomStrategy()
+        result = strategy.seed(config)
+
+        assert len(result) == 5
+        # Check all particles have quantity 5 and coordinates within bounds
+        for qty, x, y in result:
+            assert qty == 5
+            assert 1.0 <= x <= 3.0
+            assert 2.0 <= y <= 4.0
+
+    def test_random_strategy_missing_bbox(self):
+        """Test random strategy with missing bounding box."""
+        config = SeedingConfig(
+            {
+                'population': {
+                    'seeding': {
+                        'strategy': {'random': {}},
+                        'quantity': 5,
+                    }
+                }
+            }
+        )
+        strategy = RandomStrategy()
+
+        with pytest.raises(MissingConfigurationParameter, match='"bbox" must be provided'):
+            strategy.seed(config)
 
 
-# class TestXYSeeding:
-#     def test_seed_single_position(self, xy_seeder):
-#         """Test seeding a single particle at a specific position."""
-#         particles = xy_seeder.seed(initial_positions=(1.0, 2.0), release_times=1, count=1)
-#         assert len(particles) == 1
-#         for particle in particles:
-#             assert isinstance(particle, Particle)
-#             assert particle.x == 1.0
-#             assert particle.y == 2.0
+class TestGridStrategy:
+    """Test cases for GridStrategy."""
 
-# def test_seed_multiple_positions(self, xy_seeder):
-#     """Test seeding multiple particles at different positions."""
-#     particles = xy_seeder.seed(initial_positions=[(1.0, 2.0), (3.0, 4.0)], release_times=[1, 2], count=2)
-#     assert len(particles) == 2
-#     for i, particle in enumerate(particles):
-#         assert isinstance(particle, Particle)
-#         assert particle.x == [1.0, 3.0][i]
-#         assert particle.y == [2.0, 4.0][i]
+    def test_grid_strategy(self):
+        """Test basic grid strategy functionality."""
+        config = SeedingConfig(
+            {
+                'population': {
+                    'seeding': {
+                        'strategy': {
+                            'grid': {
+                                'separation': {'dx': 1.0, 'dy': 1.0},
+                            }
+                        },
+                        'quantity': 2,
+                    }
+                }
+            }
+        )
+        strategy = GridStrategy()
+        bbox = {'xmin': 0.0, 'xmax': 2.0, 'ymin': 0.0, 'ymax': 2.0}
+        result = strategy.seed(config, bbox=bbox)
 
-# def test_seed_invalid_count(self, xy_seeder):
-#     """Test seeding with an invalid count."""
+        # Should generate a 3x3 grid (0,1,2 in both directions)
+        assert len(result) == 9
+        # Check first and last points
+        assert (2, 0.0, 0.0) in result
+        assert (2, 2.0, 2.0) in result
 
-#     with pytest.raises(ValueError):
-#         xy_seeder.seed(initial_positions=(1.0, 2.0), release_times=1, count=3)
+    def test_grid_strategy_no_bbox(self):
+        """Test grid strategy without bounding box."""
+        config = SeedingConfig(
+            {
+                'population': {
+                    'seeding': {
+                        'strategy': {
+                            'grid': {
+                                'separation': {'dx': 1.0, 'dy': 1.0},
+                            }
+                        },
+                        'quantity': 2,
+                    }
+                }
+            }
+        )
+        strategy = GridStrategy()
+
+        with pytest.raises(RuntimeError, match='Bounding box must be provided'):
+            strategy.seed(config)
+
+    def test_grid_strategy_missing_separation(self):
+        """Test grid strategy with missing separation parameters."""
+        config = SeedingConfig(
+            {
+                'population': {
+                    'seeding': {
+                        'strategy': {'grid': {}},
+                        'quantity': 2,
+                    }
+                }
+            }
+        )
+        strategy = GridStrategy()
+        bbox = {'xmin': 0.0, 'xmax': 2.0, 'ymin': 0.0, 'ymax': 2.0}
+
+        with pytest.raises(MissingConfigurationParameter, match='"grid" must be provided'):
+            strategy.seed(config, bbox=bbox)
 
 
-# class TestRandomSeeding:
-#     def test_seed_single_positions(self, random_seeder):
-#         """Test seeding random particles."""
-#         """Test seeding a single particle at a specific position."""
-#         particles = random_seeder.seed(x_range=(0, 10), y_range=(0, 100), release_times=1, count=1)
-#         assert len(particles) == 1
-#         for particle in particles:
-#             assert isinstance(particle, Particle)
+class TestTransectStrategy:
+    """Test cases for TransectStrategy."""
 
-#     def test_seed_invalid_count(self, random_seeder):
-#         """Test seeding with an invalid count."""
-#         with pytest.raises(TypeError):
-#             random_seeder.seed(x_range=(0, 10), y_range=(0, 100), release_times=1, count='uno')
+    def test_transect_strategy(self):
+        """Test basic transect strategy functionality."""
+        config = SeedingConfig(
+            {
+                'population': {
+                    'seeding': {
+                        'strategy': {
+                            'transect': {
+                                'segments': ['0,0 2,0'],
+                                'k': 3,
+                            }
+                        },
+                        'quantity': 5,
+                    }
+                }
+            }
+        )
+        strategy = TransectStrategy()
+        result = strategy.seed(config)
 
-#     def test_seed_multiple_positions(self, random_seeder):
-#         """Test seeding multiple particles at different positions."""
-#         particles = random_seeder.seed(x_range=(0, 10), y_range=(0, 100), release_times=[1, 2], count=2)
-#         assert len(particles) == 2
-#         for particle in particles:
-#             assert isinstance(particle, Particle)
+        # Should generate 3 points along the line from (0,0) to (2,0)
+        assert len(result) == 3
+        assert result[0] == (5, 0.0, 0.0)  # Start point
+        assert result[1] == (5, 1.0, 0.0)  # Middle point
+        assert result[2] == (5, 2.0, 0.0)  # End point
+
+    def test_transect_strategy_multiple_segments(self):
+        """Test transect strategy with multiple segments."""
+        config = SeedingConfig(
+            {
+                'population': {
+                    'seeding': {
+                        'strategy': {
+                            'transect': {
+                                'segments': ['0,0 1,0', '1,0 1,1'],
+                                'k': 2,
+                            }
+                        },
+                        'quantity': 1,
+                    }
+                }
+            }
+        )
+        strategy = TransectStrategy()
+        result = strategy.seed(config)
+
+        # Should generate 2 points per segment = 4 total points
+        assert len(result) == 4
+        # First segment: (0,0) to (1,0)
+        assert (1, 0.0, 0.0) in result
+        assert (1, 1.0, 0.0) in result
+        # Second segment: (1,0) to (1,1)
+        assert (1, 1.0, 0.0) in result
+        assert (1, 1.0, 1.0) in result
+
+    def test_transect_strategy_missing_segments(self):
+        """Test transect strategy with missing segments."""
+        config = SeedingConfig(
+            {
+                'population': {
+                    'seeding': {
+                        'strategy': {'transect': {'k': 3}},
+                        'quantity': 5,
+                    }
+                }
+            }
+        )
+        strategy = TransectStrategy()
+
+        with pytest.raises(MissingConfigurationParameter, match='"segments" must be provided'):
+            strategy.seed(config)
+
+    def test_transect_strategy_invalid_segment_format(self):
+        """Test transect strategy with invalid segment format."""
+        config = SeedingConfig(
+            {
+                'population': {
+                    'seeding': {
+                        'strategy': {
+                            'transect': {
+                                'segments': ['invalid_format'],
+                                'k': 2,
+                            }
+                        },
+                        'quantity': 1,
+                    }
+                }
+            }
+        )
+        strategy = TransectStrategy()
+
+        with pytest.raises(ValueError, match='Invalid segment string'):
+            strategy.seed(config)

--- a/tests/particle_tracer/test_particle_seeder.py
+++ b/tests/particle_tracer/test_particle_seeder.py
@@ -91,7 +91,7 @@ def random_config():
             'population': {
                 'particle_type': 'sand',
                 'seeding': {
-                    'strategy': {'random': {'bbox': '1.0,2.0, 3.0,4.0'}},
+                    'strategy': {'random': {'bbox': '1.0,2.0, 3.0,4.0', 'seed': 42}},
                     'quantity': 5,
                     'release_start': '2025-06-18 13:00:00',
                 },

--- a/tests/particle_tracer/test_particle_seeder.py
+++ b/tests/particle_tracer/test_particle_seeder.py
@@ -35,27 +35,18 @@ def transect_strategy():
     return TransectStrategy()
 
 
-# Data fixtures
-@pytest.fixture
-def standard_bbox():
-    return {'xmin': 0.0, 'xmax': 2.0, 'ymin': 0.0, 'ymax': 2.0}
-
-
-@pytest.fixture
-def small_bbox():
-    return {'xmin': 0.0, 'xmax': 1.0, 'ymin': 0.0, 'ymax': 1.0}
-
-
 # Config fixtures
 @pytest.fixture
 def point_config_basic():
     return SeedingConfig(
         {
             'population': {
+                'particle_type': 'sand',
                 'seeding': {
                     'strategy': {'point': {'locations': ['1.0,2.0', '3.0,4.0']}},
                     'quantity': 10,
-                }
+                    'release_start': '2025-06-18 13:00:00',
+                },
             }
         }
     )
@@ -66,10 +57,12 @@ def point_config_simple():
     return SeedingConfig(
         {
             'population': {
+                'particle_type': 'sand',
                 'seeding': {
                     'strategy': {'point': {'locations': ['0,0']}},
                     'quantity': 1,
-                }
+                    'release_start': '2025-06-18 13:00:00',
+                },
             }
         }
     )
@@ -80,10 +73,12 @@ def point_config_dual():
     return SeedingConfig(
         {
             'population': {
+                'particle_type': 'sand',
                 'seeding': {
                     'strategy': {'point': {'locations': ['1.0,2.0', '3.0,4.0']}},
                     'quantity': 2,
-                }
+                    'release_start': '2025-06-18 13:00:00',
+                },
             }
         }
     )
@@ -94,10 +89,12 @@ def random_config():
     return SeedingConfig(
         {
             'population': {
+                'particle_type': 'sand',
                 'seeding': {
                     'strategy': {'random': {'bbox': '1.0,2.0, 3.0,4.0'}},
                     'quantity': 5,
-                }
+                    'release_start': '2025-06-18 13:00:00',
+                },
             }
         }
     )
@@ -108,14 +105,17 @@ def grid_config():
     return SeedingConfig(
         {
             'population': {
+                'particle_type': 'sand',
                 'seeding': {
                     'strategy': {
                         'grid': {
                             'separation': {'dx': 1.0, 'dy': 1.0},
+                            'bbox': {'xmin': 0.0, 'xmax': 2.0, 'ymin': 0.0, 'ymax': 2.0},
                         }
                     },
                     'quantity': 2,
-                }
+                    'release_start': '2025-06-18 13:00:00',
+                },
             }
         }
     )
@@ -126,14 +126,17 @@ def grid_config_single():
     return SeedingConfig(
         {
             'population': {
+                'particle_type': 'mud',
                 'seeding': {
                     'strategy': {
                         'grid': {
                             'separation': {'dx': 1.0, 'dy': 1.0},
+                            'bbox': {'xmin': 0.0, 'xmax': 1.0, 'ymin': 0.0, 'ymax': 1.0},
                         }
                     },
                     'quantity': 1,
-                }
+                    'release_start': '2025-06-18 13:00:00',
+                },
             }
         }
     )
@@ -144,6 +147,7 @@ def transect_config():
     return SeedingConfig(
         {
             'population': {
+                'particle_type': 'sand',
                 'seeding': {
                     'strategy': {
                         'transect': {
@@ -152,7 +156,8 @@ def transect_config():
                         }
                     },
                     'quantity': 5,
-                }
+                    'release_start': '2025-06-18 13:00:00',
+                },
             }
         }
     )
@@ -163,6 +168,7 @@ def transect_config_multi():
     return SeedingConfig(
         {
             'population': {
+                'particle_type': 'sand',
                 'seeding': {
                     'strategy': {
                         'transect': {
@@ -171,7 +177,8 @@ def transect_config_multi():
                         }
                     },
                     'quantity': 1,
-                }
+                    'release_start': '2025-06-18 13:00:00',
+                },
             }
         }
     )
@@ -198,13 +205,17 @@ class TestPointStrategy:
 
     def test_point_strategy_missing_locations(self, point_strategy):
         """Test point strategy with missing locations."""
+        # Since SeedingConfig validates that strategy settings exist,
+        # we need to create a config that passes validation but missing locations
         config = SeedingConfig(
             {
                 'population': {
+                    'particle_type': 'sand',
                     'seeding': {
-                        'strategy': {'point': {}},
+                        'strategy': {'point': {'not_locations': 'invalid'}},
                         'quantity': 10,
-                    }
+                        'release_start': '2025-06-18 13:00:00',
+                    },
                 }
             }
         )
@@ -217,10 +228,12 @@ class TestPointStrategy:
         config = SeedingConfig(
             {
                 'population': {
+                    'particle_type': 'sand',
                     'seeding': {
                         'strategy': {'point': {'locations': ['invalid_format']}},
                         'quantity': 10,
-                    }
+                        'release_start': '2025-06-18 13:00:00',
+                    },
                 }
             }
         )
@@ -245,13 +258,17 @@ class TestRandomStrategy:
 
     def test_random_strategy_missing_bbox(self, random_strategy):
         """Test random strategy with missing bounding box."""
+        # Since SeedingConfig validates that strategy settings exist,
+        # we need to create a config that passes validation but missing bbox
         config = SeedingConfig(
             {
                 'population': {
+                    'particle_type': 'sand',
                     'seeding': {
-                        'strategy': {'random': {}},
+                        'strategy': {'random': {'not_bbox': 'invalid'}},
                         'quantity': 5,
-                    }
+                        'release_start': '2025-06-18 13:00:00',
+                    },
                 }
             }
         )
@@ -263,9 +280,9 @@ class TestRandomStrategy:
 class TestGridStrategy:
     """Test cases for GridStrategy."""
 
-    def test_grid_strategy(self, grid_strategy, grid_config, standard_bbox):
+    def test_grid_strategy(self, grid_strategy, grid_config):
         """Test basic grid strategy functionality."""
-        result = grid_strategy.seed(grid_config, bbox=standard_bbox)
+        result = grid_strategy.seed(grid_config)
 
         # Should generate a 3x3 grid (0,1,2 in both directions)
         assert len(result) == 9
@@ -273,26 +290,50 @@ class TestGridStrategy:
         assert (2, 0.0, 0.0) in result
         assert (2, 2.0, 2.0) in result
 
-    def test_grid_strategy_no_bbox(self, grid_strategy, grid_config):
+    def test_grid_strategy_no_bbox(self, grid_strategy):
         """Test grid strategy without bounding box."""
+        config = SeedingConfig(
+            {
+                'population': {
+                    'particle_type': 'sand',
+                    'seeding': {
+                        'strategy': {
+                            'grid': {
+                                'separation': {'dx': 1.0, 'dy': 1.0},
+                                'not_bbox': 'invalid',  # Missing bbox
+                            }
+                        },
+                        'quantity': 2,
+                        'release_start': '2025-06-18 13:00:00',
+                    },
+                }
+            }
+        )
         with pytest.raises(RuntimeError, match='Bounding box must be provided'):
-            grid_strategy.seed(grid_config)
+            grid_strategy.seed(config)
 
-    def test_grid_strategy_missing_separation(self, grid_strategy, standard_bbox):
+    def test_grid_strategy_missing_separation(self, grid_strategy):
         """Test grid strategy with missing separation parameters."""
         config = SeedingConfig(
             {
                 'population': {
+                    'particle_type': 'sand',
                     'seeding': {
-                        'strategy': {'grid': {}},
+                        'strategy': {
+                            'grid': {
+                                'bbox': {'xmin': 0.0, 'xmax': 2.0, 'ymin': 0.0, 'ymax': 2.0},
+                                'not_separation': 'invalid',
+                            }
+                        },
                         'quantity': 2,
-                    }
+                        'release_start': '2025-06-18 13:00:00',
+                    },
                 }
             }
         )
 
         with pytest.raises(MissingConfigurationParameter, match='"grid" must be provided'):
-            grid_strategy.seed(config, bbox=standard_bbox)
+            grid_strategy.seed(config)
 
 
 class TestTransectStrategy:
@@ -326,10 +367,12 @@ class TestTransectStrategy:
         config = SeedingConfig(
             {
                 'population': {
+                    'particle_type': 'sand',
                     'seeding': {
                         'strategy': {'transect': {'k': 3}},
                         'quantity': 5,
-                    }
+                        'release_start': '2025-06-18 13:00:00',
+                    },
                 }
             }
         )
@@ -342,6 +385,7 @@ class TestTransectStrategy:
         config = SeedingConfig(
             {
                 'population': {
+                    'particle_type': 'sand',
                     'seeding': {
                         'strategy': {
                             'transect': {
@@ -350,7 +394,8 @@ class TestTransectStrategy:
                             }
                         },
                         'quantity': 1,
-                    }
+                        'release_start': '2025-06-18 13:00:00',
+                    },
                 }
             }
         )
@@ -362,11 +407,24 @@ class TestTransectStrategy:
 class TestParticleFactory:
     """Test cases for ParticleFactory."""
 
-    def test_create_particles_point_strategy(self, point_strategy, point_config_dual, particle_classes):
+    def test_create_particles_point_strategy(self, particle_classes):
         """Test particle creation with PointStrategy."""
         Sand = particle_classes['Sand']
 
-        particles = ParticleFactory.create_particles(point_config_dual, point_strategy, 'sand', release_time=5)
+        config = SeedingConfig(
+            {
+                'population': {
+                    'particle_type': 'sand',
+                    'seeding': {
+                        'strategy': {'point': {'locations': ['1.0,2.0', '3.0,4.0']}},
+                        'quantity': 2,
+                        'release_start': '2025-06-18 13:00:00',
+                    },
+                }
+            }
+        )
+
+        particles = ParticleFactory.create_particles(config)
 
         # Should create 2 particles per location (2 locations * 2 particles = 4 total)
         assert len(particles) == 4
@@ -377,13 +435,31 @@ class TestParticleFactory:
         assert positions.count((1.0, 2.0)) == 2  # 2 particles at first location
         assert positions.count((3.0, 4.0)) == 2  # 2 particles at second location
         # Check release times
-        assert all(p.release_time == 5 for p in particles)
+        assert all(p.release_time == '2025-06-18 13:00:00' for p in particles)
 
-    def test_create_particles_grid_strategy(self, grid_strategy, grid_config_single, small_bbox, particle_classes):
-        """Test particle creation with GridStrategy requiring bbox parameter."""
+    def test_create_particles_grid_strategy(self, particle_classes):
+        """Test particle creation with GridStrategy."""
         Mud = particle_classes['Mud']
 
-        particles = ParticleFactory.create_particles(grid_config_single, grid_strategy, 'mud', bbox=small_bbox)
+        config = SeedingConfig(
+            {
+                'population': {
+                    'particle_type': 'mud',
+                    'seeding': {
+                        'strategy': {
+                            'grid': {
+                                'separation': {'dx': 1.0, 'dy': 1.0},
+                                'bbox': {'xmin': 0.0, 'xmax': 1.0, 'ymin': 0.0, 'ymax': 1.0},
+                            }
+                        },
+                        'quantity': 1,
+                        'release_start': '2025-06-18 13:00:00',
+                    },
+                }
+            }
+        )
+
+        particles = ParticleFactory.create_particles(config)
 
         # Should create 4 particles (2x2 grid)
         assert len(particles) == 4
@@ -394,33 +470,94 @@ class TestParticleFactory:
         assert (0.0, 0.0) in positions
         assert (1.0, 1.0) in positions
 
-    def test_create_particles_different_particle_types(self, point_strategy, point_config_simple, particle_classes):
+    def test_create_particles_different_particle_types(self, particle_classes):
         """Test creating different particle types."""
         Sand, Mud, Passive = particle_classes['Sand'], particle_classes['Mud'], particle_classes['Passive']
 
         # Test Sand particles
-        sand_particles = ParticleFactory.create_particles(point_config_simple, point_strategy, 'sand')
+        sand_config = SeedingConfig(
+            {
+                'population': {
+                    'particle_type': 'sand',
+                    'seeding': {
+                        'strategy': {'point': {'locations': ['0,0']}},
+                        'quantity': 1,
+                        'release_start': '2025-06-18 13:00:00',
+                    },
+                }
+            }
+        )
+        sand_particles = ParticleFactory.create_particles(sand_config)
         assert len(sand_particles) == 1
         assert isinstance(sand_particles[0], Sand)
 
         # Test Mud particles
-        mud_particles = ParticleFactory.create_particles(point_config_simple, point_strategy, 'mud')
+        mud_config = SeedingConfig(
+            {
+                'population': {
+                    'particle_type': 'mud',
+                    'seeding': {
+                        'strategy': {'point': {'locations': ['0,0']}},
+                        'quantity': 1,
+                        'release_start': '2025-06-18 13:00:00',
+                    },
+                }
+            }
+        )
+        mud_particles = ParticleFactory.create_particles(mud_config)
         assert len(mud_particles) == 1
         assert isinstance(mud_particles[0], Mud)
 
         # Test Passive particles
-        passive_particles = ParticleFactory.create_particles(point_config_simple, point_strategy, 'passive')
+        passive_config = SeedingConfig(
+            {
+                'population': {
+                    'particle_type': 'passive',
+                    'seeding': {
+                        'strategy': {'point': {'locations': ['0,0']}},
+                        'quantity': 1,
+                        'release_start': '2025-06-18 13:00:00',
+                    },
+                }
+            }
+        )
+        passive_particles = ParticleFactory.create_particles(passive_config)
         assert len(passive_particles) == 1
         assert isinstance(passive_particles[0], Passive)
 
-    def test_create_particles_invalid_particle_type(self, point_strategy, point_config_simple):
+    def test_create_particles_invalid_particle_type(self):
         """Test error handling for invalid particle type."""
+        config = SeedingConfig(
+            {
+                'population': {
+                    'particle_type': 'invalid_type',
+                    'seeding': {
+                        'strategy': {'point': {'locations': ['0,0']}},
+                        'quantity': 1,
+                        'release_start': '2025-06-18 13:00:00',
+                    },
+                }
+            }
+        )
+
         with pytest.raises(ValueError, match='Unknown particle type'):
-            ParticleFactory.create_particles(point_config_simple, point_strategy, 'invalid_type')
+            ParticleFactory.create_particles(config)
 
-    def test_create_particles_release_time_default(self, point_strategy, point_config_simple):
-        """Test default release time behavior."""
-        particles = ParticleFactory.create_particles(point_config_simple, point_strategy, 'sand')
+    def test_create_particles_release_time_set(self):
+        """Test that release time is set correctly."""
+        config = SeedingConfig(
+            {
+                'population': {
+                    'particle_type': 'sand',
+                    'seeding': {
+                        'strategy': {'point': {'locations': ['0,0']}},
+                        'quantity': 1,
+                        'release_start': '2025-06-18 13:00:00',
+                    },
+                }
+            }
+        )
+        particles = ParticleFactory.create_particles(config)
 
-        # Should default to release_time = 0
-        assert particles[0].release_time == 0
+        # Should have the correct release time
+        assert particles[0].release_time == '2025-06-18 13:00:00'


### PR DESCRIPTION
dThis PR contains changes to the particle seeding. 

The following particle strategies have been implemented:

- Point
- Random
- Grid
- Transect

Adds a ParticleFactory to create any number of particles.
This also contains changes to the config schema. Changes were necessary to modify the options that each seeding strategy provides. 

## Reasoning and Usage

In the configuration file the particle for a simulation are defined using populations. A population is a collection of particles of the save type and characteristics, which have the same tracer methods and seeding strategy:

```yml
particles:
  population:
    name: my_population
    particle_type: sand
    characteristics:
      grain_size: 0.01 
      density: 2650.0  
    tracer_methods:
      vanwesten:
        alpha: 0.2
        beta: 0.3
    seeding:
      release_start: 2025-06-18 13:00:00
      quantity: 1
      strategy: 
        point:
          locations: 
            - "40000,17000"
```

> Note that a simulation can have more than one population. And that if we want to include particles of different types or characteristics, or seed particles using different strategies, we shall create different populations.

The code in this PR follows this reasoning:
- The seeding tool generates n-number of particles for a population using the seeding strategy defined in the configuration for each population.  
- The number of particle per location are  defined by `quantity` and the number of seeding locations depend on the strategy used. e.g., above only one seed location is specified. The number of seeding locations for some of the strategies are computed at runtime (e.g., grid).
- The total number of particle in a population is the product of `quantity * seeding locations` 
- When seeding happens a list with the total number of particles in a population is created. If more than one population is specified in the configuration file, than particle creation should be repeated for each one (I will work on automating this). The creation of particle is manage by a `ParticleFactory`, which takes the configuration for a population and generates the particles, assigns the initial x,y coordinates, release_time (release_start) and quantity. 

The `ParticleFactory` can be used as follows:

```python
    # Example usage
config_point = SeedingConfig(
    {
        'population': {
            'seeding': {
                'strategy': {'point': {'locations': [
                                                '1.0,2.0', 
                                                '3.0,4.0'
                                               ]
                                 }},
                'quantity': 1,
                'release_start': '2025-06-18 13:00:00'
            }
        }
    }
)

# create 
particles = ParticleFactory.create_particles(config_point)
```
Which returns something like (1*2 number of particles):

```python
[
Sand(id=1, _x=1.0, _y=2.0, _release_time='2025-06-18 13:00:00', _is_mobile=True, name='', trace={}, physical_properties=PhysicalProperties(density=2650.0, diameter=0.0002)), 
Sand(id=2, _x=3.0, _y=4.0, _release_time='2025-06-18 13:00:00', _is_mobile=True, name='', trace={}, physical_properties=PhysicalProperties(density=2650.0, diameter=0.0002))
]
```
Particle `id` is automatically assigned. 



