### PR TITLE
Particle Population

### DIFF
--- a/examples/seeder_example.py
+++ b/examples/seeder_example.py
@@ -1,7 +1,7 @@
-from sedtrails.particle_tracer import SeedingConfig, ParticleFactory
+from sedtrails.particle_tracer import PopulationConfig
 
 # Example usage of the ParticleFactory  to create population of particles
-config_random = SeedingConfig(
+config_random = PopulationConfig(
     {
         'population': {
             'particle_type': 'sand',
@@ -14,5 +14,12 @@ config_random = SeedingConfig(
     }
 )
 
-particles = ParticleFactory.create_particles(config_random)
-print('Created particles:', particles)
+
+from sedtrails.particle_tracer import ParticlePopulation
+import numpy as np
+
+population = ParticlePopulation(
+    field_x=np.array([0.0, 1.0, 2.5, 5.0]),
+    field_y=np.array([0.0, 1.0, 2.0, 3.0]),
+    population_config=config_random,
+)

--- a/examples/seeder_example.py
+++ b/examples/seeder_example.py
@@ -6,8 +6,8 @@ config_random = PopulationConfig(
         'population': {
             'particle_type': 'sand',
             'seeding': {
-                'strategy': {'random': {'bbox': '1.0,2.0, 3.0,4.0', 'seed': 42}},
-                'quantity': 5,
+                'strategy': {'random': {'bbox': '1.0,2.0, 3.0,4.0', 'nlocations': 1, 'seed': 42}},
+                'quantity': 2,
                 'release_start': '2025-06-18 13:00:00',
             },
         }
@@ -23,3 +23,5 @@ population = ParticlePopulation(
     field_y=np.array([0.0, 1.0, 2.0, 3.0]),
     population_config=config_random,
 )
+
+print(population.particles)  # Output the x-coordinates of the particles

--- a/examples/seeder_example.py
+++ b/examples/seeder_example.py
@@ -1,4 +1,5 @@
-from sedtrails.particle_tracer import PopulationConfig
+from sedtrails.particle_tracer import PopulationConfig, ParticlePopulation
+import numpy as np
 
 # Example usage of the ParticleFactory  to create population of particles
 config_random = PopulationConfig(
@@ -14,9 +15,6 @@ config_random = PopulationConfig(
     }
 )
 
-
-from sedtrails.particle_tracer import ParticlePopulation
-import numpy as np
 
 population = ParticlePopulation(
     field_x=np.array([0.0, 1.0, 2.5, 5.0]),

--- a/examples/seeder_example.py
+++ b/examples/seeder_example.py
@@ -1,0 +1,18 @@
+from sedtrails.particle_tracer import SeedingConfig, ParticleFactory
+
+# Example usage of the ParticleFactory  to create population of particles
+config_random = SeedingConfig(
+    {
+        'population': {
+            'particle_type': 'sand',
+            'seeding': {
+                'strategy': {'random': {'bbox': '1.0,2.0, 3.0,4.0', 'seed': 42}},
+                'quantity': 5,
+                'release_start': '2025-06-18 13:00:00',
+            },
+        }
+    }
+)
+
+particles = ParticleFactory.create_particles(config_random)
+print('Created particles:', particles)

--- a/src/sedtrails/config/population.schema.json
+++ b/src/sedtrails/config/population.schema.json
@@ -327,9 +327,14 @@
                                     "type": "string",
                                     "description": "bounding box for random point generation, as 'xmin,ymin xmax,ymax'"
                                 },
+                                "nlocations": {
+                                    "type": "integer",
+                                    "default": 1,
+                                    "description": "number of random points to generate within the bounding box or polygon"
+                                },
                                 "seed": {
                                     "type": "number",
-                                    "default": 1,
+                                    "default": 42,
                                     "description": "seed for random number generator"
                                 },
                                 "show_check_plots": {
@@ -343,6 +348,9 @@
                                     "description": "Do you want to save cluster check plots?"
                                 }
                             },
+                            "required": [
+                                "nlocations"
+                            ],
                             "oneOf": [
                                 {
                                     "required": [

--- a/src/sedtrails/particle_tracer/__init__.py
+++ b/src/sedtrails/particle_tracer/__init__.py
@@ -1,1 +1,5 @@
 """A directory for the Lagrangian Particle Tracer"""
+
+from .particle_seeder import SeedingConfig, ParticleFactory
+
+__all__ = ['SeedingConfig', 'ParticleFactory']

--- a/src/sedtrails/particle_tracer/__init__.py
+++ b/src/sedtrails/particle_tracer/__init__.py
@@ -1,5 +1,6 @@
 """A directory for the Lagrangian Particle Tracer"""
 
-from .particle_seeder import SeedingConfig, ParticleFactory
+from .particle_seeder import PopulationConfig
+from .population import ParticlePopulation
 
-__all__ = ['SeedingConfig', 'ParticleFactory']
+__all__ = ['PopulationConfig', 'ParticlePopulation']

--- a/src/sedtrails/particle_tracer/particle_seeder.py
+++ b/src/sedtrails/particle_tracer/particle_seeder.py
@@ -23,7 +23,7 @@ from sedtrails.configuration_interface.find import find_value
 
 
 @dataclass
-class SeedingConfig:
+class PopulationConfig:
     """
     A class to represent the seeding parameters of a population of particle.
     A population is a group of particles that share the same type and seeding strategy.
@@ -77,7 +77,7 @@ class SeedingStrategy(ABC):
     """
 
     @abstractmethod
-    def seed(self, config: SeedingConfig) -> List[Tuple[int, float, float]]:
+    def seed(self, config: PopulationConfig) -> List[Tuple[int, float, float]]:
         """
         Asociates quantity of particles to a seeding locations for a given strategy.
 
@@ -102,7 +102,7 @@ class PointStrategy(SeedingStrategy):
     Seeding strategy to release particles at specific locations (x,y).
     """
 
-    def seed(self, config: SeedingConfig) -> list[Tuple[int, float, float]]:
+    def seed(self, config: PopulationConfig) -> list[Tuple[int, float, float]]:
         locations = getattr(config, 'strategy_settings', {}).get('locations', [])
         if not locations:
             raise MissingConfigurationParameter('"locations" must be provided for PointStrategy.')
@@ -127,7 +127,7 @@ class RandomStrategy(SeedingStrategy):
     bounding box 'xmin,ymin xmax,ymax'.
     """
 
-    def seed(self, config: SeedingConfig) -> list[Tuple[int, float, float]]:
+    def seed(self, config: PopulationConfig) -> list[Tuple[int, float, float]]:
         # expects strategy_settings to contain 'bbox' and 'seed'
         bbox = getattr(config, 'strategy_settings', {}).get('bbox', None)
         if not bbox:
@@ -159,7 +159,7 @@ class GridStrategy(SeedingStrategy):
     The origin of the grid is at the bottom left corner of the bounding box
     """
 
-    def seed(self, config: SeedingConfig) -> list[Tuple[int, float, float]]:
+    def seed(self, config: PopulationConfig) -> list[Tuple[int, float, float]]:
         bbox = getattr(config, 'strategy_settings', {}).get('bbox', None)
         if not bbox:
             raise RuntimeError('Bounding box must be provided for GridStrategy.')
@@ -206,7 +206,7 @@ class TransectStrategy(SeedingStrategy):
     the number of release locations per segment (k).
     """
 
-    def seed(self, config: SeedingConfig) -> list[Tuple[int, float, float]]:
+    def seed(self, config: PopulationConfig) -> list[Tuple[int, float, float]]:
         # expect to return a dictionary with keys 'segments', 'k'
         segments = getattr(config, 'strategy_settings', {}).get('segments', None)
         if not segments:
@@ -250,7 +250,7 @@ class TransectStrategy(SeedingStrategy):
 
 class ParticleFactory:
     @staticmethod
-    def create_particles(config: SeedingConfig) -> list[Particle]:
+    def create_particles(config: PopulationConfig) -> list[Particle]:
         """
         Create a list of particles of the specified type using a seeding strategy.
 
@@ -304,7 +304,7 @@ class ParticleFactory:
 
 if __name__ == '__main__':
     # Example usage
-    config_point = SeedingConfig(
+    config_point = PopulationConfig(
         {
             'population': {
                 'particle_type': 'sand',
@@ -317,7 +317,7 @@ if __name__ == '__main__':
         }
     )
 
-    config_transect = SeedingConfig(
+    config_transect = PopulationConfig(
         {
             'population': {
                 'particle_type': 'sand',
@@ -335,7 +335,7 @@ if __name__ == '__main__':
         }
     )
 
-    config_random = SeedingConfig(
+    config_random = PopulationConfig(
         {
             'population': {
                 'particle_type': 'sand',

--- a/src/sedtrails/particle_tracer/particle_seeder.py
+++ b/src/sedtrails/particle_tracer/particle_seeder.py
@@ -138,13 +138,17 @@ class RandomStrategy(SeedingStrategy):
             raise MissingConfigurationParameter('"seed" must be provided for RandomStrategy.')
         random.seed(seed)
 
+        nlocations = getattr(config, 'strategy_settings', {}).get('nlocations', None)
+        if not nlocations:
+            raise MissingConfigurationParameter('"nlocations" must be provided for RandomStrategy.')
+
         if config.quantity is None:
             raise MissingConfigurationParameter('"quantity" must be an integer for RandomStrategy.')
         quantity = int(config.quantity)
         seed_locations = []
 
         _bbox = bbox.replace(',', ' ').split()  # separates values with whitespaces. Order is xmin, ymin, xmax, ymax
-        for _ in range(quantity):
+        for _ in range(nlocations):
             x = random.uniform(float(_bbox[0]), float(_bbox[2]))
             y = random.uniform(float(_bbox[1]), float(_bbox[3]))
             seed_locations.append((quantity, x, y))
@@ -340,7 +344,7 @@ if __name__ == '__main__':
             'population': {
                 'particle_type': 'sand',
                 'seeding': {
-                    'strategy': {'random': {'bbox': '1.0,2.0, 3.0,4.0', 'seed': 42}},
+                    'strategy': {'random': {'bbox': '1.0,2.0, 3.0,4.0', 'nlocations': 2, 'seed': 42}},
                     'quantity': 5,
                     'release_start': '2025-06-18 13:00:00',
                 },
@@ -349,4 +353,6 @@ if __name__ == '__main__':
     )
 
     particles = ParticleFactory.create_particles(config_random)
-    print('Created particles:', particles)  # Should print the created particles with their positions and release times
+    print(
+        'Created particles:', len(particles)
+    )  # Should print the created particles with their positions and release times

--- a/src/sedtrails/particle_tracer/population.py
+++ b/src/sedtrails/particle_tracer/population.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, field
 from sedtrails.particle_tracer.position_calculator_numba import create_numba_particle_calculator
 from typing import Dict, Any
 import numpy as np
-from sedtrails.particle_tracer import ParticleFactory, SeedingConfig
+from .particle_seeder import PopulationConfig, ParticleFactory
 
 
 @dataclass
@@ -18,7 +18,7 @@ class ParticlePopulation:
         The x-coordinates of the flow field data where particles are seeded.
     field_y : ndarray
         The y-coordinates of the flow field data where particles are seeded.
-    population_config : SeedingConfig
+    population_config : PopulationConfig
         Configuration for the particle population, including seeding strategy and parameters.
     particles : Dict
         A dictionary containing particle attributes such as positions and status.
@@ -38,7 +38,7 @@ class ParticlePopulation:
 
     field_x: ndarray
     field_y: ndarray
-    population_config: SeedingConfig
+    population_config: PopulationConfig
     particles: Dict = field(init=False, default_factory=dict)  # a dictionary with arrays
     _field_interpolator: Any = field(init=False)  # holds a Numba function
     _position_calculator: Any = field(init=False)  # holds a Numba function

--- a/src/sedtrails/particle_tracer/population.py
+++ b/src/sedtrails/particle_tracer/population.py
@@ -1,0 +1,161 @@
+from numpy import ndarray
+from dataclasses import dataclass, field
+from sedtrails.particle_tracer.position_calculator_numba import create_numba_particle_calculator
+from typing import Dict, Any
+import numpy as np
+from sedtrails.particle_tracer import ParticleFactory, SeedingConfig
+
+
+@dataclass
+class ParticlePopulation:
+    """
+    Class handle operations for population of particles.
+    A population is a group of particles that share the same type and seeding strategy.
+
+    Attributes
+    ----------
+    field_x : ndarray
+        The x-coordinates of the flow field data where particles are seeded.
+    field_y : ndarray
+        The y-coordinates of the flow field data where particles are seeded.
+    population_config : SeedingConfig
+        Configuration for the particle population, including seeding strategy and parameters.
+    particles : Dict
+        A dictionary containing particle attributes such as positions and status.
+    _field_interpolator : Dict
+        A dictionary containing Numba functions for interpolating field data.
+    _position_calculator : Dict
+        A dictionary containing Numba functions for calculating particle positions.
+    _current_time : ndarray
+        The current time in the simulation, used for updating particle positions.
+    _field_mixing_depth : ndarray
+        The mixing depth of the flow field, used to determine particle behavior.
+    _field_bed_level_change : ndarray
+        The change in bed level of the flow field, affecting particle burial and exposure.
+    _field_transport_probability : ndarray
+        The probability of particle transport in the flow field, used to determine if particles are picked up.
+    """
+
+    field_x: ndarray
+    field_y: ndarray
+    population_config: SeedingConfig
+    particles: Dict = field(init=False, default_factory=dict)  # a dictionary with arrays
+    _field_interpolator: Any = field(init=False)  # holds a Numba function
+    _position_calculator: Any = field(init=False)  # holds a Numba function
+    _current_time: ndarray = field(init=False)
+    _field_mixing_depth: ndarray = field(init=False)  # TODO: we're not using this field yet
+    _field_bed_level_change: ndarray = field(init=False)  # TODO: we're not using this field yet
+    _field_transport_probability: ndarray = field(init=False)  # TODO: we're not using this field yet
+
+    def __post_init__(self):
+        # Create a Numba calculator for particle operations
+        numba_functions = create_numba_particle_calculator(grid_x=self.field_x, grid_y=self.field_y)
+
+        self._field_interpolator = numba_functions['interpolate_field']
+        self._position_calculator = numba_functions['update_particles']
+
+        # generate particles based on the configuration
+        _particles = ParticleFactory.create_particles(self.population_config)
+        self.particles = {'x': np.array([p.x for p in _particles]), 'y': np.array([p.y for p in _particles])}
+
+    def update_information(
+        self, mixing_depth: ndarray, bed_level_change: ndarray, transport_probability: ndarray, bed_level: ndarray
+    ) -> None:
+        """
+        Updates field data information for particles in the population.
+        Parameters
+        ----------
+        mixing_depth : ndarray
+            The mixing depth of the flow field.
+        bed_level_change : ndarray
+            The change in bed level of the flow field.
+        transport_probability : ndarray
+            The probability of particle transport in the flow field.
+        bed_level : ndarray
+            The bed level of the flow field.
+        """
+
+        if not np.isnan(mixing_depth).all():
+            # add key 'mixing_depth' to the particles dictionary
+            self.particles['mixing_depth'] = self._field_interpolator(
+                mixing_depth, self.particles['x'], self.particles['y']
+            )
+        if not np.isnan(bed_level_change).all():
+            # add ke 'bed_level_change' to the particles dictionary
+            self.particles['bed_level_change'] = self._field_interpolator(
+                bed_level_change, self.particles['x'], self.particles['y']
+            )
+
+        if not np.isnan(transport_probability).all():
+            """
+            vaulues between 0 and 1"""
+            # add key 'transport_probability' to the particles dictionary
+            self.particles['transport_probability'] = self._field_interpolator(
+                transport_probability, self.particles['x'], self.particles['y']
+            )
+
+        if not np.isnan(bed_level).all():
+            # add key 'bed_level' to the particles dictionary
+            self.particles['bed_level'] = self._field_interpolator(bed_level, self.particles['x'], self.particles['y'])
+
+    def update_burial_depth(self) -> None:
+        """Updates the burial depth of particles in the population.
+        This method is a placeholder and should be implemented with the actual logic for updating burial depth.
+        Currently, it does not perform any operations.
+        """
+        pass
+        # TODO: implement the actual logic for updating burial depth
+
+    def update_status(self) -> None:
+        """
+        updates status of particles in the population.
+        """
+        n_particles = len(self.particles['x'])
+
+        # Computer whether particles are picked up based on transport probability
+        self.particles['is_picked_up'] = np.random.rand(n_particles) < self.particles['transport_probability']
+
+        # TODO: implement the actual logic for determining the status of particles
+        self.particles['is_inside'] = np.ones(n_particles, dtype=bool)
+        self.particles['is_alive'] = np.ones(n_particles, dtype=bool)
+        self.particles['is_exposed'] = np.ones(n_particles, dtype=bool)
+        self.particles['is_released'] = np.ones(n_particles, dtype=bool)
+
+        self.particles['is_mobile'] = (
+            self.particles['is_inside']
+            & self.particles['is_alive']
+            & self.particles['is_exposed']
+            & self.particles['is_released']
+        )
+
+    def update_position(self, flow_field: Dict, current_timestep: float) -> None:
+        """
+        Update the position of particles in the population based on the flow field.
+
+        Parameters
+        ----------
+        flow_field : Dict
+            A dictionary containing the flow field information.
+        current_timestep : float
+            The current time step in the simulation in seconds.
+        """
+
+        ix = self.particles['is_mobile']  # Get indices of mobile particles
+
+        n_particles = len(self.particles['x'])
+        dx = np.zeros(n_particles)
+        dy = np.zeros(n_particles)
+
+        new_x, new_y = self._position_calculator(
+            self.particles['x'][ix],
+            self.particles['y'][ix],
+            flow_field['u'],
+            flow_field['v'],
+            current_timestep,
+        )
+
+        dx[ix] = new_x - self.particles['x'][ix]
+        dy[ix] = new_y - self.particles['y'][ix]
+
+        self.particles['x'][ix] = new_x
+        self.particles['y'][ix] = new_y

--- a/tests/particle_tracer/test_population.py
+++ b/tests/particle_tracer/test_population.py
@@ -1,0 +1,36 @@
+"""
+Tests for the population.py module in the sedtrails package.
+"""
+
+import pytest
+from sedtrails.particle_tracer import PopulationConfig, ParticlePopulation
+import numpy as np
+
+
+@pytest.fixture
+def population_config():
+    return PopulationConfig(
+        {
+            'population': {
+                'particle_type': 'sand',
+                'seeding': {
+                    'strategy': {'random': {'bbox': '1.0,2.0, 3.0,4.0', 'nlocations': 2, 'seed': 42}},
+                    'quantity': 5,
+                    'release_start': '2025-06-18 13:00:00',
+                },
+            }
+        }
+    )
+
+
+class TestParticlePopulation:
+    def test_create_population(self, population_config):
+        """Test creating a ParticlePopulation with a valid configuration."""
+        population = ParticlePopulation(
+            field_x=np.array([0.0, 1.0, 2.5, 5.0]),
+            field_y=np.array([0.0, 1.0, 2.0, 3.0]),
+            population_config=population_config,
+        )
+        assert population is not None
+        assert len(population.particles['x']) == 10  # 2 nlocations * 5 quantity
+        assert len(population.particles['y']) == 10  # 2 nlocations * 5 quantity


### PR DESCRIPTION
This RP introduces a `ParticlePopulation` class to handle particle operations. 

Other changes:
- Fix bug in random seeding strategy
- Rename SeedingConfig
- Unit tests for ParticlePopulation

Particle Population example:

```python
from sedtrails.particle_tracer import PopulationConfig

# Example usage of the ParticleFactory  to create population of particles
config_random = PopulationConfig(
    {
        'population': {
            'particle_type': 'sand',
            'seeding': {
                'strategy': {'random': {'bbox': '1.0,2.0, 3.0,4.0', 'nlocations': 1, 'seed': 42}},
                'quantity': 2,
                'release_start': '2025-06-18 13:00:00',
            },
        }
    }
)


from sedtrails.particle_tracer import ParticlePopulation
import numpy as np

population = ParticlePopulation(
    field_x=np.array([0.0, 1.0, 2.5, 5.0]),
    field_y=np.array([0.0, 1.0, 2.0, 3.0]),
    population_config=config_random,
)
```