### PR TITLE
Fix logger and output file handling

### DIFF
--- a/src/sedtrails/configuration_interface/configuration_controller.py
+++ b/src/sedtrails/configuration_interface/configuration_controller.py
@@ -9,11 +9,9 @@ and provides configurations to other components.
 from abc import ABC, abstractmethod
 import sys
 import os
-import logging
 
 from sedtrails.configuration_interface.validator import YAMLConfigValidator
 from sedtrails.configuration_interface.find import find_value
-from sedtrails.logger.logger import setup_logging
 from typing import Dict, Any, Optional
 
 class Controller(ABC):
@@ -100,10 +98,6 @@ class ConfigurationController(Controller):
             validator = YAMLConfigValidator()
             self.config_data = validator.validate_yaml(config_file)
 
-            self.init_logging_from_config()
-            logger = logging.getLogger(__name__)
-            logger.info("Configuration loaded")
-
         return None
 
     def get_config(self) -> dict:
@@ -150,17 +144,3 @@ class ConfigurationController(Controller):
         config_data = deepcopy(self.get_config())
 
         return find_value(config_data, keys, default)
-
-    def init_logging_from_config(self) -> None:
-        """Initialize global logging using settings from config."""
-        output_dir = (
-            self.get('outputs.directory')
-            or self.get('folder_settings.output_dir')
-            or 'results'
-        )
-        log_level = (
-            self.get('outputs.log_level')
-            or self.get('folder_settings.log_level')
-            or 'INFO'
-        )
-        setup_logging(output_dir=output_dir, level=log_level)

--- a/src/sedtrails/data_manager/manager.py
+++ b/src/sedtrails/data_manager/manager.py
@@ -42,11 +42,11 @@ class DataManager:
         file_counter : int
             Counter for naming output files uniquely.
         """
-
-        self.output_dir = output_dir
+        
         self.data_buffer = SimulationDataBuffer()
         self.memory_manager = MemoryManager(max_bytes=max_bytes)
         self.writer = NetCDFWriter(output_dir)
+        self.output_dir = self.writer.output_dir # Make sure we are using the same results directory
         self._mesh_info = None
         self.file_counter = 0
 

--- a/src/sedtrails/logger/__init__.py
+++ b/src/sedtrails/logger/__init__.py
@@ -1,5 +1,0 @@
-from .logger import LoggerManager
-
-__all__ = [
-            "LoggerManager"
-           ]

--- a/src/sedtrails/logger/logger.py
+++ b/src/sedtrails/logger/logger.py
@@ -3,254 +3,278 @@ SedTRAILS Logger
 ================
 A global logger for the SedTRAILS Particle Tracer System.
 """
-
 import logging
 import os
+import sys
 
-class LoggerManager:
-    def __init__(self, log_dir: str = "logs"):
-        self.logger = None
-        self.log_dir = log_dir
+# Use this in modules:
+#   import logging
+#   logger = logging.getLogger(__name__)
+
+def setup_logging(output_dir: str, level: str = "INFO") -> logging.Logger:
+    """
+    Configure global logging.
+    - Attaches handlers to the top-level 'sedtrails' logger
+    - Detects prior setup by checking handler markers
+    - Captures warnings and installs a global exception hook
+    """
+    os.makedirs(output_dir, exist_ok=True)
+    logfile = os.path.join(output_dir, "log.txt")
+
+    logger = logging.getLogger("sedtrails")
+
+    # If our handlers are already present, skip reconfiguration
+    if any(getattr(h, "is_sedtrails_handler", False) for h in logger.handlers):
+        return logger
+
+    # Configure the 'sedtrails' logger (parents: sedtrails.* module loggers)
+    numeric_level = getattr(logging, level.upper(), logging.INFO)
+    logger.setLevel(numeric_level)
+
+    formatter = logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+
+    # File handler
+    file_handler = logging.FileHandler(logfile)
+    file_handler.setLevel(numeric_level)
+    file_handler.setFormatter(formatter)
+    file_handler.is_sedtrails_handler = True  # marker to prevent duplicates
+    logger.addHandler(file_handler)
+
+    console_handler = logging.StreamHandler(stream=sys.stdout)
+    console_handler.setLevel(numeric_level)
+    console_handler.setFormatter(formatter)
+    console_handler.is_sedtrails_handler = True  # marker to prevent duplicates
+    logger.addHandler(console_handler)
+
+    # Prevent propagation to root logger
+    logger.propagate = False
     
-    def setup_logger(self):
-        """Set up the logger"""
-        if self.logger is not None:
-            return self.logger
+    # Install a global exception hook
+    install_global_excepthook(logger)
 
-        # Check if logs directory exists; raise error if not
-        if not os.path.isdir(self.log_dir):
-            raise FileNotFoundError(f"Log directory does not exist: {self.log_dir}")
+    logger.info("=== LOGGING INITIALIZED ===")
+    logger.info(f"Log file: {os.path.abspath(logfile)}")
+    return logger
 
 
-        # Simple log file name
-        log_filename = os.path.join(self.log_dir, 'log.txt')
+def install_global_excepthook(logger: logging.Logger) -> None:
+    """
+    Install an excepthook that logs unhandled exceptions.
+    Avoids globals by tagging the hook function itself.
+    """
+    # If our hook is already installed, skip
+    if getattr(sys.excepthook, "_sedtrails_excepthook", False):
+        return
 
-        # Create logger directly (avoid basicConfig)
-        self.logger = logging.getLogger('simulation_logger')
+    def _hook(exc_type, exc_value, exc_tb):
+        if issubclass(exc_type, KeyboardInterrupt):
+            sys.__excepthook__(exc_type, exc_value, exc_tb)
+            return
+        logger.exception("Unhandled exception", exc_info=(exc_type, exc_value, exc_tb))
+        # Call original hook (prints trace if configured elsewhere)
+        sys.__excepthook__(exc_type, exc_value, exc_tb)
 
-        # Only configure if not already configured
-        if not self.logger.handlers:
-            # Set logging level
-            self.logger.setLevel(logging.DEBUG)
+    _hook._sedtrails_excepthook = True  # tag for idempotency
+    sys.excepthook = _hook
 
-            # Create formatter
-            formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
 
-            # Create file handler
-            file_handler = logging.FileHandler(log_filename)
-            file_handler.setLevel(logging.DEBUG)
-            file_handler.setFormatter(formatter)
+def get_logger(name: str | None = None) -> logging.Logger:
+    """
+    Get a logger. Prefer logging.getLogger(__name__) in modules so logs
+    propagate to the 'sedtrails' logger configured above.
+    """
+    return logging.getLogger(name or "sedtrails")
 
-            # Create console handler
-            console_handler = logging.StreamHandler()
-            console_handler.setLevel(logging.INFO)
-            console_handler.setFormatter(formatter)
-
-            # Add handlers to logger
-            self.logger.addHandler(file_handler)
-            self.logger.addHandler(console_handler)
-
-            # Prevent propagation to root logger
-            self.logger.propagate = False
-
-            # Log the file location immediately
-            absolute_path = os.path.abspath(log_filename)
-            self.logger.info('=== LOGGING INITIALIZED ===')
-            self.logger.info(f'Log file: {os.path.basename(absolute_path)}')
-            self.logger.info(f'Location: {os.path.dirname(absolute_path)}')
-
-        return self.logger
-
-    def log_simulation_state(self, state: dict, level=logging.INFO) -> None:
-        """
-        Logs the current state of the simulation with human-readable sentences.
-        Long messages are split into multiple lines for readability.
-        """    
-        status = state.get('status', state.get('state', 'unknown'))
+def log_simulation_state(logger: logging.Logger, state: dict, level=logging.INFO) -> None:
+    """
+    Logs the current state of the simulation with human-readable sentences.
+    Long messages are split into multiple lines for readability.
+    """    
+    status = state.get('status', state.get('state', 'unknown'))
+    
+    # Create messages, split when necessary
+    if status == 'simulation_started':
+        command = state.get('command', 'unknown')
+        config = state.get('config_file', 'unknown')
+        python_ver = state.get('python_version', 'unknown')
+        working_dir = state.get('working_directory', 'unknown')
         
-        # Create messages, split when necessary
-        if status == 'simulation_started':
-            command = state.get('command', 'unknown')
-            config = state.get('config_file', 'unknown')
-            python_ver = state.get('python_version', 'unknown')
-            working_dir = state.get('working_directory', 'unknown')
+        # Split into multiple log lines
+        logger.log(level, "=== SIMULATION START ===")
+        logger.log(level, f"Command: {command}")
+        logger.log(level, f"Python: {python_ver}")
+        logger.log(level, f"Config: {config}")
+        logger.log(level, f"Working directory: {working_dir}")
+        
+    elif status == 'config_loading':
+        config_path = state.get('config_file_path', 'unknown')
+        logger.log(level, f"Loading configuration: {config_path}")
+        
+    elif status == 'simulation_parameters':
+        duration = state.get('duration', 'unknown')
+        timestep = state.get('timestep', 'unknown')
+        start_time = state.get('start_time', 'unknown')
+        strategy = state.get('seeding_strategy', 'unknown')
+        output_dir = state.get('output_dir', 'unknown')
+        
+        # Format seeding strategy for readability
+        formatted_strategy = _format_seeding_strategy(strategy)
+        
+        # Split parameters into multiple lines
+        logger.log(level, "--- Simulation Parameters ---")
+        logger.log(level, f"Duration: {duration}")
+        logger.log(level, f"Time step: {timestep}")
+        logger.log(level, f"Start time: {start_time}")
+        logger.log(level, f"Seeding: {formatted_strategy}")
+        logger.log(level, f"Output directory: {output_dir}")
+        
+    elif status == 'particles_created' or status == 'particles_initialized':
+        count = state.get('count', 1)
+        position = state.get('start_position', state.get('position', 'unknown'))
+        seeding_strategy = state.get('seeding_strategy', {})
+        
+        logger.log(level, f"Created {count} particle(s)")
+        logger.log(level, f"Starting position: {position}")
+        
+        # Format seeding strategy if provided
+        if seeding_strategy and seeding_strategy != {}:
+            formatted_strategy = _format_seeding_strategy(seeding_strategy)
+            logger.log(level, f"Seeding method: {formatted_strategy}")
             
-            # Split into multiple log lines
-            self.logger.log(level, "=== SIMULATION START ===")
-            self.logger.log(level, f"Command: {command}")
-            self.logger.log(level, f"Python: {python_ver}")
-            self.logger.log(level, f"Config: {config}")
-            self.logger.log(level, f"Working directory: {working_dir}")
+    elif status == 'data_conversion_completed':
+        timesteps = state.get('num_timesteps', 'unknown')
+        field_name = state.get('flow_field_name', 'unknown')
+        duration = state.get('simulation_duration_seconds', 'unknown')
+        timestep = state.get('simulation_timestep_seconds', 'unknown')
+        
+        logger.log(level, "--- Data Conversion Complete ---")
+        logger.log(level, f"Timesteps: {timesteps}")
+        logger.log(level, f"Flow field: {field_name}")
+        logger.log(level, f"Duration: {duration}s")
+        logger.log(level, f"Time step: {timestep}s")
+        
+    elif status == 'numba_compilation_started':
+        grid_x = state.get('grid_size_x', 'unknown')
+        grid_y = state.get('grid_size_y', 'unknown')
+        logger.log(level, f"Compiling calculator for {grid_x}x{grid_y} grid")
+        
+    elif status == 'compilation_complete':
+        time_sec = state.get('time_sec', 'unknown')
+        logger.log(level, f"Calculator compiled in {time_sec} seconds")
+        
+    elif status == 'warmup_complete':
+        time_sec = state.get('time_sec', 'unknown')
+        logger.log(level, f"JIT warmed up in {time_sec} seconds")
+        
+    elif status == 'simulation_progress':
+        progress = state.get('progress_pct', 0)
+        step = state.get('step', 0)
+        position = state.get('position', 'unknown')
+        logger.log(level, f"Progress: {progress}% (step {step}) at {position}")
+        
+    elif status == 'simulation_complete' or status == 'simulation_completed':
+        steps = state.get('total_steps', 'unknown')
+        time_sec = state.get('total_time_sec', 'unknown')
+        final_pos = state.get('final_position', 'unknown')
+        
+        logger.log(level, "=== SIMULATION COMPLETE ===")
+        logger.log(level, f"Total steps: {steps}")
+        logger.log(level, f"Runtime: {time_sec}s")
+        logger.log(level, f"Final position: {final_pos}")
+        
+    elif status == 'visualization_saved':
+        filename = state.get('file', 'trajectory plot')
+        output_path = state.get('output_plot_path', 'unknown')
+        
+        logger.log(level, f"Visualization saved: {filename}")
+        if output_path != 'unknown':
+            logger.log(level, f"Location: {output_path}")
             
-        elif status == 'config_loading':
-            config_path = state.get('config_file_path', 'unknown')
-            self.logger.log(level, f"Loading configuration: {config_path}")
-            
-        elif status == 'simulation_parameters':
-            duration = state.get('duration', 'unknown')
-            timestep = state.get('timestep', 'unknown')
-            start_time = state.get('start_time', 'unknown')
-            strategy = state.get('seeding_strategy', 'unknown')
-            output_dir = state.get('output_dir', 'unknown')
-            
-            # Format seeding strategy for readability
-            formatted_strategy = self._format_seeding_strategy(strategy)
-            
-            # Split parameters into multiple lines
-            self.logger.log(level, "--- Simulation Parameters ---")
-            self.logger.log(level, f"Duration: {duration}")
-            self.logger.log(level, f"Time step: {timestep}")
-            self.logger.log(level, f"Start time: {start_time}")
-            self.logger.log(level, f"Seeding: {formatted_strategy}")
-            self.logger.log(level, f"Output directory: {output_dir}")
-            
-        elif status == 'particles_created' or status == 'particles_initialized':
-            count = state.get('count', 1)
-            position = state.get('start_position', state.get('position', 'unknown'))
-            seeding_strategy = state.get('seeding_strategy', {})
-            
-            self.logger.log(level, f"Created {count} particle(s)")
-            self.logger.log(level, f"Starting position: {position}")
-            
-            # Format seeding strategy if provided
-            if seeding_strategy and seeding_strategy != {}:
-                formatted_strategy = self._format_seeding_strategy(seeding_strategy)
-                self.logger.log(level, f"Seeding method: {formatted_strategy}")
-                
-        elif status == 'data_conversion_completed':
-            timesteps = state.get('num_timesteps', 'unknown')
-            field_name = state.get('flow_field_name', 'unknown')
-            duration = state.get('simulation_duration_seconds', 'unknown')
-            timestep = state.get('simulation_timestep_seconds', 'unknown')
-            
-            self.logger.log(level, "--- Data Conversion Complete ---")
-            self.logger.log(level, f"Timesteps: {timesteps}")
-            self.logger.log(level, f"Flow field: {field_name}")
-            self.logger.log(level, f"Duration: {duration}s")
-            self.logger.log(level, f"Time step: {timestep}s")
-            
-        elif status == 'numba_compilation_started':
-            grid_x = state.get('grid_size_x', 'unknown')
-            grid_y = state.get('grid_size_y', 'unknown')
-            self.logger.log(level, f"Compiling calculator for {grid_x}x{grid_y} grid")
-            
-        elif status == 'compilation_complete':
-            time_sec = state.get('time_sec', 'unknown')
-            self.logger.log(level, f"Calculator compiled in {time_sec} seconds")
-            
-        elif status == 'warmup_complete':
-            time_sec = state.get('time_sec', 'unknown')
-            self.logger.log(level, f"JIT warmed up in {time_sec} seconds")
-            
-        elif status == 'simulation_progress':
-            progress = state.get('progress_pct', 0)
-            step = state.get('step', 0)
-            position = state.get('position', 'unknown')
-            self.logger.log(level, f"Progress: {progress}% (step {step}) at {position}")
-            
-        elif status == 'simulation_complete' or status == 'simulation_completed':
-            steps = state.get('total_steps', 'unknown')
-            time_sec = state.get('total_time_sec', 'unknown')
-            final_pos = state.get('final_position', 'unknown')
-            
-            self.logger.log(level, "=== SIMULATION COMPLETE ===")
-            self.logger.log(level, f"Total steps: {steps}")
-            self.logger.log(level, f"Runtime: {time_sec}s")
-            self.logger.log(level, f"Final position: {final_pos}")
-            
-        elif status == 'visualization_saved':
-            filename = state.get('file', 'trajectory plot')
-            output_path = state.get('output_plot_path', 'unknown')
-            
-            self.logger.log(level, f"Visualization saved: {filename}")
-            if output_path != 'unknown':
-                self.logger.log(level, f"Location: {output_path}")
-                
-        elif status == 'creating_visualization':
-            points = state.get('trajectory_points', 'unknown')
-            self.logger.log(level, f"Creating visualization with {points} trajectory points")
+    elif status == 'creating_visualization':
+        points = state.get('trajectory_points', 'unknown')
+        logger.log(level, f"Creating visualization with {points} trajectory points")
 
-        elif status == 'simulation_failed':
-            error_type = state.get('error_type', 'unknown')
-            error_message = state.get('error_message', 'unknown')
-            
-            self.logger.log(level, "=== SIMULATION FAILED ===")
-            self.logger.log(level, f"Error type: {error_type}")
-            self.logger.log(level, f"Error message: {error_message}")
-            self.logger.log(level, "Check log above for full stack trace")
-            
-        else:
-            # Fallback for unmapped states
-            clean_status = status.replace('_', ' ').title()
-            self.logger.log(level, f"Status: {clean_status}")
-            
-            # Log each parameter on separate line if many parameters
-            params = {k: v for k, v in state.items() if k not in ['status', 'state']}
-            if len(params) > 3:  # If more than 3 params, split them
-                for k, v in params.items():
-                    self.logger.log(level, f"  {k}: {v}")
-            elif params:  # If 3 or fewer, keep on one line
-                param_str = ', '.join(f"{k}: {v}" for k, v in params.items())
-                self.logger.log(level, f"  {param_str}")
+    elif status == 'simulation_failed':
+        error_type = state.get('error_type', 'unknown')
+        error_message = state.get('error_message', 'unknown')
+        
+        logger.log(level, "=== SIMULATION FAILED ===")
+        logger.log(level, f"Error type: {error_type}")
+        logger.log(level, f"Error message: {error_message}")
+        logger.log(level, "Check log above for full stack trace")
+        
+    else:
+        # Fallback for unmapped states
+        clean_status = status.replace('_', ' ').title()
+        logger.log(level, f"Status: {clean_status}")
+        
+        # Log each parameter on separate line if many parameters
+        params = {k: v for k, v in state.items() if k not in ['status', 'state']}
+        if len(params) > 3:  # If more than 3 params, split them
+            for k, v in params.items():
+                logger.log(level, f"  {k}: {v}")
+        elif params:  # If 3 or fewer, keep on one line
+            param_str = ', '.join(f"{k}: {v}" for k, v in params.items())
+            logger.log(level, f"  {param_str}")
 
-    def log_exception(self, e: Exception, context: str = None) -> None:
-        """
-        Logs exceptions with stack trace and context information.
-        
-        Parameters
-        ----------
-        e : Exception
-            The exception that occurred
-        context : str, optional
-            Additional context about where/when the exception occurred
-        """
-        # Log exception with context
-        if context:
-            self.logger.error(f"=== ERROR: {context} ===")
-        else:
-            self.logger.error("=== SIMULATION ERROR ===")
-        
-        self.logger.error(f"Exception type: {type(e).__name__}")
-        self.logger.error(f"Exception message: {str(e)}")
-        self.logger.error("Stack trace:", exc_info=True)
-        self.logger.error("=" * 50)
+def log_exception(logger: logging.Logger, e: Exception, context: str = None) -> None:
+    """
+    Logs exceptions with stack trace and context information.
+    
+    Parameters
+    ----------
+    e : Exception
+        The exception that occurred
+    context : str, optional
+        Additional context about where/when the exception occurred
+    """
+    # Log exception with context
+    if context:
+        logger.error(f"=== ERROR: {context} ===")
+    else:
+        logger.error("=== SIMULATION ERROR ===")
+    
+    logger.error(f"Exception type: {type(e).__name__}")
+    logger.error(f"Exception message: {str(e)}")
+    logger.error("Stack trace:", exc_info=True)
+    logger.error("=" * 50)
 
-    def _format_seeding_strategy(self, strategy):
-        """Helper function to format seeding strategy for readable logging."""
-        if not strategy or strategy == 'unknown':
-            return 'none'
+def _format_seeding_strategy(strategy):
+    """Helper function to format seeding strategy for readable logging."""
+    if not strategy or strategy == 'unknown':
+        return 'none'
+    
+    if isinstance(strategy, str):
+        return strategy
+    
+    if isinstance(strategy, dict):
+        formatted_parts = []
         
-        if isinstance(strategy, str):
-            return strategy
-        
-        if isinstance(strategy, dict):
-            formatted_parts = []
-            
-            for strategy_type, config in strategy.items():
-                if strategy_type == 'point':
-                    points = config.get('points', [])
-                    if isinstance(points, list):
-                        point_count = len(points)
-                        if point_count == 1:
-                            formatted_parts.append(f"single point at {points[0]}")
-                        else:
-                            formatted_parts.append(f"{point_count} points")
+        for strategy_type, config in strategy.items():
+            if strategy_type == 'point':
+                points = config.get('points', [])
+                if isinstance(points, list):
+                    point_count = len(points)
+                    if point_count == 1:
+                        formatted_parts.append(f"single point at {points[0]}")
                     else:
-                        formatted_parts.append("point seeding")
-                
-                elif strategy_type == 'line':
-                    formatted_parts.append("line seeding")
-                
-                elif strategy_type == 'grid':
-                    formatted_parts.append("grid seeding")
-                
-                elif strategy_type == 'random':
-                    count = config.get('count', 'unknown')
-                    formatted_parts.append(f"random ({count} particles)")
-                
+                        formatted_parts.append(f"{point_count} points")
                 else:
-                    formatted_parts.append(f"{strategy_type} seeding")
+                    formatted_parts.append("point seeding")
             
-            return ', '.join(formatted_parts)
+            elif strategy_type == 'line':
+                formatted_parts.append("line seeding")
+            
+            elif strategy_type == 'grid':
+                formatted_parts.append("grid seeding")
+            
+            elif strategy_type == 'random':
+                count = config.get('count', 'unknown')
+                formatted_parts.append(f"random ({count} particles)")
+            
+            else:
+                formatted_parts.append(f"{strategy_type} seeding")
         
-        return str(strategy)
+        return ', '.join(formatted_parts)
+    
+    return str(strategy)

--- a/src/sedtrails/simulation.py
+++ b/src/sedtrails/simulation.py
@@ -12,7 +12,7 @@ from sedtrails.configuration_interface.configuration_controller import Configura
 from sedtrails.data_manager import DataManager
 from sedtrails.particle_tracer.timer import Time, Duration, Timer
 
-from sedtrails.logger.logger import log_simulation_state
+from sedtrails.logger.logger import setup_logging, log_simulation_state
 from sedtrails.exceptions.exceptions import ConfigurationError
 from sedtrails.pathway_visualizer import SimulationDashboard
 # from sedtrails.data_manager.simulation_netcdf_writer import SimulationNetCDFWriter
@@ -70,10 +70,11 @@ class Simulation:
         self.data_manager.set_mesh()  # TODO: was this ever answered? is it needed?
         self.particles: list[Particle] = []  # List to hold particles
         self.dashboard = self._create_dashboard()  #
-        self.writer = None  # TODO:
+        self.writer = self.data_manager.writer
 
-        # Setup global exception handling
-        # setup_global_exception_logging(self.logger_manager)
+        setup_logging(output_dir=self.writer.output_dir) # Initialize logging in the results directory
+        self.logger = logging.getLogger(__name__)
+        self.logger.info("Configuration loaded")
 
     def _create_dashboard(self):
         """Create and return a dashboard instance."""


### PR DESCRIPTION
Added a centralized logging module which is initialized in simulation.py and the logger output is the same as the simulation results output.

Closes #288 #321

- Logger is initialized in``simulation.py` after configuration is loaded.
- Provides a single, global logger (“sedtrails”) usable from any module as:
```python
import logging
logger = logging.getLogger(__name__)
logger.info("Insert your log message here")
```
- Adds a global exception hook so unhandled exceptions are written to the log.
- The structured log messages we use during simulation run are still there and can be accessed via `logger.log_simulation_state`
- The logger initialization comes after DataManger is initialized, which internally initializes NetCDFWriter and creates a new results folder with the timestamp appended if it already exists. This way, the logger is initialized in the correct results folder (which is defined by the NetCDFWriter internally).
