### PR TITLE
Implement SedtrailsMetadata class and integrate with SedtrailsData

### DIFF
--- a/src/sedtrails/transport_converter/plugins/format/fm_netcdf.py
+++ b/src/sedtrails/transport_converter/plugins/format/fm_netcdf.py
@@ -5,6 +5,7 @@ import xarray as xr
 import numpy as np
 from sedtrails.transport_converter.plugins import BaseFormatPlugin
 from sedtrails.transport_converter.sedtrails_data import SedtrailsData
+from sedtrails.transport_converter.sedtrails_metadata import SedtrailsMetadata
 from pathlib import Path
 from typing import Dict, Any, List, Union
 
@@ -120,6 +121,16 @@ class FormatPlugin(BaseFormatPlugin):
             'magnitude': np.zeros_like(depth_avg_velocity_magnitude),
         }
 
+        # Create SedtrailsMetadata object
+        metadata = SedtrailsMetadata(
+            flowfield_domain={
+                'x_min': np.min(mapped_data['x']),
+                'x_max': np.max(mapped_data['x']),
+                'y_min': np.min(mapped_data['y']),
+                'y_max': np.max(mapped_data['y']),
+            }
+        )
+
         # Create SedtrailsData object
         sedtrails_data = SedtrailsData(
             times=seconds_since_ref,
@@ -136,6 +147,7 @@ class FormatPlugin(BaseFormatPlugin):
             max_bed_shear_stress=mapped_data['max_bed_shear_stress'],
             sediment_concentration=mapped_data['sediment_concentration'],
             nonlinear_wave_velocity=nonlinear_wave_velocity,
+            metadata=metadata,
         )
 
         return sedtrails_data

--- a/src/sedtrails/transport_converter/sedtrails_data.py
+++ b/src/sedtrails/transport_converter/sedtrails_data.py
@@ -87,9 +87,22 @@ class SedtrailsData:
     metadata: SedtrailsMetadata
 
     def __post_init__(self):
-        """Initialize container for dynamic physics fields."""
+        """Initialize container for dynamic physics fields and validate metadata."""
+        # Validate metadata field
+        self._validate_metadata()
+        # TODO: do we also need to check that min max values are sensible? i.e. min <= max
+        
         # Create a container for physics data that can be added later
-        self._physics_fields = {}
+        self._physics_fields = {}    
+
+    def _validate_metadata(self):
+        """Validate that metadata field exists and is the correct type."""
+        # Only check that metadata is the right type
+        if not isinstance(self.metadata, SedtrailsMetadata):
+            raise TypeError(
+                f"metadata must be an instance of SedtrailsMetadata, "
+                f"got {type(self.metadata).__name__}"
+            )
 
     def add_physics_field(self, name: str, data):
         """

--- a/src/sedtrails/transport_converter/sedtrails_data.py
+++ b/src/sedtrails/transport_converter/sedtrails_data.py
@@ -1,7 +1,7 @@
 import numpy as np
 from typing import Dict
 from dataclasses import dataclass
-
+from sedtrails.transport_converter.sedtrails_metadata import SedtrailsMetadata
 
 @dataclass
 class SedtrailsData:
@@ -48,6 +48,8 @@ class SedtrailsData:
     nonlinear_wave_velocity: Dict[str, np.ndarray]
         Nonlinear wave velocity in m/s
         (keys: 'x', 'y', 'magnitude', each with time as first dimension)
+    metadata: SedtrailsMetadata
+        Additional metadata for this dataset        
 
     # === PHYSICS FIELDS (added by PhysicsConverter) ===
     # Note: All physics fields match the structure of transport data
@@ -82,6 +84,7 @@ class SedtrailsData:
     max_bed_shear_stress: np.ndarray
     sediment_concentration: np.ndarray
     nonlinear_wave_velocity: Dict[str, np.ndarray]
+    metadata: SedtrailsMetadata
 
     def __post_init__(self):
         """Initialize container for dynamic physics fields."""

--- a/src/sedtrails/transport_converter/sedtrails_metadata.py
+++ b/src/sedtrails/transport_converter/sedtrails_metadata.py
@@ -82,3 +82,19 @@ class SedtrailsMetadata:
         """Custom repr showing all attributes."""
         attrs = {k: v for k, v in self.__dict__.items() if not k.startswith('_')}
         return f"SedtrailsMetadata({attrs})"
+    
+
+# Example usage
+# 1. Create with flowfield_domain dictionary
+# metadata = SedtrailsMetadata(
+#     flowfield_domain={
+#         "x_min": 0.0,
+#         "x_max": 100.0,
+#         "y_min": 0.0,
+#         "y_max": 50.0
+#     }
+# )
+# 2. Add additional metadata dynamically
+# metadata.add("model", "delft3d")
+# metadata.add("timestep", 600)
+# metadata.add("units", "meters")

--- a/src/sedtrails/transport_converter/sedtrails_metadata.py
+++ b/src/sedtrails/transport_converter/sedtrails_metadata.py
@@ -39,25 +39,19 @@ class SedtrailsMetadata:
             self.flowfield_domain[key] = float(self.flowfield_domain[key])
 
     def __setattr__(self, name: str, value: Any):
-        """Allow setting dynamic attributes while protecting reserved ones."""
+        """Protect reserved attributes after initialization."""
         if name in self.RESERVED_KEYS and hasattr(self, name):
-            # Only allow setting flowfield_domain during initialization
-            if name == "flowfield_domain" and not hasattr(self, '_initialized'):
-                super().__setattr__(name, value)
-                super().__setattr__('_initialized', True)
-            else:
-                raise ValueError(f"'{name}' is reserved and cannot be overwritten")
-        else:
-            super().__setattr__(name, value)
+            raise ValueError(f"'{name}' is reserved and cannot be overwritten")
+        super().__setattr__(name, value)
 
     def add(self, key: str, value: Any):
         """Add a single metadata entry as an attribute."""
         setattr(self, key, value)
 
     def update(self, metadata_dict: Mapping[str, Any]):
-        """Add multiple metadata entries as attributes."""
+        """Update metadata with a dictionary of key-value pairs."""
         for key, value in metadata_dict.items():
-            setattr(self, key, value)
+            self.add(key, value) 
 
     def get(self, key: str, default=None) -> Any:
         """Get metadata value by key."""
@@ -77,12 +71,6 @@ class SedtrailsMetadata:
             if not key.startswith('_'):  # Skip private attributes
                 result[key] = value
         return result
-
-    def __repr__(self) -> str:
-        """Custom repr showing all attributes."""
-        attrs = {k: v for k, v in self.__dict__.items() if not k.startswith('_')}
-        return f"SedtrailsMetadata({attrs})"
-    
 
 # Example usage
 # 1. Create with flowfield_domain dictionary

--- a/src/sedtrails/transport_converter/sedtrails_metadata.py
+++ b/src/sedtrails/transport_converter/sedtrails_metadata.py
@@ -1,0 +1,84 @@
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping
+
+@dataclass
+class SedtrailsMetadata:
+    """
+    A dataclass for storing metadata used by the SedtrailsData class.
+    Domain / grid metadata for a SedtrailsData instance.
+
+    The flowfield_domain is required and contains the spatial bounds of the domain.
+    Additional metadata can be added as attributes dynamically.
+
+    Attributes
+    ----------
+    flowfield_domain : dict
+        Required dictionary containing:
+        - x_min : float
+        - x_max : float  
+        - y_min : float
+        - y_max : float
+    """
+    
+    flowfield_domain: Dict[str, float]
+    
+    REQUIRED_DOMAIN_KEYS = {"x_min", "x_max", "y_min", "y_max"}
+    RESERVED_KEYS = {"flowfield_domain"}
+
+    def __post_init__(self):
+        """Validate that flowfield_domain contains required keys."""
+        if not isinstance(self.flowfield_domain, dict):
+            raise TypeError("flowfield_domain must be a dictionary")
+        
+        missing_keys = self.REQUIRED_DOMAIN_KEYS - set(self.flowfield_domain.keys())
+        if missing_keys:
+            raise ValueError(f"flowfield_domain missing required keys: {missing_keys}")
+        
+        # Ensure all values are float
+        for key in self.REQUIRED_DOMAIN_KEYS:
+            self.flowfield_domain[key] = float(self.flowfield_domain[key])
+
+    def __setattr__(self, name: str, value: Any):
+        """Allow setting dynamic attributes while protecting reserved ones."""
+        if name in self.RESERVED_KEYS and hasattr(self, name):
+            # Only allow setting flowfield_domain during initialization
+            if name == "flowfield_domain" and not hasattr(self, '_initialized'):
+                super().__setattr__(name, value)
+                super().__setattr__('_initialized', True)
+            else:
+                raise ValueError(f"'{name}' is reserved and cannot be overwritten")
+        else:
+            super().__setattr__(name, value)
+
+    def add(self, key: str, value: Any):
+        """Add a single metadata entry as an attribute."""
+        setattr(self, key, value)
+
+    def update(self, metadata_dict: Mapping[str, Any]):
+        """Add multiple metadata entries as attributes."""
+        for key, value in metadata_dict.items():
+            setattr(self, key, value)
+
+    def get(self, key: str, default=None) -> Any:
+        """Get metadata value by key."""
+        return getattr(self, key, default)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Export all metadata as dictionary.
+        
+        Returns
+        -------
+        dict
+            Complete metadata dictionary including dynamic attributes
+        """
+        result = {}
+        for key, value in self.__dict__.items():
+            if not key.startswith('_'):  # Skip private attributes
+                result[key] = value
+        return result
+
+    def __repr__(self) -> str:
+        """Custom repr showing all attributes."""
+        attrs = {k: v for k, v in self.__dict__.items() if not k.startswith('_')}
+        return f"SedtrailsMetadata({attrs})"


### PR DESCRIPTION
Added a new `SedtrailsMetadata` class to store flowfield domain bounds and additional metadata (for future), and integrates it as a required field in `SedtrailsData` class. 

Closes #273 

# Relevant files
- `src/sedtrails/transport_converter/sedtrails_metadata.py`
    - SedtrailsMetada dataclass also allows for dynamic attribute addition
    - Required `flowfield_domain`: Contains bounds (x_min, x_max, y_min, y_max)
    - Validates required keys and converts values to float in `__post_init__`
    - Prevents overwriting reserved keys like `flowfield_domain`
    - Example use:
 ```python
# Required domain bounds
metadata = SedtrailsMetadata(
    flowfield_domain={"x_min": 0.0, "x_max": 100.0, "y_min": 0.0, "y_max": 50.0}
)

# Add additional metadata dynamically
metadata.add("model_type", "delft3d_fm")
metadata.update({"timestep": 600, "units": "meters"})

# Access domain bounds
print(metadata.x_min)  # 0.0
```

- `src/sedtrails/transport_converter/sedtrails_data.py`
    - Type checking to ensure metadata is a `SedtrailsMetadata` instance
    - Relies on SedtrailsMetadata's own validation for internal structure

- `src/sedtrails/transport_converter/plugins/format/fm_netcdf.py`
    - Creates `SedtrailsMetadata` with computed domain bounds from coordinate data (`net_xcc` and `net_ycc`)
    - Passes metadata as required field to `SedtrailsData` constructor