### PR TITLE
Add timestep and grid metadata to SedtrailsMetadata class

### DIFF
--- a/src/sedtrails/transport_converter/plugins/format/fm_netcdf.py
+++ b/src/sedtrails/transport_converter/plugins/format/fm_netcdf.py
@@ -3,8 +3,6 @@
 import xugrid as xu
 import xarray as xr
 import numpy as np
-from scipy.spatial.distance import pdist
-from scipy.spatial import ConvexHull
 from sedtrails.transport_converter.plugins import BaseFormatPlugin
 from sedtrails.transport_converter.sedtrails_data import SedtrailsData
 from sedtrails.transport_converter.sedtrails_metadata import SedtrailsMetadata
@@ -62,36 +60,6 @@ class FormatPlugin(BaseFormatPlugin):
                 print(f'Variables in {self.input_file}:')
 
         return self._input_variables
-
-    def _compute_grid_metadata(self, x: np.ndarray, y: np.ndarray) -> Dict[str, Any]:
-        """
-        Compute grid metadata: minimum resolution and outer envelope.
-
-        Parameters:
-        -----------
-        x : np.ndarray
-            X-coordinates of grid points
-        y : np.ndarray
-            Y-coordinates of grid points
-
-        Returns:
-        --------
-        Dict
-            Dictionary containing 'min_resolution' and 'outer_envelope'
-        """
-        # Stack coordinates for distance calculations
-        coords = np.column_stack((x.flatten(), y.flatten()))
-
-        # Compute minimum resolution (minimum distance between any two points)
-        distances = pdist(coords)
-        min_resolution = np.min(distances)
-
-        # FIXME: temporary solution!
-        # Compute outer envelope using convex hull
-        hull = ConvexHull(coords)
-        outer_envelope = coords[hull.vertices]
-
-        return {'min_resolution': min_resolution, 'outer_envelope': outer_envelope}
 
     def _decompress_time(self, time_info: Dict) -> Dict:
         """
@@ -161,9 +129,6 @@ class FormatPlugin(BaseFormatPlugin):
         mapped_data = self._map_dfm_variables(time_info, time_start_idx, time_end_idx)
         seconds_since_ref = time_info['seconds_since_reference']
         self.reference_date = time_info['reference_date']
-
-        # Compute grid metadata
-        grid_metadata = self._compute_grid_metadata(mapped_data['x'], mapped_data['y'])
 
         # Calculate magnitudes for vector quantities
         # Flow velocity magnitude

--- a/src/sedtrails/transport_converter/sedtrails_data.py
+++ b/src/sedtrails/transport_converter/sedtrails_data.py
@@ -107,7 +107,7 @@ class SedtrailsData:
             
             # Optional: Add validation
             if timestep <= 0:
-                warnings.warn(f"Calculated timestep is non-positive: {timestep}")
+                warnings.warn(f"Calculated timestep is non-positive: {timestep}", stacklevel=1)
 
             # Check if we have timesteps deviating from the median
             tolerance = 1e-6
@@ -116,7 +116,8 @@ class SedtrailsData:
             
             if len(deviating_indices) > 0:
                 warnings.warn(
-                    f"Found {len(deviating_indices)} timesteps deviating from median ({timestep:.6f}s)"
+                    f"Found {len(deviating_indices)} timesteps deviating from median ({timestep:.6f}s)",
+                    stacklevel=2
                     )                
         
         self.metadata.add('timestep', timestep)


### PR DESCRIPTION
Updated SedtrailsData class to calculate timestep and grid metadata class and update the SedtrailsMetadata attribute.

Closes #285 
Closes #286 

### Relevant files
- `src/sedtrails/transport_converter/sedtrails_data.py`
    - Added `_calculate_timestep()` method. This method validates the timestep (must be non negative) and warns about the timesteps deviating from the median 
    - Added `_compute_grid_metadata()` method (moved from plugin `fm_netcdf.py`)
- `src/sedtrails/transport_converter/plugins/format/fm_netcdf.py`
    - Removed `_compute_grid_metadata()` method and related imports

- New metadata fields available to access
```python
sedtrails_data.metadata.get('timestep')         # seconds
sedtrails_data.metadata.get('min_resolution')   # meters
sedtrails_data.metadata.get('outer_envelope')   # coordinate list
```