### PR TITLE
FIx simulation loop to avoid recreating sedtrails_data unnecessarily

### DIFF
--- a/src/sedtrails/simulation.py
+++ b/src/sedtrails/simulation.py
@@ -272,7 +272,7 @@ class Simulation:
                 # Avoid recreating SedTRAILS data if current time is before the first time step
                 if current_time_seconds < sedtrails_data.times[0]:
                     timer.advance()
-                    pass
+                    continue
                 # Convert to SedTRAILS format
                 sedtrails_data = self.format_converter.convert_to_sedtrails(
                     current_time=current_time_seconds, reading_interval=simulation_time.read_input_timestep.seconds

--- a/src/sedtrails/simulation.py
+++ b/src/sedtrails/simulation.py
@@ -267,9 +267,12 @@ class Simulation:
             current_time_seconds = timer.current
             if (
                 sedtrails_data is None
-                or current_time_seconds < sedtrails_data.times[0]
                 or current_time_seconds > sedtrails_data.times[-2]
             ):
+                # Avoid recreating SedTRAILS data if current time is before the first time step
+                if current_time_seconds < sedtrails_data.times[0]:
+                    timer.advance()
+                    pass
                 # Convert to SedTRAILS format
                 sedtrails_data = self.format_converter.convert_to_sedtrails(
                     current_time=current_time_seconds, reading_interval=simulation_time.read_input_timestep.seconds


### PR DESCRIPTION
A quick fix to the simulation time loop so we avoid recreating the `sedtrails_data` and converting multiple times from scratch before the simulation has started. 

Closes #304 

https://github.com/aysunrhn/sedtrails/blob/0d2c0a480db73c855eab5ec78966098f41010621/src/sedtrails/simulation.py#L266-L275

```python
            # Check if current time is within loaded SedTRAILS data
            current_time_seconds = timer.current
            if (
                sedtrails_data is None
                or current_time_seconds > sedtrails_data.times[-2]
            ):
                # Avoid recreating SedTRAILS data if current time is before the first time step
                if current_time_seconds < sedtrails_data.times[0]:
                    timer.advance()
                    continue
```