### PR TITLE
Polish NetCDFReader class and add tests

### DIFF
--- a/src/sedtrails/data_manager/netcdf_reader.py
+++ b/src/sedtrails/data_manager/netcdf_reader.py
@@ -12,23 +12,68 @@ class NetCDFReader:
     """
     A class for reading NetCDF files produced by the SedTrails Particle Tracer System.
 
+    This class validates and loads NetCDF files using xugrid's lazy loading functionality.
+    The file is automatically validated and loaded upon instantiation.
+
+    Parameters:
+    -----------
+    file_path : str
+        The path to the CF compliant NetCDF file.
+
     Attributes:
     -----------
-        file_path: str
-            The path to the CF complaint NetCDF file.
+    file_path : str
+        The path to the CF compliant NetCDF file.
+    data : xu.UgridDataset
+        The loaded NetCDF dataset as an xugrid UgridDataset object.
+
+    Raises:
+    -------
+    FileNotFoundError
+        If the specified file does not exist.
+    ValueError
+        If the file exists but is not a valid NetCDF file or has an invalid extension.
+
+    Examples:
+    ---------
+    >>> reader = NetCDFReader('sample-data/example_output.nc')
+    >>> print(reader.data)
+    >>> particle_id = reader.data['particle_id']
     """
 
     def __init__(self, file_path: str) -> None:
         self.file_path: str = file_path
-        self.data: xu.UgridDataset = self._read_file()
+        self._read_file()
             
     def _validate_file(self) -> bool:
         """
-        Validates the file path to ensure it is a NetCDF file.
+        Validates the file path to ensure it exists and is a NetCDF file.
+        
+        Raises:
+            FileNotFoundError: If the file does not exist.
+            ValueError: If the file exists but is not a valid NetCDF file.
+        
+        Returns:
+            bool: True if the file is valid.
         """
-        FILE_EXTENSIONS = ['.nc']
+        FILE_EXTENSIONS = ['.nc', '.nc4', '.netcdf']  # Added more common NetCDF extensions
         path = Path(self.file_path)
-        return path.is_file() and path.suffix in FILE_EXTENSIONS
+        
+        # Check if file exists
+        if not path.is_file():
+            raise FileNotFoundError(f"File not found: {self.file_path}")
+        
+        # Check if file has valid NetCDF extension
+        if path.suffix.lower() not in FILE_EXTENSIONS:
+            raise ValueError(f"Invalid file type. Expected NetCDF file with extensions {FILE_EXTENSIONS}, got: {path.suffix}")
+        
+        # Optional: Check if file is actually readable as NetCDF
+        try:
+            xu.open_dataset(self.file_path)
+        except Exception as e:
+            raise ValueError(f"File exists but is not a valid NetCDF file: {e}") from e
+        
+        return True
 
     def _read_file(self):
         """
@@ -37,19 +82,11 @@ class NetCDFReader:
         if not self._validate_file():
             raise ValueError("Invalid file path. Ensure the file is a NetCDF file.")
         else:
-            self.data = xu.open_mfdataset(self.file_path)
-            # TODO:  this retuns a hadler for the dataset. What this class shoudl do with it?
-    
-    def __str__(self):
-        """
-        Returns the string representation of the NetCDFReader object.
-        """
-
-        return self.data
+            self.data = xu.open_dataset(self.file_path)
 
 
 if __name__ == "__main__":
-    reader = NetCDFReader('sample-data/dfm_sedtrails.nc')
+    reader = NetCDFReader('sample-data/example_output.nc')
     print(reader)
 
     # # dfm dataset:

--- a/tests/data_manager/test_netcdf_reader.py
+++ b/tests/data_manager/test_netcdf_reader.py
@@ -1,0 +1,55 @@
+import pytest
+from sedtrails.data_manager.netcdf_reader import NetCDFReader
+
+
+class DummyDataset:
+    def __init__(self, path):
+        self.path = path
+
+
+def test_missing_file():
+    """Missing file should raise FileNotFoundError."""
+    with pytest.raises(FileNotFoundError):
+        NetCDFReader("no_such_file.nc")
+
+
+def test_invalid_extension(tmp_path):
+    """Wrong extension should raise ValueError before trying to open."""
+    bad_extension = tmp_path / "data.txt"
+    bad_extension.write_text("x")
+    with pytest.raises(ValueError):
+        NetCDFReader(str(bad_extension))
+
+
+def test_valid_nc_opens(monkeypatch, tmp_path):
+    """Valid .nc path calls xugrid.open_dataset and stores dataset."""
+    nc = tmp_path / "ok.nc"
+    nc.write_text("placeholder")  # existence + suffix only
+
+    import xugrid as xu
+    called = {}
+
+    def fake_open_dataset(path):
+        called["path"] = path
+        return DummyDataset(path)
+
+    monkeypatch.setattr(xu, "open_dataset", fake_open_dataset)
+
+    reader = NetCDFReader(str(nc))
+    assert hasattr(reader, "data")
+    assert isinstance(reader.data, DummyDataset)
+    assert called["path"] == str(nc)
+    assert reader.data.path == str(nc)
+
+
+@pytest.mark.parametrize("ext", [".nc", ".nc4", ".netcdf"])
+def test_supported_extensions(monkeypatch, tmp_path, ext):
+    """All supported extensions accepted."""
+    f = tmp_path / f"sample{ext}"
+    f.write_text("x")
+
+    import xugrid as xu
+    monkeypatch.setattr(xu, "open_dataset", lambda path: DummyDataset(str(f)))
+
+    reader = NetCDFReader(str(f))
+    assert reader.data.path == str(f)


### PR DESCRIPTION
Updated the NetCDFReader class in `netcdf_reader.py` to be handle file loading errors more cleanly and added accompanying tests.

Closes #234 

# Relevant files
- `src/sedtrails/data_manager/netcdf_reader.py`
    - Added multiple file validations (correct file extension, file exists, and if it can be opened with xu)
    - Switched to `xu.open_dataset` because NetCDFReader will handle single file instead of multiples
    - Updated docstrings

- `tests/data_manager/test_netcdf_reader.py`
    - Tests cover missing file, bad extension, readable file and supported extensions (".nc", ".nc4", ".netcdf")