### PR TITLE
Update soulsby.py: Correct grain-velocity multiplication to avoid in-place overwrite and fix Rb values that were previously set to 0.

### DIFF
--- a/src/sedtrails/transport_converter/plugins/physics/soulsby.py
+++ b/src/sedtrails/transport_converter/plugins/physics/soulsby.py
@@ -199,7 +199,7 @@ class PhysicsPlugin(BasePhysicsPlugin):  # all clases should be called the Physi
                     soulsby_R[i][j] = Rb[i][j]
 
         # Compute grain velocities
-        grain_velocity_magnitude = np.multiply(np.multiply(soulsby_P, soulsby_R), flow_velocity_magnitude)  # (Equation 1)
+        grain_velocity_magnitude = soulsby_P * soulsby_R * flow_velocity_magnitude  # (Equation 1)
         grain_velocity_x = np.multiply((flow_velocity_x / flow_velocity_magnitude), grain_velocity_magnitude)
         grain_velocity_y = np.multiply((flow_velocity_y / flow_velocity_magnitude), grain_velocity_magnitude)
 

--- a/src/sedtrails/transport_converter/plugins/physics/soulsby.py
+++ b/src/sedtrails/transport_converter/plugins/physics/soulsby.py
@@ -168,7 +168,7 @@ class PhysicsPlugin(BasePhysicsPlugin):  # all clases should be called the Physi
                     Rb[i][j] = bed_load_velocity[i][j] / flow_velocity_magnitude[i][j]
                     if Rb[i][j] > 1:
                         Rb[i][j] = 1  # apply velocity limiter (grain velocity cannot exceed flow velocity)
-                    else:
+                    elif np.isnan(Rb[i][j]):
                         Rb[i][j] = 0
 
         # VECTORIZE THESE LOOPS!

--- a/src/sedtrails/transport_converter/plugins/physics/soulsby.py
+++ b/src/sedtrails/transport_converter/plugins/physics/soulsby.py
@@ -168,7 +168,7 @@ class PhysicsPlugin(BasePhysicsPlugin):  # all clases should be called the Physi
                     Rb[i][j] = bed_load_velocity[i][j] / flow_velocity_magnitude[i][j]
                     if Rb[i][j] > 1:
                         Rb[i][j] = 1  # apply velocity limiter (grain velocity cannot exceed flow velocity)
-                    elif np.isnan(Rb[i][j]):
+                    elif not np.isfinite(Rb[i][j]):
                         Rb[i][j] = 0
 
         # VECTORIZE THESE LOOPS!

--- a/src/sedtrails/transport_converter/plugins/physics/soulsby.py
+++ b/src/sedtrails/transport_converter/plugins/physics/soulsby.py
@@ -199,7 +199,7 @@ class PhysicsPlugin(BasePhysicsPlugin):  # all clases should be called the Physi
                     soulsby_R[i][j] = Rb[i][j]
 
         # Compute grain velocities
-        grain_velocity_magnitude = np.multiply(soulsby_P, soulsby_R, flow_velocity_magnitude)  # (Equation 1)
+        grain_velocity_magnitude = np.multiply(np.multiply(soulsby_P, soulsby_R), flow_velocity_magnitude)  # (Equation 1)
         grain_velocity_x = np.multiply((flow_velocity_x / flow_velocity_magnitude), grain_velocity_magnitude)
         grain_velocity_y = np.multiply((flow_velocity_y / flow_velocity_magnitude), grain_velocity_magnitude)
 


### PR DESCRIPTION
Previously, grain_velocity_magnitude was computed using:

np.multiply(soulsby_P, soulsby_R, flow_velocity_magnitude)

Because np.multiply interprets the third positional argument as out, this operation overwrote
sedtrails_data.depth_avg_flow_velocity['magnitude'] in place.

This led to unintended changes in the stored flow-velocity magnitudes and caused downstream inconsistencies.

The calculation was updated to np.multiply(np.multiply(soulsby_P, soulsby_R), flow_velocity_magnitude) to ensure no in-place modification occurs.