### PR TITLE
ST-388 fix spatial interpolation

### DIFF
--- a/debug_sedtrails.py
+++ b/debug_sedtrails.py
@@ -32,7 +32,10 @@ def main():
     # config_file = r"C:\surfdrive\650_SedTRAILS\pyTesting\02_soulsby-debugging\008_coarser_hidExp_off\config.example_soulsby.yaml"
     # config_file = r"C:\surf\650_SedTRAILS\pyTesting\02_soulsby-debugging\004_grain-size-test\config.example_soulsby.yaml"
     #  config_file = r'D:\OSS\github_repos\sedtrailsdev\examples\config.example_soulsby.yaml'
-    config_file = r'D:\OSS\github_repos\sedtrailsdev\examples\config.example_sfincs.yaml'
+    # config_file = r'.\examples\config.example_soulsby.yaml'
+    config_file = r'C:\sedtrails\examples\config.example_sfincs.yaml'
+    # config_file = r'.\examples\sedtrails-example.yaml'
+
 
     # Set up logging for verbose output (equivalent to CLI verbose mode)
     logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')

--- a/debug_sedtrails.py
+++ b/debug_sedtrails.py
@@ -31,12 +31,9 @@ def main():
     # config_file = r"C:\surfdrive\650_SedTRAILS\pyTesting\02_soulsby-debugging\007_finer_hidExp_off\config.example_soulsby.yaml"
     # config_file = r"C:\surfdrive\650_SedTRAILS\pyTesting\02_soulsby-debugging\008_coarser_hidExp_off\config.example_soulsby.yaml"
     # config_file = r"C:\surf\650_SedTRAILS\pyTesting\02_soulsby-debugging\004_grain-size-test\config.example_soulsby.yaml"
-    #  config_file = r'D:\OSS\github_repos\sedtrailsdev\examples\config.example_soulsby.yaml'
-    # config_file = r'.\examples\config.example_soulsby.yaml'
-    config_file = r'C:\sedtrails\examples\config.example_sfincs.yaml'
-    # config_file = r'.\examples\sedtrails-example.yaml'
-
-
+    #  config_file = r"C:\surf\650_SedTRAILS\pyTesting\02_soulsby-debugging\009_missingGrainSizeField\config.example_soulsby.yaml"
+    #  config_file = r'.\examples\config.example_sfincs.yaml'
+    config_file = r'.\examples\config.example_soulsby.yaml'
     # Set up logging for verbose output (equivalent to CLI verbose mode)
     logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
@@ -152,13 +149,12 @@ if __name__ == '__main__':
     exit_code = main()
 
     # 2. Test just configuration loading (uncomment to test config only)
-    config_file = r'D:\OSS\github_repos\sedtrailsdev\examples\config.example_soulsby.yaml'
-    #  config = debug_config_loading(config_file=config_file)
-    #  exit_code = 0 if config is not None else 1
+    # config = debug_config_loading()
+    # exit_code = 0 if config is not None else 1
 
     # 3. Test just simulation creation (uncomment to test simulation creation only)
-    #  simulation = debug_simulation_creation(config_file)
-    #  exit_code = 0 if simulation is not None else 1
+    # simulation = debug_simulation_creation()
+    # exit_code = 0 if simulation is not None else 1
 
     # Exit with the appropriate code
     sys.exit(exit_code)

--- a/debug_sedtrails.py
+++ b/debug_sedtrails.py
@@ -14,148 +14,148 @@ This script replicates the behavior of:
     sedtrails run -c U:\\MangroveConnectivity\\pyST\\02_soulsby-debugging\\001_defaults\\config.example_soulsby.yaml
 """
 
-import sys
 import logging
+import sys
 from pathlib import Path
 
 # Add the source directory to the path so we can import sedtrails
 sys.path.insert(0, str(Path(__file__).parent / 'src'))
 
+
 def main():
     """Main debug function that runs the SedTRAILS simulation."""
-    
+
     # Configuration
-    #config_file = r"C:\surfdrive\650_SedTRAILS\pyTesting\02_soulsby-debugging\005_finer\config.example_soulsby.yaml"
-    #config_file = r"C:\surfdrive\650_SedTRAILS\pyTesting\02_soulsby-debugging\006_coarser\config.example_soulsby.yaml"
-    #config_file = r"C:\surfdrive\650_SedTRAILS\pyTesting\02_soulsby-debugging\007_finer_hidExp_off\config.example_soulsby.yaml"
-    #config_file = r"C:\surfdrive\650_SedTRAILS\pyTesting\02_soulsby-debugging\008_coarser_hidExp_off\config.example_soulsby.yaml"
-    #config_file = r"C:\surf\650_SedTRAILS\pyTesting\02_soulsby-debugging\004_grain-size-test\config.example_soulsby.yaml"
-    config_file = r"C:\surf\650_SedTRAILS\pyTesting\02_soulsby-debugging\009_missingGrainSizeField\config.example_soulsby.yaml"
-    
+    # config_file = r"C:\surfdrive\650_SedTRAILS\pyTesting\02_soulsby-debugging\005_finer\config.example_soulsby.yaml"
+    # config_file = r"C:\surfdrive\650_SedTRAILS\pyTesting\02_soulsby-debugging\006_coarser\config.example_soulsby.yaml"
+    # config_file = r"C:\surfdrive\650_SedTRAILS\pyTesting\02_soulsby-debugging\007_finer_hidExp_off\config.example_soulsby.yaml"
+    # config_file = r"C:\surfdrive\650_SedTRAILS\pyTesting\02_soulsby-debugging\008_coarser_hidExp_off\config.example_soulsby.yaml"
+    # config_file = r"C:\surf\650_SedTRAILS\pyTesting\02_soulsby-debugging\004_grain-size-test\config.example_soulsby.yaml"
+    #  config_file = r'D:\OSS\github_repos\sedtrailsdev\examples\config.example_soulsby.yaml'
+    config_file = r'D:\OSS\github_repos\sedtrailsdev\examples\config.example_sfincs.yaml'
+
     # Set up logging for verbose output (equivalent to CLI verbose mode)
-    logging.basicConfig(
-        level=logging.INFO,
-        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-    )
-    
-    print("Debug: Starting SedTRAILS simulation...")
-    print(f"Debug: Configuration file: {config_file}")
-    print(f"Debug: Working directory: {Path.cwd()}")
-    
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+    print('Debug: Starting SedTRAILS simulation...')
+    print(f'Debug: Configuration file: {config_file}')
+    print(f'Debug: Working directory: {Path.cwd()}')
+
     # Check if config file exists
     config_path = Path(config_file)
     if not config_path.exists():
-        print(f"ERROR: Configuration file not found: {config_file}")
+        print(f'ERROR: Configuration file not found: {config_file}')
         return 1
-    
+
     try:
         # Import SedTRAILS (this is where initial import errors might occur)
-        print("Debug: Importing SedTRAILS...")
+        print('Debug: Importing SedTRAILS...')
         import sedtrails
-        print(f"Debug: SedTRAILS version: {sedtrails.__version__}")
-        
+
+        print(f'Debug: SedTRAILS version: {sedtrails.__version__}')
+
         # This is equivalent to what the CLI does:
         # sedtrails.application_interfaces.api.run_simulation(config_file=config_file, verbose=True)
-        print("Debug: Starting simulation...")
-        
+        print('Debug: Starting simulation...')
+
         # You can set a breakpoint here to step into the run_simulation function
-        output_dir = sedtrails.run_simulation(
-            config_file=config_file, 
-            verbose=True
-        )
-        
-        print("Debug: Simulation completed successfully!")
-        print(f"Debug: Results saved to: {output_dir}")
+        output_dir = sedtrails.run_simulation(config_file=config_file, verbose=True)
+
+        print('Debug: Simulation completed successfully!')
+        print(f'Debug: Results saved to: {output_dir}')
         return 0
-        
+
     except ImportError as e:
-        print(f"ERROR: Failed to import SedTRAILS: {e}")
-        print("This might be due to missing dependencies or environment issues.")
+        print(f'ERROR: Failed to import SedTRAILS: {e}')
+        print('This might be due to missing dependencies or environment issues.')
         return 1
-        
+
     except Exception as e:
-        print(f"ERROR: Simulation failed: {e}")
-        print(f"ERROR Type: {type(e).__name__}")
-        
+        print(f'ERROR: Simulation failed: {e}')
+        print(f'ERROR Type: {type(e).__name__}')
+
         # Print the full stack trace for debugging
         import traceback
-        print("\nFull traceback:")
+
+        print('\nFull traceback:')
         traceback.print_exc()
         return 1
 
-def debug_config_loading():
+
+def debug_config_loading(config_file):
     """Debug function to test just the configuration loading part."""
-    
-    config_file = r"C:\surf\650_SedTRAILS\pyTesting\02_soulsby-debugging\005_finer\config.example_soulsby.yaml"
-    
+
     try:
-        print("Debug: Testing configuration loading...")
+        print('Debug: Testing configuration loading...')
         import sedtrails
-        
+
         # Test configuration loading
         config = sedtrails.load_configuration(config_file)
-        print("Debug: Configuration loaded successfully!")
-        print(f"Debug: Config keys: {list(config.keys())}")
-        
+        print('Debug: Configuration loaded successfully!')
+        print(f'Debug: Config keys: {list(config.keys())}')
+
         # Test configuration validation
         is_valid = sedtrails.validate_configuration(config_file)
-        print(f"Debug: Configuration valid: {is_valid}")
-        
+        print(f'Debug: Configuration valid: {is_valid}')
+
         return config
-        
+
     except Exception as e:
-        print(f"ERROR: Configuration loading failed: {e}")
+        print(f'ERROR: Configuration loading failed: {e}')
         import traceback
+
         traceback.print_exc()
         return None
 
-def debug_simulation_creation():
+
+def debug_simulation_creation(config_file):
     """Debug function to test just the simulation object creation."""
-    
-    config_file = r"C:\surf\650_SedTRAILS\pyTesting\02_soulsby-debugging\005_finer\config.example_soulsby.yaml"
-    
+
     try:
-        print("Debug: Testing simulation creation...")
-        
+        print('Debug: Testing simulation creation...')
+
         # Import the Simulation class directly
         from sedtrails.simulation_orchestrator.simulation_manager import Simulation
-        
+
         # Create simulation instance (this is where many issues occur)
-        print("Debug: Creating Simulation instance...")
+        print('Debug: Creating Simulation instance...')
         simulation = Simulation(config_file, enable_dashboard=None)
-        print("Debug: Simulation instance created successfully!")
-        
+        print('Debug: Simulation instance created successfully!')
+
         # You can inspect the simulation object here
-        print(f"Debug: Simulation config loaded: {simulation.config is not None}")
-        print(f"Debug: Data manager created: {simulation.data_manager is not None}")
-        
+        print(f'Debug: Simulation config loaded: {simulation.config is not None}')
+        print(f'Debug: Data manager created: {simulation.data_manager is not None}')
+
         return simulation
-        
+
     except Exception as e:
-        print(f"ERROR: Simulation creation failed: {e}")
+        print(f'ERROR: Simulation creation failed: {e}')
         import traceback
+
         traceback.print_exc()
         return None
 
-if __name__ == "__main__":
+
+if __name__ == '__main__':
     """
     Main entry point for debugging.
     
     You can uncomment different debug functions to test specific parts:
     """
-    
+
     # Uncomment one of these debug functions to test specific parts:
-    
+
     # 1. Full simulation (equivalent to CLI command)
     exit_code = main()
-    
+
     # 2. Test just configuration loading (uncomment to test config only)
-    # config = debug_config_loading()
-    # exit_code = 0 if config is not None else 1
-    
-    # 3. Test just simulation creation (uncomment to test simulation creation only)  
-    # simulation = debug_simulation_creation()
-    # exit_code = 0 if simulation is not None else 1
-    
+    config_file = r'D:\OSS\github_repos\sedtrailsdev\examples\config.example_soulsby.yaml'
+    #  config = debug_config_loading(config_file=config_file)
+    #  exit_code = 0 if config is not None else 1
+
+    # 3. Test just simulation creation (uncomment to test simulation creation only)
+    #  simulation = debug_simulation_creation(config_file)
+    #  exit_code = 0 if simulation is not None else 1
+
     # Exit with the appropriate code
     sys.exit(exit_code)

--- a/examples/config.example_sfincs.yaml
+++ b/examples/config.example_sfincs.yaml
@@ -9,7 +9,7 @@ inputs:
 time:
   start:  2024-05-01 00:00:00
   timestep: 60S
-  duration: 5M
+  duration: 6H
   cfl_condition: 0.7  # CFL condition for adaptive timestep (0 = disabled)
 particles:
   populations:
@@ -37,4 +37,4 @@ outputs:
 visualization:
   dashboard:
     enable: true
-    update_interval: 30S
+    update_interval: 1200S

--- a/examples/config.example_sfincs.yaml
+++ b/examples/config.example_sfincs.yaml
@@ -1,0 +1,40 @@
+general:
+  input_model: 
+    format: sfincs
+    reference_date: 2024-05-01  # Default reference date for the input model
+    morfac: 1  # Morphological acceleration factor for time decompression
+inputs:
+  data: ./sample-data/sfincs_map.nc
+  read_interval: 30M  # Time chunk size for reading input data
+time:
+  start:  2024-05-01 00:00:00
+  timestep: 60S
+  duration: 2H
+  cfl_condition: 0.7  # CFL condition for adaptive timestep (0 = disabled)
+particles:
+  populations:
+    - name: FineSand
+      particle_type: passive
+      tracer_methods: 
+         passive_tracer:
+            flow_field_name: ["depth_avg_flow_velocity"]
+      characteristics:
+        diffusion_coefficient: 0.0
+      transport_probability: no_probability  # Options: no_probability, stochastic_transport, reduced_velocity
+      seeding:
+        release_start: 2024-05-01 00:00:00
+        burial_depth: 
+           constant: 0.0
+        quantity: 1
+        strategy:
+           point: 
+             locations: 
+                - "3.0870e+05,5.8620e+04"
+outputs:
+  #directory: .\results
+  store_tracks: true
+  save_interval: 1H
+visualization:
+  dashboard:
+    enable: true
+    update_interval: 1H

--- a/examples/config.example_sfincs.yaml
+++ b/examples/config.example_sfincs.yaml
@@ -9,7 +9,7 @@ inputs:
 time:
   start:  2024-05-01 00:00:00
   timestep: 60S
-  duration: 2H
+  duration: 5M
   cfl_condition: 0.7  # CFL condition for adaptive timestep (0 = disabled)
 particles:
   populations:
@@ -33,8 +33,8 @@ particles:
 outputs:
   #directory: .\results
   store_tracks: true
-  save_interval: 1H
+  save_interval: 30S
 visualization:
   dashboard:
     enable: true
-    update_interval: 1H
+    update_interval: 30S

--- a/src/sedtrails/application_interfaces/configuration_controller.py
+++ b/src/sedtrails/application_interfaces/configuration_controller.py
@@ -7,9 +7,10 @@ and provides configurations to other components.
 """
 
 from abc import ABC, abstractmethod
-from sedtrails.application_interfaces.validator import YAMLConfigValidator
+from typing import Any, Dict
+
 from sedtrails.application_interfaces.find import find_value
-from typing import Dict, Any
+from sedtrails.application_interfaces.validator import YAMLConfigValidator
 
 
 class Controller(ABC):
@@ -18,7 +19,7 @@ class Controller(ABC):
     """
 
     # TODO: Something to keep in mind in this class:
-    # if we can and it is convenient to have separted methods to retrieve parts of the configuration
+    # if we can and it is convenient to have separated methods to retrieve parts of the configuration
     # that go to the particle tracer and the transport converter. For example, if it is convenient to
     # have a method that returns the configuration values that are only relevant for the particle tracer.
 
@@ -27,7 +28,7 @@ class Controller(ABC):
         """
         Reads the configuration file and applies default values.
         """
-        
+
         pass
 
     @abstractmethod
@@ -35,7 +36,7 @@ class Controller(ABC):
         """
         Returns the current configuration.
         """
-        
+
         pass
 
     @abstractmethod
@@ -53,7 +54,7 @@ class ConfigurationController(Controller):
 
     Attributes
     ----------
-    
+
     config : str
         The path to the configuration file.
     config_data : dict
@@ -65,11 +66,11 @@ class ConfigurationController(Controller):
         Initializes the ConfigurationController with a configuration file.
         Parameters
         ----------
-        
+
         config_file : str
             The path to the configuration file to read.
         """
-        
+
         self.config: str = config_file
         self.config_data = {}
 
@@ -79,7 +80,7 @@ class ConfigurationController(Controller):
 
         Parameters
         ----------
-        
+
         config_file : str
             The path to the configuration file to read.
         """
@@ -99,11 +100,11 @@ class ConfigurationController(Controller):
 
         Returns
         -------
-        
+
         dict
             The current configuration.
         """
-        
+
         if not self.config_data:
             self.load_config(self.config)
 
@@ -115,7 +116,7 @@ class ConfigurationController(Controller):
 
         Parameters
         ----------
-        
+
         key : str
             The dot-separated key to retrieve from the configuration.
         default : any, optional
@@ -123,13 +124,13 @@ class ConfigurationController(Controller):
 
         Returns
         -------
-        
+
         any
             The value associated with the key or the default value. None if the key is not found.
 
         Example
         --------
-        
+
         >>> controller = ConfigurationController()
         >>> controller.read_config('path/to/config.yaml')
         >>> value = controller.get('some.nested.key')

--- a/src/sedtrails/application_interfaces/validator.py
+++ b/src/sedtrails/application_interfaces/validator.py
@@ -1,11 +1,12 @@
+import json
+from importlib.resources import files
+from pathlib import Path
+from typing import Any, Dict, Optional
+
 import jsonschema
 import yaml
-import json
-from typing import Any, Dict, Optional
-from sedtrails.exceptions import YamlParsingError, YamlOutputError, YamlValidationError
-from pathlib import Path
-from importlib.resources import files
 
+from sedtrails.exceptions import YamlOutputError, YamlParsingError, YamlValidationError
 
 # Schema file names (will be resolved using importlib.resources or pkg_resources)
 ROOT_SCHEMA = 'main.schema.json'
@@ -20,7 +21,7 @@ class SedtrailsYamlLoader(yaml.SafeLoader):
     """
     Custom YAML loader that avoids converting datetime strings to datetime objects.
     A custom YAML loader is necessary because default loader always converts datetime strings to datetime objects
-    We want to keey datetime as strings, for convenience convertions are handled internally
+    We want to keep datetime as strings, for convenience conversions are handled internally
     by the SedTRAILS configuration interface"""
 
     pass

--- a/src/sedtrails/config/main.schema.json
+++ b/src/sedtrails/config/main.schema.json
@@ -110,10 +110,11 @@
             "fm_netcdf",
             "d3d4",
             "xbeach",
-            "aeolis"
+            "aeolis",
+            "sfincs"
           ],
           "default": "fm_netcdf",
-          "description": "'fm_netcdf' = D-Flow FM, 'd3d4' = Delft3D-4, 'xbeach' = xbeach, 'aeolis' = aeolis"
+          "description": "'fm_netcdf' = D-Flow FM, 'd3d4' = Delft3D-4, 'xbeach' = xbeach, 'aeolis' = aeolis, 'sfincs' = SFINCS"
         },
         "reference_date": {
           "type": "string",

--- a/src/sedtrails/config/population.schema.json
+++ b/src/sedtrails/config/population.schema.json
@@ -2,8 +2,8 @@
     "$id": "urn:sedtrails:config:population.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema#",
     "type": "object",
-    "title": "Sediment Trails Population Configuration",
-    "description": "Configuration for particle populations in Sediment Trails",
+    "title": "SedTrails Population Configuration",
+    "description": "Configuration for particle populations in SedTrails",
     "unevaluatedProperties": false,
     "$defs": {
         "passive_characteristics": {
@@ -161,6 +161,20 @@
                 }
             },
             "description": "Soulsby method for particle tracking"
+        },
+        "passive_method": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "flow_field_name": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "List of flow field names to use for passive tracer method"
+                }
+            },
+            "description": "Passive tracer method for particle tracking"
         }
     },
     "properties": {
@@ -197,6 +211,9 @@
                 },
                 "soulsby": {
                     "$ref": "#/$defs/soulsby_method"
+                },
+                "passive_tracer": {
+                    "$ref": "#/$defs/passive_method"
                 }
             },
             "minProperties": 1,
@@ -428,7 +445,7 @@
                             "properties": {
                                 "pol_file": {
                                     "type": "string",
-                                    "description": "path to Deltares '.pol' file with bounding polygon for cluster analysis"
+                                    "description": "path to tekal '.pol' file with bounding polygon for cluster analysis"
                                 },
                                 "separation": {
                                     "type": "object",
@@ -463,51 +480,51 @@
                                     "type": "boolean",
                                     "default": false,
                                     "description": "Do you want to save cluster check plots?"
+                                }
+                            },
+                            "oneOf": [
+                                {
+                                    "required": [
+                                        "pol_file"
+                                    ]
                                 },
-                                "oneOf": [
-                                    {
-                                        "required": [
-                                            "pol_file"
-                                        ]
-                                    },
-                                    {
-                                        "required": [
-                                            "separation"
-                                        ]
-                                    }
-                                ]
-                            }
+                                {
+                                    "required": [
+                                        "separation"
+                                    ]
+                                }
+                            ]
                         },
                         "file_points": {
                             "type": "object",
-							"additionalProperties": false,
+							       "additionalProperties": false,
                             "properties": {
-								"path":       { "type": "string", "minLength": 1, "description": "Path to text/CSV/TSV with x,y columns" },
-								"x_col":      { "oneOf": [ { "type": "integer", "minimum": 0 }, { "type": "string", "minLength": 1 } ], "description": "Column index or name for x" },
-								"y_col":      { "oneOf": [ { "type": "integer", "minimum": 0 }, { "type": "string", "minLength": 1 } ], "description": "Column index or name for y" },
-								"has_header": { "type": "boolean", "default": true },
-								"deduplicate":{ "type": "boolean", "default": true },
-								"dropna":     { "type": "boolean", "default": true },
-								"stride":     { "type": "integer", "minimum": 1, "default": 1, "description": "Keep every Nth point" },
-								"bbox": {
-								  "oneOf": [
-									{ "type": "string", "description": "xmin,ymin xmax,ymax (commas/whitespace allowed)" },
-									{
-									  "type": "object",
-									  "additionalProperties": false,
-									  "properties": {
-										"xmin": { "type": "number" },
-										"ymin": { "type": "number" },
-										"xmax": { "type": "number" },
-										"ymax": { "type": "number" }
-									  },
-									  "required": ["xmin","ymin","xmax","ymax"]
-									}
-								  ]
-								}
-							},
-							"required": ["path"]
-						}						
+                                 "path":       { "type": "string", "minLength": 1, "description": "Path to text/CSV/TSV with x,y columns" },
+                                 "x_col":      { "oneOf": [ { "type": "integer", "minimum": 0 }, { "type": "string", "minLength": 1 } ], "description": "Column index or name for x" },
+                                 "y_col":      { "oneOf": [ { "type": "integer", "minimum": 0 }, { "type": "string", "minLength": 1 } ], "description": "Column index or name for y" },
+                                 "has_header": { "type": "boolean", "default": true },
+                                 "deduplicate":{ "type": "boolean", "default": true },
+                                 "dropna":     { "type": "boolean", "default": true },
+                                 "stride":     { "type": "integer", "minimum": 1, "default": 1, "description": "Keep every Nth point" },
+                                 "bbox": {
+                                 "oneOf": [
+                                    { "type": "string", "description": "xmin,ymin xmax,ymax (commas/whitespace allowed)" },
+                                    {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                       "xmin": { "type": "number" },
+                                       "ymin": { "type": "number" },
+                                       "xmax": { "type": "number" },
+                                       "ymax": { "type": "number" }
+                                    },
+                                    "required": ["xmin","ymin","xmax","ymax"]
+                                    }
+                                 ]
+                                 }
+                              },
+                              "required": ["path"]
+                           }
                     },
                     "oneOf": [
                         {

--- a/src/sedtrails/data_manager/xarray_dataset.py
+++ b/src/sedtrails/data_manager/xarray_dataset.py
@@ -151,7 +151,7 @@ def collect_timestep_data(ds, populations, timestep, current_time):
             'status_released', np.ones(num_particles, dtype=int)
         )
         ds['status_mobile'][particle_slice, timestep] = population.particles.get(
-            'status_mobile', np.zeros(num_particles, dtype=int)
+            'is_mobile', population.particles.get('status_mobile', np.zeros(num_particles, dtype=int))
         )
 
         particle_offset += num_particles

--- a/src/sedtrails/particle_tracer/data_retriever.py
+++ b/src/sedtrails/particle_tracer/data_retriever.py
@@ -37,6 +37,7 @@ class FieldDataRetriever:
         """
         self.sedtrails_data = sedtrails_data
         self.fraction_index = fraction_index
+        self._flow_max_cache = {}
 
     def get_interpolation_indices(self, target_time: float) -> Tuple[int, int, float]:
         """
@@ -217,6 +218,87 @@ class FieldDataRetriever:
                 'magnitude': flow_mag,
             }
 
+    def get_flow_field_bounds(self, time: float, flow_field_name: str) -> Dict:
+        """
+        Return lower/upper time slices for a flow field without full-grid interpolation.
+
+        Particle interpolation is linear in the nodal values, so callers with a
+        small number of query points can interpolate each time slice at those
+        points and blend the results by `weight`.
+        """
+        lower_index, upper_index, weight = self.get_interpolation_indices(time)
+        lower_slice = self.sedtrails_data[lower_index]
+
+        if flow_field_name not in lower_slice:
+            raise KeyError(
+                f"Flow field '{flow_field_name}' not found in SedtrailsData. "
+                f'Available fields: {list(lower_slice.keys())}'
+            )
+
+        lower_flow = self._extract_fraction(lower_slice[flow_field_name])
+        if lower_index == upper_index:
+            upper_flow = lower_flow
+        else:
+            upper_slice = self.sedtrails_data[upper_index]
+            if flow_field_name not in upper_slice:
+                raise KeyError(
+                    f"Flow field '{flow_field_name}' not found in SedtrailsData. "
+                    f'Available fields: {list(upper_slice.keys())}'
+                )
+            upper_flow = self._extract_fraction(upper_slice[flow_field_name])
+
+        return {
+            'x': self.sedtrails_data.x,
+            'y': self.sedtrails_data.y,
+            'lower': {
+                'u': lower_flow['x'],
+                'v': lower_flow['y'],
+                'magnitude': lower_flow['magnitude'],
+            },
+            'upper': {
+                'u': upper_flow['x'],
+                'v': upper_flow['y'],
+                'magnitude': upper_flow['magnitude'],
+            },
+            'weight': weight,
+            'lower_index': lower_index,
+            'upper_index': upper_index,
+        }
+
+    def get_flow_max_velocity_bound(self, time: float, flow_field_name: str) -> float:
+        """
+        Return a conservative max velocity bound for CFL without interpolating a full grid.
+
+        The bound is `(1-w) * max(lower) + w * max(upper)`, which is greater
+        than or equal to the exact max of the linearly interpolated magnitude
+        field for `0 <= w <= 1`.
+        """
+        lower_index, upper_index, weight = self.get_interpolation_indices(time)
+        lower_max = self._get_flow_time_slice_max(flow_field_name, lower_index)
+        if lower_index == upper_index:
+            return lower_max
+
+        upper_max = self._get_flow_time_slice_max(flow_field_name, upper_index)
+        return (1.0 - weight) * lower_max + weight * upper_max
+
+    def _get_flow_time_slice_max(self, flow_field_name: str, time_index: int) -> float:
+        cache_key = (flow_field_name, time_index, self.fraction_index)
+        if cache_key in self._flow_max_cache:
+            return self._flow_max_cache[cache_key]
+
+        time_slice = self.sedtrails_data[time_index]
+        if flow_field_name not in time_slice:
+            raise KeyError(
+                f"Flow field '{flow_field_name}' not found in SedtrailsData. "
+                f'Available fields: {list(time_slice.keys())}'
+            )
+
+        flow_field = self._extract_fraction(time_slice[flow_field_name])
+        magnitude = flow_field['magnitude']
+        max_velocity = 0.0 if np.isnan(magnitude).all() else float(np.nanmax(magnitude))
+        self._flow_max_cache[cache_key] = max_velocity
+        return max_velocity
+
     def get_scalar_field(self, time: float, scalar_field_name: str) -> Dict[str, np.ndarray]:
         """
         Get a scalar field and coordinates at the specified time.
@@ -278,6 +360,39 @@ class FieldDataRetriever:
             scalar_interpolated = self._interpolate_linearly(lower_scalar, upper_scalar, weight)
 
             return {'x': self.sedtrails_data.x, 'y': self.sedtrails_data.y, 'magnitude': scalar_interpolated}
+
+    def get_scalar_field_bounds(self, time: float, scalar_field_name: str) -> Dict:
+        """Return lower/upper time slices for a scalar field without full-grid interpolation."""
+        lower_index, upper_index, weight = self.get_interpolation_indices(time)
+        lower_slice = self.sedtrails_data[lower_index]
+
+        if scalar_field_name not in lower_slice:
+            raise KeyError(
+                f"Scalar field '{scalar_field_name}' not found in SedtrailsData. "
+                f'Available fields: {list(lower_slice.keys())}'
+            )
+
+        lower_scalar = self._extract_fraction(lower_slice[scalar_field_name])
+        if lower_index == upper_index:
+            upper_scalar = lower_scalar
+        else:
+            upper_slice = self.sedtrails_data[upper_index]
+            if scalar_field_name not in upper_slice:
+                raise KeyError(
+                    f"Scalar field '{scalar_field_name}' not found in SedtrailsData. "
+                    f'Available fields: {list(upper_slice.keys())}'
+                )
+            upper_scalar = self._extract_fraction(upper_slice[scalar_field_name])
+
+        return {
+            'x': self.sedtrails_data.x,
+            'y': self.sedtrails_data.y,
+            'lower': lower_scalar,
+            'upper': upper_scalar,
+            'weight': weight,
+            'lower_index': lower_index,
+            'upper_index': upper_index,
+        }
 
 
 # Note: The example code has been moved to examples/data_retriever_example.py

--- a/src/sedtrails/particle_tracer/data_retriever.py
+++ b/src/sedtrails/particle_tracer/data_retriever.py
@@ -4,7 +4,9 @@ Field Data Retriever
 Retrieves field data from the transport converter or the simulation caching and state tracker.
 Performs temporal interpolation to provide accurate field data at any time point for particle tracing.
 """
-from typing import Tuple, Dict
+
+from typing import Dict, Tuple
+
 import numpy as np
 
 from sedtrails.transport_converter.format_converter import SedtrailsData
@@ -13,19 +15,19 @@ from sedtrails.transport_converter.format_converter import SedtrailsData
 class FieldDataRetriever:
     """
     Retrieves and interpolates field data from SedtrailsData.
-    
-    This class provides methods to extract both vector fields (flow fields) and scalar fields 
+
+    This class provides methods to extract both vector fields (flow fields) and scalar fields
     at specific times, performing temporal interpolation as needed.
     """
-    
+
     # Constants for interpolation weights
     MIN_WEIGHT = 0.0
     MAX_WEIGHT = 1.0
-    
+
     def __init__(self, sedtrails_data: SedtrailsData, fraction_index: int = 0):
         """
         Initialize the FieldDataRetriever.
-        
+
         Parameters:
         -----------
         sedtrails_data : SedtrailsData
@@ -35,50 +37,50 @@ class FieldDataRetriever:
         """
         self.sedtrails_data = sedtrails_data
         self.fraction_index = fraction_index
-    
+
     def get_interpolation_indices(self, target_time: float) -> Tuple[int, int, float]:
         """
         Get indices for interpolation between two time steps.
-        
+
         Parameters:
         -----------
         target_time : float
             Target time in seconds since reference_date
-            
+
         Returns:
         --------
         Tuple[int, int, float]
             (lower_index, upper_index, weight) where weight is the interpolation factor [0-1]
         """
         times = self.sedtrails_data.times
-        
+
         # Handle edge cases
         if target_time <= times[0]:
             return 0, 0, self.MIN_WEIGHT
-        
+
         if target_time >= times[-1]:
             last_index = len(times) - 1
             return last_index, last_index, self.MAX_WEIGHT
-        
+
         # Find the index of the last time that is less than or equal to the target time
         lower_index = np.searchsorted(times, target_time, side='right') - 1
         upper_index = lower_index + 1
-        
+
         # Calculate the interpolation weight
         time_range = times[upper_index] - times[lower_index]
-        
+
         # Avoid division by zero
         if time_range == 0:
             weight = self.MIN_WEIGHT
         else:
             weight = (target_time - times[lower_index]) / time_range
-            
+
         return lower_index, upper_index, weight
-    
+
     def _interpolate_linearly(self, lower_value: np.ndarray, upper_value: np.ndarray, weight: float) -> np.ndarray:
         """
         Perform linear interpolation between two values.
-        
+
         Parameters:
         -----------
         lower_value : np.ndarray
@@ -87,7 +89,7 @@ class FieldDataRetriever:
             Value at the upper time index
         weight : float
             Interpolation weight (between MIN_WEIGHT and MAX_WEIGHT)
-            
+
         Returns:
         --------
         np.ndarray
@@ -95,16 +97,16 @@ class FieldDataRetriever:
         """
         # Linear interpolation: result = (1-w)*lower + w*upper
         return (1 - weight) * lower_value + weight * upper_value
-    
+
     def _extract_fraction(self, field_data):
         """
         Helper function to handle fraction dimension in field data.
-        
+
         Parameters:
         -----------
         field_data : dict or np.ndarray
             Field data that may contain fraction dimensions
-            
+
         Returns:
         --------
         dict or np.ndarray
@@ -118,17 +120,13 @@ class FieldDataRetriever:
                 return field_data
             elif x_data.shape[0] == 1:
                 # Shape: (1, N) - single fraction, squeeze out the fraction dimension
-                return {
-                    'x': field_data['x'][0],
-                    'y': field_data['y'][0], 
-                    'magnitude': field_data['magnitude'][0]
-                }
+                return {'x': field_data['x'][0], 'y': field_data['y'][0], 'magnitude': field_data['magnitude'][0]}
             else:
                 # Shape: (>1, N) - multiple fractions, select the specified fraction
                 return {
                     'x': field_data['x'][self.fraction_index],
                     'y': field_data['y'][self.fraction_index],
-                    'magnitude': field_data['magnitude'][self.fraction_index]
+                    'magnitude': field_data['magnitude'][self.fraction_index],
                 }
         else:
             # Scalar field case
@@ -141,22 +139,22 @@ class FieldDataRetriever:
             else:
                 # Shape: (>1, N) - multiple fractions, select the specified fraction
                 return field_data[self.fraction_index]
-    
+
     def get_flow_field(self, time: float, flow_field_name: str) -> Dict[str, np.ndarray]:
         """
         Get the flow field and coordinates at the specified time.
-        
+
         This method performs temporal interpolation between the two closest time steps
         in the SedtrailsData object to obtain the flow field at the requested time.
-        
+
         Parameters:
         -----------
         time : float
             Time in seconds since the reference date of the SedtrailsData object
         flow_field_name : str
-            Name of the flow field to retrieve (e.g., 'depth_avg_flow_velocity', 
+            Name of the flow field to retrieve (e.g., 'depth_avg_flow_velocity',
             'bed_load_velocity', 'suspended_velocity')
-            
+
         Returns:
         --------
         Dict[str, np.ndarray]
@@ -169,59 +167,63 @@ class FieldDataRetriever:
         """
         # Get indices for interpolation
         lower_index, upper_index, weight = self.get_interpolation_indices(time)
-            
+
         # If time is exactly at a time step or outside the range, no interpolation needed
         if lower_index == upper_index:
             time_slice = self.sedtrails_data[lower_index]
-            
+
             if flow_field_name not in time_slice:
-                raise KeyError(f"Flow field '{flow_field_name}' not found in SedtrailsData. "
-                             f"Available fields: {list(time_slice.keys())}")
-            
+                raise KeyError(
+                    f"Flow field '{flow_field_name}' not found in SedtrailsData. "
+                    f'Available fields: {list(time_slice.keys())}'
+                )
+
             flow_field = time_slice[flow_field_name]
             flow_field = self._extract_fraction(flow_field)
-            
+
             return {
                 'x': self.sedtrails_data.x,
                 'y': self.sedtrails_data.y,
                 'u': flow_field['x'],
                 'v': flow_field['y'],
-                'magnitude': flow_field['magnitude']
+                'magnitude': flow_field['magnitude'],
             }
         else:
             # Otherwise, perform linear interpolation between the two time steps
             lower_slice = self.sedtrails_data[lower_index]
             upper_slice = self.sedtrails_data[upper_index]
-            
+
             if flow_field_name not in lower_slice or flow_field_name not in upper_slice:
-                raise KeyError(f"Flow field '{flow_field_name}' not found in SedtrailsData. "
-                             f"Available fields: {list(lower_slice.keys())}")
-            
+                raise KeyError(
+                    f"Flow field '{flow_field_name}' not found in SedtrailsData. "
+                    f'Available fields: {list(lower_slice.keys())}'
+                )
+
             lower_flow = lower_slice[flow_field_name]
             upper_flow = upper_slice[flow_field_name]
             lower_flow = self._extract_fraction(lower_flow)
             upper_flow = self._extract_fraction(upper_flow)
-            
+
             # Use the interpolation function for velocity components
             flow_x = self._interpolate_linearly(lower_flow['x'], upper_flow['x'], weight)
             flow_y = self._interpolate_linearly(lower_flow['y'], upper_flow['y'], weight)
             flow_mag = self._interpolate_linearly(lower_flow['magnitude'], upper_flow['magnitude'], weight)
-            
+
             return {
                 'x': self.sedtrails_data.x,
                 'y': self.sedtrails_data.y,
                 'u': flow_x,
                 'v': flow_y,
-                'magnitude': flow_mag
+                'magnitude': flow_mag,
             }
-    
+
     def get_scalar_field(self, time: float, scalar_field_name: str) -> Dict[str, np.ndarray]:
         """
         Get a scalar field and coordinates at the specified time.
-        
+
         This method performs temporal interpolation between the two closest time steps
         in the SedtrailsData object to obtain the scalar field at the requested time.
-        
+
         Parameters:
         -----------
         time : float
@@ -230,7 +232,7 @@ class FieldDataRetriever:
             Name of the scalar field to retrieve (e.g., 'water_depth', 'shields_number',
             'bed_load_layer_thickness', 'suspended_layer_thickness', 'mixing_layer_thickness',
             'mean_bed_shear_stress', 'max_bed_shear_stress', 'sediment_concentration')
-            
+
         Returns:
         --------
         Dict[str, np.ndarray]
@@ -241,47 +243,43 @@ class FieldDataRetriever:
         """
         # Get indices for interpolation
         lower_index, upper_index, weight = self.get_interpolation_indices(time)
-            
+
         # If time is exactly at a time step or outside the range, no interpolation needed
         if lower_index == upper_index:
             time_slice = self.sedtrails_data[lower_index]
-            
+
             if scalar_field_name not in time_slice:
-                raise KeyError(f"Scalar field '{scalar_field_name}' not found in SedtrailsData. "
-                             f"Available fields: {list(time_slice.keys())}")
-            
+                raise KeyError(
+                    f"Scalar field '{scalar_field_name}' not found in SedtrailsData. "
+                    f'Available fields: {list(time_slice.keys())}'
+                )
+
             scalar_field = time_slice[scalar_field_name]
             scalar_field = self._extract_fraction(scalar_field)
-            
-            return {
-                'x': self.sedtrails_data.x,
-                'y': self.sedtrails_data.y,
-                'magnitude': scalar_field
-            }
+
+            return {'x': self.sedtrails_data.x, 'y': self.sedtrails_data.y, 'magnitude': scalar_field}
         else:
             # Otherwise, perform linear interpolation between the two time steps
             lower_slice = self.sedtrails_data[lower_index]
             upper_slice = self.sedtrails_data[upper_index]
-            
+
             if scalar_field_name not in lower_slice or scalar_field_name not in upper_slice:
-                raise KeyError(f"Scalar field '{scalar_field_name}' not found in SedtrailsData. "
-                             f"Available fields: {list(lower_slice.keys())}")
-            
+                raise KeyError(
+                    f"Scalar field '{scalar_field_name}' not found in SedtrailsData. "
+                    f'Available fields: {list(lower_slice.keys())}'
+                )
+
             lower_scalar = lower_slice[scalar_field_name]
             upper_scalar = upper_slice[scalar_field_name]
             lower_scalar = self._extract_fraction(lower_scalar)
             upper_scalar = self._extract_fraction(upper_scalar)
-            
+
             # Use the interpolation function for scalar field
             scalar_interpolated = self._interpolate_linearly(lower_scalar, upper_scalar, weight)
-            
-            return {
-                'x': self.sedtrails_data.x,
-                'y': self.sedtrails_data.y,
-                'magnitude': scalar_interpolated
-            }
+
+            return {'x': self.sedtrails_data.x, 'y': self.sedtrails_data.y, 'magnitude': scalar_interpolated}
 
 
 # Note: The example code has been moved to examples/data_retriever_example.py
-if __name__ == "__main__":
-    print("Please see the examples directory for usage examples.")
+if __name__ == '__main__':
+    print('Please see the examples directory for usage examples.')

--- a/src/sedtrails/particle_tracer/particle_seeder.py
+++ b/src/sedtrails/particle_tracer/particle_seeder.py
@@ -270,6 +270,7 @@ class TransectStrategy(SeedingStrategy):
 
         return seed_locations
 
+
 class FilePointsStrategy(SeedingStrategy):
     """
     Seeding strategy to read (x, y) locations from a file.
@@ -288,6 +289,7 @@ class FilePointsStrategy(SeedingStrategy):
 
     def seed(self, config: PopulationConfig) -> list[Tuple[int, float, float]]:
         import os
+
         import pandas as pd
 
         settings = getattr(config, 'strategy_settings', {})
@@ -333,11 +335,7 @@ class FilePointsStrategy(SeedingStrategy):
 
         # --- Read file, auto-delimiter handling via pandas (engine="python" allows sep=None sniffing)
         try:
-            df = pd.read_csv(
-                path,
-                sep=None, engine="python",
-                header=0 if has_header else None
-            )
+            df = pd.read_csv(path, sep=None, engine='python', header=0 if has_header else None)
         except Exception:
             # Fallback: whitespace-delimited
             df = pd.read_csv(path, delim_whitespace=True, header=0 if has_header else None)
@@ -348,6 +346,7 @@ class FilePointsStrategy(SeedingStrategy):
                 # Convert positional index to actual column name
                 return df.columns[col]
             return col  # assume str
+
         x_name = _resolve_col(x_col, df)
         y_name = _resolve_col(y_col, df)
 
@@ -374,8 +373,11 @@ class FilePointsStrategy(SeedingStrategy):
             raise ValueError('No valid (x, y) points found after filtering.')
 
         # Build seed locations
-        seed_locations = [(quantity, float(x), float(y)) for x, y in zip(df['x'].to_numpy(), df['y'].to_numpy(), strict=True)]
+        seed_locations = [
+            (quantity, float(x), float(y)) for x, y in zip(df['x'].to_numpy(), df['y'].to_numpy(), strict=True)
+        ]
         return seed_locations
+
 
 class ParticleFactory:
     @staticmethod
@@ -413,16 +415,6 @@ class ParticleFactory:
         if strategy_name.lower() not in STRATEGY_MAP:
             raise ValueError(f'Unknown seeding strategy: {strategy_name}')
         StrategyClass = STRATEGY_MAP[strategy_name.lower()]
-        from sedtrails.particle_tracer.particle import Mud, Passive, Sand
-
-        PARTICLE_MAP = {'sand': Sand, 'mud': Mud, 'passive': Passive}
-        STRATEGY_MAP = {
-            'point': PointStrategy(),
-            'random': RandomStrategy(),
-            'grid': GridStrategy(),
-            'transect': TransectStrategy(),
-            'file_points': FilePointsStrategy(),
-        }
 
         # computes seeding positions using the strategy in config
         burial_depth = getattr(config, 'burial_depth', None)
@@ -566,18 +558,18 @@ class ParticlePopulation:
         self.particles['is_inside'] = self._outer_envelope.contains_points(
             np.column_stack((self.particles['x'], self.particles['y']))
         )
-                
+
         # New conditional logic based on transport_probability_method
         if self.population_config.population_config['transport_probability'] == 'no_probability':
             # For no_probability method, all particles are considered exposed (always mobile)
             self.particles['is_exposed'] = np.ones(n_particles, dtype=bool)
         else:
             # For stochastic_transport and reduced_velocity methods, use burial_depth vs mixing_depth
-            
+
             # if van westen method:
             # a particle is considered exposed if it is buried at a shallower depth compared to the mixing depth
             self.particles['is_exposed'] = self.particles['burial_depth'] < self.particles['mixing_depth']
-            
+
             # if soulsby method:
             # self.particles['is_exposed'] = (this is where we implement Soulsby's F based on a and b)
 

--- a/src/sedtrails/particle_tracer/particle_seeder.py
+++ b/src/sedtrails/particle_tracer/particle_seeder.py
@@ -495,6 +495,7 @@ class ParticlePopulation:
         )
 
         self._field_interpolator = numba_functions['interpolate_field']
+        self._field_interpolator_multi = numba_functions['interpolate_fields']
         self._position_calculator = numba_functions['update_particles']
         self._position_calculator_temporal = numba_functions['update_particles_temporal']
 
@@ -541,17 +542,24 @@ class ParticlePopulation:
         if _is_temporal_field(field_value):
             lower_values = np.asarray(field_value['lower'])
             upper_values = np.asarray(field_value['upper'])
-            if lower_values.size == 0 or np.isnan(lower_values).all():
-                if upper_values.size == 0 or np.isnan(upper_values).all():
-                    return
+            if lower_values.size == 0:
+                return
 
-            lower_particle_values = self._field_interpolator(lower_values, self.particles['x'], self.particles['y'])
             weight = field_value['weight']
             if weight <= 0.0 or lower_values is upper_values:
+                lower_particle_values = self._field_interpolator(lower_values, self.particles['x'], self.particles['y'])
+                if np.isnan(lower_particle_values).all():
+                    return
                 self.particles[name] = lower_particle_values
                 return
 
-            upper_particle_values = self._field_interpolator(upper_values, self.particles['x'], self.particles['y'])
+            lower_particle_values, upper_particle_values = self._field_interpolator_multi(
+                (lower_values, upper_values),
+                self.particles['x'],
+                self.particles['y'],
+            )
+            if np.isnan(lower_particle_values).all() and np.isnan(upper_particle_values).all():
+                return
             self.particles[name] = lower_particle_values + weight * (upper_particle_values - lower_particle_values)
             return
 
@@ -560,10 +568,14 @@ class ParticlePopulation:
             return
 
         field_array = np.asarray(field_value)
-        if field_array.size == 0 or np.isnan(field_array).all():
+        if field_array.size == 0:
             return
 
-        self.particles[name] = self._field_interpolator(field_array, self.particles['x'], self.particles['y'])
+        particle_values = self._field_interpolator(field_array, self.particles['x'], self.particles['y'])
+        if np.isnan(particle_values).all():
+            return
+
+        self.particles[name] = particle_values
 
     def update_burial_depth(self) -> None:
         """Updates the burial depth of particles in the population.
@@ -644,10 +656,6 @@ class ParticlePopulation:
 
         ix = self.particles['is_mobile']  # Get indices of mobile particles
 
-        n_particles = len(self.particles['x'])
-        dx = np.zeros(n_particles)
-        dy = np.zeros(n_particles)
-
         if _is_temporal_flow_field(flow_field):
             new_x, new_y = self._position_calculator_temporal(
                 self.particles['x'][ix],
@@ -667,9 +675,6 @@ class ParticlePopulation:
                 flow_field['v'],
                 current_timestep,
             )
-
-        dx[ix] = new_x - self.particles['x'][ix]  # TODO: this should be stored in the netcdf, as part of the flow field
-        dy[ix] = new_y - self.particles['y'][ix]
 
         # TODO: implement Bart's solution for gross/net values here. Add
 

--- a/src/sedtrails/particle_tracer/particle_seeder.py
+++ b/src/sedtrails/particle_tracer/particle_seeder.py
@@ -22,12 +22,11 @@ from typing import Any, Dict, List, Protocol, Tuple, Union
 import numpy as np
 from matplotlib.path import Path
 from numpy import ndarray
-from scipy.spatial import ConvexHull
 
 from sedtrails.application_interfaces.find import find_value
 from sedtrails.exceptions import MissingConfigurationParameter
 from sedtrails.particle_tracer.particle import Particle
-from sedtrails.particle_tracer.position_calculator_numba import create_numba_particle_calculator
+from sedtrails.particle_tracer.position_calculator_numba import create_grid_geometry, create_numba_particle_calculator
 
 
 class HasFieldCoordinates(Protocol):
@@ -468,6 +467,7 @@ class ParticlePopulation:
     field_x: ndarray
     field_y: ndarray
     population_config: PopulationConfig
+    grid_geometry: Any = None
     particles: Dict = field(init=False, default_factory=dict)  # a dictionary with arrays
     _field_interpolator: Any = field(init=False)  # holds a Numba function
     _position_calculator: Any = field(init=False)  # holds a Numba function
@@ -476,8 +476,15 @@ class ParticlePopulation:
     _field_transport_probability: ndarray = field(init=False)  # TODO: we're not using this field yet
 
     def __post_init__(self):
-        # Create a Numba calculator for particle operations
-        numba_functions = create_numba_particle_calculator(grid_x=self.field_x, grid_y=self.field_y)
+        if self.grid_geometry is None:
+            self.grid_geometry = create_grid_geometry(self.field_x, self.field_y)
+
+        # Create calculator callables from shared grid geometry.
+        numba_functions = create_numba_particle_calculator(
+            grid_x=self.field_x,
+            grid_y=self.field_y,
+            grid_geometry=self.grid_geometry,
+        )
 
         self._field_interpolator = numba_functions['interpolate_field']
         self._position_calculator = numba_functions['update_particles']
@@ -491,13 +498,11 @@ class ParticlePopulation:
             'burial_depth': np.array([p.burial_depth for p in _particles]),
         }
 
-        # store the outer envelope of the domain
-        coords = np.column_stack((self.field_x, self.field_y))
-        hull = ConvexHull(coords)
-        self._outer_envelope = Path(coords[hull.vertices])
+        # Store the outer envelope of the domain using shared grid geometry.
+        self._outer_envelope = Path(self.grid_geometry.outer_envelope)
 
     def update_information(
-        self, current_time: Union[int, float], mixing_depth: ndarray, transport_probability: ndarray, bed_level: ndarray
+        self, current_time: Union[int, float], mixing_depth: Any, transport_probability: Any, bed_level: Any
     ) -> None:
         """
         Updates field data information for particles in the population.
@@ -516,19 +521,23 @@ class ParticlePopulation:
 
         self._current_time = current_time
 
-        if not np.isnan(mixing_depth).all():
-            self.particles['mixing_depth'] = self._field_interpolator(
-                mixing_depth, self.particles['x'], self.particles['y']
-            )
+        self._update_particle_field('mixing_depth', mixing_depth)
+        self._update_particle_field('transport_probability', transport_probability)
+        self._update_particle_field('bed_level', bed_level)
 
-        if not np.isnan(transport_probability).all():
-            """values between 0 and 1"""
-            self.particles['transport_probability'] = self._field_interpolator(
-                transport_probability, self.particles['x'], self.particles['y']
-            )
+    def _update_particle_field(self, name: str, field_value) -> None:
+        if field_value is None:
+            return
 
-        if not np.isnan(bed_level).all():
-            self.particles['bed_level'] = self._field_interpolator(bed_level, self.particles['x'], self.particles['y'])
+        if np.isscalar(field_value):
+            self.particles[name] = np.full(len(self.particles['x']), field_value, dtype=float)
+            return
+
+        field_array = np.asarray(field_value)
+        if field_array.size == 0 or np.isnan(field_array).all():
+            return
+
+        self.particles[name] = self._field_interpolator(field_array, self.particles['x'], self.particles['y'])
 
     def update_burial_depth(self) -> None:
         """Updates the burial depth of particles in the population.
@@ -674,9 +683,15 @@ class ParticleSeeder:
             raise ValueError('No population configurations provided for seeding.')
 
         populations = []
+        grid_geometry = create_grid_geometry(sedtrails_data.x, sedtrails_data.y)
         for pop_config in self.population_configs:
             config = PopulationConfig(population_config=pop_config)
-            pop = ParticlePopulation(field_x=sedtrails_data.x, field_y=sedtrails_data.y, population_config=config)
+            pop = ParticlePopulation(
+                field_x=sedtrails_data.x,
+                field_y=sedtrails_data.y,
+                population_config=config,
+                grid_geometry=grid_geometry,
+            )
             populations.append(pop)
         return populations
 

--- a/src/sedtrails/particle_tracer/particle_seeder.py
+++ b/src/sedtrails/particle_tracer/particle_seeder.py
@@ -34,6 +34,14 @@ class HasFieldCoordinates(Protocol):
     y: ndarray
 
 
+def _is_temporal_field(field_value: Any) -> bool:
+    return isinstance(field_value, dict) and {'lower', 'upper', 'weight'}.issubset(field_value)
+
+
+def _is_temporal_flow_field(flow_field: Dict) -> bool:
+    return _is_temporal_field(flow_field) and isinstance(flow_field.get('lower'), dict)
+
+
 @dataclass
 class PopulationConfig:
     """
@@ -488,6 +496,7 @@ class ParticlePopulation:
 
         self._field_interpolator = numba_functions['interpolate_field']
         self._position_calculator = numba_functions['update_particles']
+        self._position_calculator_temporal = numba_functions['update_particles_temporal']
 
         # generate particles based on the configuration
         _particles = ParticleFactory.create_particles(self.population_config)
@@ -527,6 +536,23 @@ class ParticlePopulation:
 
     def _update_particle_field(self, name: str, field_value) -> None:
         if field_value is None:
+            return
+
+        if _is_temporal_field(field_value):
+            lower_values = np.asarray(field_value['lower'])
+            upper_values = np.asarray(field_value['upper'])
+            if lower_values.size == 0 or np.isnan(lower_values).all():
+                if upper_values.size == 0 or np.isnan(upper_values).all():
+                    return
+
+            lower_particle_values = self._field_interpolator(lower_values, self.particles['x'], self.particles['y'])
+            weight = field_value['weight']
+            if weight <= 0.0 or lower_values is upper_values:
+                self.particles[name] = lower_particle_values
+                return
+
+            upper_particle_values = self._field_interpolator(upper_values, self.particles['x'], self.particles['y'])
+            self.particles[name] = lower_particle_values + weight * (upper_particle_values - lower_particle_values)
             return
 
         if np.isscalar(field_value):
@@ -622,13 +648,25 @@ class ParticlePopulation:
         dx = np.zeros(n_particles)
         dy = np.zeros(n_particles)
 
-        new_x, new_y = self._position_calculator(
-            self.particles['x'][ix],
-            self.particles['y'][ix],
-            flow_field['u'],
-            flow_field['v'],
-            current_timestep,
-        )
+        if _is_temporal_flow_field(flow_field):
+            new_x, new_y = self._position_calculator_temporal(
+                self.particles['x'][ix],
+                self.particles['y'][ix],
+                flow_field['lower']['u'],
+                flow_field['lower']['v'],
+                flow_field['upper']['u'],
+                flow_field['upper']['v'],
+                flow_field['weight'],
+                current_timestep,
+            )
+        else:
+            new_x, new_y = self._position_calculator(
+                self.particles['x'][ix],
+                self.particles['y'][ix],
+                flow_field['u'],
+                flow_field['v'],
+                current_timestep,
+            )
 
         dx[ix] = new_x - self.particles['x'][ix]  # TODO: this should be stored in the netcdf, as part of the flow field
         dy[ix] = new_y - self.particles['y'][ix]

--- a/src/sedtrails/particle_tracer/particle_seeder.py
+++ b/src/sedtrails/particle_tracer/particle_seeder.py
@@ -17,7 +17,7 @@ Random: Release particles at random locations (x,y) within an area
 import random
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Protocol, Tuple, Union
 
 import numpy as np
 from matplotlib.path import Path
@@ -28,7 +28,11 @@ from sedtrails.application_interfaces.find import find_value
 from sedtrails.exceptions import MissingConfigurationParameter
 from sedtrails.particle_tracer.particle import Particle
 from sedtrails.particle_tracer.position_calculator_numba import create_numba_particle_calculator
-from sedtrails.transport_converter.sedtrails_data import SedtrailsData
+
+
+class HasFieldCoordinates(Protocol):
+    x: ndarray
+    y: ndarray
 
 
 @dataclass
@@ -645,14 +649,14 @@ class ParticleSeeder:
     def __init__(self, population_configs: List[Dict[str, Any]] | Dict[str, Any]):
         self.population_configs = population_configs
 
-    def seed(self, sedtrails_data: SedtrailsData) -> List[ParticlePopulation]:
+    def seed(self, sedtrails_data: HasFieldCoordinates) -> List[ParticlePopulation]:
         """
         Create particles from a list of population configuration dictionaries.
 
         Parameters
         ----------
-         sedtrails_data : SedtrailsData
-            The SedtrailsData object containing the field data (x, y coordinates).
+         sedtrails_data : HasFieldCoordinates
+            Any object exposing `x` and `y` field coordinate arrays.
 
         Returns
         -------

--- a/src/sedtrails/particle_tracer/particle_seeder.py
+++ b/src/sedtrails/particle_tracer/particle_seeder.py
@@ -26,7 +26,7 @@ from numpy import ndarray
 from sedtrails.application_interfaces.find import find_value
 from sedtrails.exceptions import MissingConfigurationParameter
 from sedtrails.particle_tracer.particle import Particle
-from sedtrails.particle_tracer.position_calculator_numba import create_grid_geometry, create_numba_particle_calculator
+from sedtrails.particle_tracer.position_calculator_numba import create_grid_geometry
 
 
 class HasFieldCoordinates(Protocol):
@@ -460,16 +460,22 @@ class ParticlePopulation:
         Configuration for the particle population, including seeding strategy and parameters.
     particles : Dict
         A dictionary containing particle attributes such as positions and status.
-    _field_interpolator : Dict
-        A dictionary containing Numba functions for interpolating field data.
-    _position_calculator : Dict
-        A dictionary containing Numba functions for calculating particle positions.
+    _field_interpolator : Any
+        Bound method for interpolating one nodal field to particle positions.
+    _field_interpolator_multi : Any
+        Bound method for interpolating multiple nodal fields with one point-location pass.
+    _position_calculator_with_simplex : Any
+        Bound method for advancing particles while reusing cached simplex ids.
+    _position_calculator_temporal_with_simplex : Any
+        Bound method for temporal particle updates while reusing cached simplex ids.
+    _particle_simplices : ndarray
+        Cached containing-triangle ids for each particle, used to avoid global point location on every update.
     _current_time : ndarray
         The current time in the simulation, used for updating particle positions.
     _field_mixing_depth : ndarray
-        The mixing depth of the flow field, used to determine particle behavior.
+        The mixing depth of the flow field, reserved for later particle-behavior logic.
     _field_transport_probability : ndarray
-        The probability of particle transport in the flow field, used to determine if particles are picked up.
+        The probability of particle transport in the flow field, reserved for later pickup logic.
     """
 
     field_x: ndarray
@@ -477,27 +483,24 @@ class ParticlePopulation:
     population_config: PopulationConfig
     grid_geometry: Any = None
     particles: Dict = field(init=False, default_factory=dict)  # a dictionary with arrays
-    _field_interpolator: Any = field(init=False)  # holds a Numba function
-    _position_calculator: Any = field(init=False)  # holds a Numba function
+    _field_interpolator: Any = field(init=False)
+    _field_interpolator_multi: Any = field(init=False)
+    _position_calculator_with_simplex: Any = field(init=False)
+    _position_calculator_temporal_with_simplex: Any = field(init=False)
+    _particle_simplices: ndarray = field(init=False)
     _current_time: float = field(init=False)
-    _field_mixing_depth: ndarray = field(init=False)  # TODO: we're not using this field yet
-    _field_transport_probability: ndarray = field(init=False)  # TODO: we're not using this field yet
+    _field_mixing_depth: ndarray = field(init=False)  # TODO: reserved for later particle-behavior logic
+    _field_transport_probability: ndarray = field(init=False)  # TODO: reserved for later pickup logic
 
     def __post_init__(self):
         if self.grid_geometry is None:
             self.grid_geometry = create_grid_geometry(self.field_x, self.field_y)
 
-        # Create calculator callables from shared grid geometry.
-        numba_functions = create_numba_particle_calculator(
-            grid_x=self.field_x,
-            grid_y=self.field_y,
-            grid_geometry=self.grid_geometry,
-        )
-
-        self._field_interpolator = numba_functions['interpolate_field']
-        self._field_interpolator_multi = numba_functions['interpolate_fields']
-        self._position_calculator = numba_functions['update_particles']
-        self._position_calculator_temporal = numba_functions['update_particles_temporal']
+        # Reuse methods bound to the shared grid geometry.
+        self._field_interpolator = self.grid_geometry.interpolate_field
+        self._field_interpolator_multi = self.grid_geometry.interpolate_fields
+        self._position_calculator_with_simplex = self.grid_geometry.update_particles_with_simplex
+        self._position_calculator_temporal_with_simplex = self.grid_geometry.update_particles_temporal_with_simplex
 
         # generate particles based on the configuration
         _particles = ParticleFactory.create_particles(self.population_config)
@@ -507,6 +510,7 @@ class ParticlePopulation:
             'release_time': np.array([p.release_time for p in _particles]),
             'burial_depth': np.array([p.burial_depth for p in _particles]),
         }
+        self._particle_simplices = self.grid_geometry.locate_points(self.particles['x'], self.particles['y'])
 
         # Store the outer envelope of the domain using shared grid geometry.
         self._outer_envelope = Path(self.grid_geometry.outer_envelope)
@@ -655,9 +659,12 @@ class ParticlePopulation:
         """
 
         ix = self.particles['is_mobile']  # Get indices of mobile particles
+        particle_indices = np.flatnonzero(ix)
+        if particle_indices.size == 0:
+            return
 
         if _is_temporal_flow_field(flow_field):
-            new_x, new_y = self._position_calculator_temporal(
+            new_x, new_y, new_simplices = self._position_calculator_temporal_with_simplex(
                 self.particles['x'][ix],
                 self.particles['y'][ix],
                 flow_field['lower']['u'],
@@ -666,20 +673,23 @@ class ParticlePopulation:
                 flow_field['upper']['v'],
                 flow_field['weight'],
                 current_timestep,
+                simplex_ids=self._particle_simplices[particle_indices],
             )
         else:
-            new_x, new_y = self._position_calculator(
+            new_x, new_y, new_simplices = self._position_calculator_with_simplex(
                 self.particles['x'][ix],
                 self.particles['y'][ix],
                 flow_field['u'],
                 flow_field['v'],
                 current_timestep,
+                simplex_ids=self._particle_simplices[particle_indices],
             )
 
         # TODO: implement Bart's solution for gross/net values here. Add
 
         self.particles['x'][ix] = new_x
         self.particles['y'][ix] = new_y
+        self._particle_simplices[particle_indices] = new_simplices
 
 
 class ParticleSeeder:

--- a/src/sedtrails/particle_tracer/position_calculator_numba.py
+++ b/src/sedtrails/particle_tracer/position_calculator_numba.py
@@ -117,16 +117,22 @@ class GridGeometry:
 
     def interpolate_field(self, field, x_points, y_points):
         """Barycentrically interpolate a nodal field at point coordinates."""
-        values = np.asarray(field, dtype=np.float64).ravel()
+        return self.interpolate_fields((field,), x_points, y_points)[0]
+
+    def interpolate_fields(self, fields, x_points, y_points):
+        """Interpolate multiple nodal fields using one point-location pass."""
         simplices, weights = self.barycentric_weights(x_points, y_points)
-        out = np.zeros(len(simplices), dtype=np.float64)
+        outputs = [np.zeros(len(simplices), dtype=np.float64) for _ in fields]
 
         valid = simplices >= 0
         if np.any(valid):
             vertices = self.triangles[simplices[valid]]
-            out[valid] = np.sum(values[vertices] * weights[valid], axis=1)
+            valid_weights = weights[valid]
+            for output, field in zip(outputs, fields, strict=True):
+                values = np.asarray(field).ravel()
+                output[valid] = np.einsum('ij,ij->i', values[vertices], valid_weights)
 
-        return out
+        return tuple(outputs)
 
     def update_particles(self, x0, y0, grid_u, grid_v, dt, igeo=0):
         """Advance particle positions one RK4 step using barycentric velocity sampling."""
@@ -173,26 +179,29 @@ class GridGeometry:
 
     def interpolate_temporal_vector(self, lower_u, lower_v, upper_u, upper_v, weight, x_points, y_points):
         """Interpolate lower/upper vector fields spatially, then blend in time."""
-        lower_u_values, lower_v_values = self.interpolate_vector(lower_u, lower_v, x_points, y_points)
         if weight <= 0.0:
-            return lower_u_values, lower_v_values
+            return self.interpolate_fields((lower_u, lower_v), x_points, y_points)
 
-        upper_u_values, upper_v_values = self.interpolate_vector(upper_u, upper_v, x_points, y_points)
+        lower_u_values, lower_v_values, upper_u_values, upper_v_values = self.interpolate_fields(
+            (lower_u, lower_v, upper_u, upper_v),
+            x_points,
+            y_points,
+        )
         return (
             lower_u_values + weight * (upper_u_values - lower_u_values),
             lower_v_values + weight * (upper_v_values - lower_v_values),
         )
 
     def _velocity_arrays(self, grid_u, grid_v, igeo):
-        grid_u = np.asarray(grid_u, dtype=np.float64).ravel()
-        grid_v = np.asarray(grid_v, dtype=np.float64).ravel()
+        grid_u = np.asarray(grid_u).ravel()
+        grid_v = np.asarray(grid_v).ravel()
 
         if igeo != 1:
             return grid_u, grid_v
 
         geofac = 6378137.0
         cos_lat = np.cos(np.deg2rad(self.grid_y))
-        return grid_u / (geofac * cos_lat), grid_v / geofac
+        return grid_u.astype(np.float64, copy=False) / (geofac * cos_lat), grid_v.astype(np.float64, copy=False) / geofac
 
 
 def _bounding_box(points):
@@ -260,6 +269,7 @@ def create_numba_particle_calculator(grid_x, grid_y, triangles=None, grid_geomet
         'triangles': geometry.triangles,
         'find_triangle': geometry.find_triangle,
         'interpolate_field': geometry.interpolate_field,
+        'interpolate_fields': geometry.interpolate_fields,
         'update_particles': geometry.update_particles,
         'update_particles_temporal': geometry.update_particles_temporal,
         'update_particles_parallel': geometry.update_particles,

--- a/src/sedtrails/particle_tracer/position_calculator_numba.py
+++ b/src/sedtrails/particle_tracer/position_calculator_numba.py
@@ -130,26 +130,35 @@ class GridGeometry:
 
     def update_particles(self, x0, y0, grid_u, grid_v, dt, igeo=0):
         """Advance particle positions one RK4 step using barycentric velocity sampling."""
+        return self.update_particles_temporal(x0, y0, grid_u, grid_v, grid_u, grid_v, 0.0, dt, igeo)
+
+    def update_particles_temporal(self, x0, y0, lower_u, lower_v, upper_u, upper_v, weight, dt, igeo=0):
+        """Advance particles using lower/upper time-slice velocities blended by weight."""
         x0 = np.asarray(x0, dtype=np.float64)
         y0 = np.asarray(y0, dtype=np.float64)
         if x0.size == 0:
             return x0.copy(), y0.copy()
 
-        grid_u_adj, grid_v_adj = self._velocity_arrays(grid_u, grid_v, igeo)
+        lower_u_adj, lower_v_adj = self._velocity_arrays(lower_u, lower_v, igeo)
+        if weight <= 0.0:
+            upper_u_adj = lower_u_adj
+            upper_v_adj = lower_v_adj
+        else:
+            upper_u_adj, upper_v_adj = self._velocity_arrays(upper_u, upper_v, igeo)
 
-        u1, v1 = self.interpolate_vector(grid_u_adj, grid_v_adj, x0, y0)
+        u1, v1 = self.interpolate_temporal_vector(lower_u_adj, lower_v_adj, upper_u_adj, upper_v_adj, weight, x0, y0)
         x1 = x0 + 0.5 * u1 * dt
         y1 = y0 + 0.5 * v1 * dt
 
-        u2, v2 = self.interpolate_vector(grid_u_adj, grid_v_adj, x1, y1)
+        u2, v2 = self.interpolate_temporal_vector(lower_u_adj, lower_v_adj, upper_u_adj, upper_v_adj, weight, x1, y1)
         x2 = x0 + 0.5 * u2 * dt
         y2 = y0 + 0.5 * v2 * dt
 
-        u3, v3 = self.interpolate_vector(grid_u_adj, grid_v_adj, x2, y2)
+        u3, v3 = self.interpolate_temporal_vector(lower_u_adj, lower_v_adj, upper_u_adj, upper_v_adj, weight, x2, y2)
         x3 = x0 + u3 * dt
         y3 = y0 + v3 * dt
 
-        u4, v4 = self.interpolate_vector(grid_u_adj, grid_v_adj, x3, y3)
+        u4, v4 = self.interpolate_temporal_vector(lower_u_adj, lower_v_adj, upper_u_adj, upper_v_adj, weight, x3, y3)
 
         x_new = x0 + dt / 6.0 * (u1 + 2.0 * u2 + 2.0 * u3 + u4)
         y_new = y0 + dt / 6.0 * (v1 + 2.0 * v2 + 2.0 * v3 + v4)
@@ -160,6 +169,18 @@ class GridGeometry:
         return (
             self.interpolate_field(grid_u, x_points, y_points),
             self.interpolate_field(grid_v, x_points, y_points),
+        )
+
+    def interpolate_temporal_vector(self, lower_u, lower_v, upper_u, upper_v, weight, x_points, y_points):
+        """Interpolate lower/upper vector fields spatially, then blend in time."""
+        lower_u_values, lower_v_values = self.interpolate_vector(lower_u, lower_v, x_points, y_points)
+        if weight <= 0.0:
+            return lower_u_values, lower_v_values
+
+        upper_u_values, upper_v_values = self.interpolate_vector(upper_u, upper_v, x_points, y_points)
+        return (
+            lower_u_values + weight * (upper_u_values - lower_u_values),
+            lower_v_values + weight * (upper_v_values - lower_v_values),
         )
 
     def _velocity_arrays(self, grid_u, grid_v, igeo):
@@ -240,6 +261,7 @@ def create_numba_particle_calculator(grid_x, grid_y, triangles=None, grid_geomet
         'find_triangle': geometry.find_triangle,
         'interpolate_field': geometry.interpolate_field,
         'update_particles': geometry.update_particles,
+        'update_particles_temporal': geometry.update_particles_temporal,
         'update_particles_parallel': geometry.update_particles,
     }
 

--- a/src/sedtrails/particle_tracer/position_calculator_numba.py
+++ b/src/sedtrails/particle_tracer/position_calculator_numba.py
@@ -11,10 +11,12 @@ from dataclasses import dataclass
 from typing import Any
 
 import numpy as np
+from numba import njit, prange
 from scipy.spatial import ConvexHull, Delaunay
 
 
 TRIANGLE_TOLERANCE = 1e-10
+MAX_SIMPLEX_WALK_STEPS = 128
 
 
 @dataclass
@@ -26,6 +28,13 @@ class GridGeometry:
     triangulation: Any
     triangles: np.ndarray
     outer_envelope: np.ndarray
+    triangle_neighbors: np.ndarray
+    p0_x: np.ndarray
+    p0_y: np.ndarray
+    inv00: np.ndarray
+    inv01: np.ndarray
+    inv10: np.ndarray
+    inv11: np.ndarray
     triangle_finder: Any = None
 
     @classmethod
@@ -48,6 +57,7 @@ class GridGeometry:
             # Delaunay owns the simplex search structure and affine transforms.
             triangulation = Delaunay(points)
             triangle_array = np.asarray(triangulation.simplices, dtype=np.int64)
+            triangle_neighbors = np.asarray(triangulation.neighbors, dtype=np.int64)
         else:
             import matplotlib.tri as mtri
 
@@ -56,6 +66,7 @@ class GridGeometry:
                 raise ValueError('triangles must be an array with shape (n_triangles, 3)')
             triangulation = None
             triangle_finder = mtri.Triangulation(x, y, triangle_array).get_trifinder()
+            triangle_neighbors = _compute_triangle_neighbors(triangle_array)
 
         unique_points = np.unique(finite_points, axis=0)
         if unique_points.shape[0] >= 3:
@@ -66,12 +77,21 @@ class GridGeometry:
         else:
             outer_envelope = _bounding_box(unique_points)
 
+        p0_x, p0_y, inv00, inv01, inv10, inv11 = _triangle_inverse_matrices(x, y, triangle_array)
+
         return cls(
             grid_x=x,
             grid_y=y,
             triangulation=triangulation,
             triangles=triangle_array,
             outer_envelope=outer_envelope,
+            triangle_neighbors=triangle_neighbors,
+            p0_x=p0_x,
+            p0_y=p0_y,
+            inv00=inv00,
+            inv01=inv01,
+            inv10=inv10,
+            inv11=inv11,
             triangle_finder=triangle_finder,
         )
 
@@ -81,6 +101,49 @@ class GridGeometry:
             simplex = self.triangulation.find_simplex(np.array([[x, y]], dtype=np.float64), tol=TRIANGLE_TOLERANCE)
             return int(simplex[0])
         return int(self.triangle_finder([x], [y])[0])
+
+    def locate_points(self, x_points, y_points, start_simplices=None):
+        """Locate points, using cached simplices first and global search only for misses."""
+        points = _points_array(x_points, y_points)
+        if points.size == 0:
+            return np.empty(0, dtype=np.int64)
+
+        if start_simplices is None:
+            simplices = np.full(points.shape[0], -1, dtype=np.int64)
+        else:
+            simplices = np.asarray(start_simplices, dtype=np.int64).copy()
+            if simplices.shape != (points.shape[0],):
+                raise ValueError(
+                    f'start_simplices must have shape {(points.shape[0],)}, got {simplices.shape}'
+                )
+            simplices = _locate_points_walk_numba(
+                points[:, 0],
+                points[:, 1],
+                simplices,
+                self.triangle_neighbors,
+                self.p0_x,
+                self.p0_y,
+                self.inv00,
+                self.inv01,
+                self.inv10,
+                self.inv11,
+                MAX_SIMPLEX_WALK_STEPS,
+                TRIANGLE_TOLERANCE,
+            )
+
+        missing = simplices < 0
+        if not np.any(missing):
+            return simplices
+
+        if self.triangulation is not None:
+            simplices[missing] = self.triangulation.find_simplex(points[missing], tol=TRIANGLE_TOLERANCE)
+        else:
+            simplices[missing] = np.asarray(
+                self.triangle_finder(points[missing, 0], points[missing, 1]),
+                dtype=np.int64,
+            )
+
+        return simplices
 
     def barycentric_weights(self, x_points, y_points):
         """Return simplex indices and barycentric weights for points."""
@@ -140,10 +203,54 @@ class GridGeometry:
 
     def update_particles_temporal(self, x0, y0, lower_u, lower_v, upper_u, upper_v, weight, dt, igeo=0):
         """Advance particles using lower/upper time-slice velocities blended by weight."""
+        x_new, y_new, _ = self.update_particles_temporal_with_simplex(
+            x0,
+            y0,
+            lower_u,
+            lower_v,
+            upper_u,
+            upper_v,
+            weight,
+            dt,
+            simplex_ids=None,
+            igeo=igeo,
+        )
+        return x_new, y_new
+
+    def update_particles_with_simplex(self, x0, y0, grid_u, grid_v, dt, simplex_ids=None, igeo=0):
+        """Advance particles and return updated simplex ids for the new positions."""
+        return self.update_particles_temporal_with_simplex(
+            x0,
+            y0,
+            grid_u,
+            grid_v,
+            grid_u,
+            grid_v,
+            0.0,
+            dt,
+            simplex_ids=simplex_ids,
+            igeo=igeo,
+        )
+
+    def update_particles_temporal_with_simplex(
+        self,
+        x0,
+        y0,
+        lower_u,
+        lower_v,
+        upper_u,
+        upper_v,
+        weight,
+        dt,
+        simplex_ids=None,
+        igeo=0,
+    ):
+        """Advance particles with a Numba RK4 kernel and cached simplex ids."""
         x0 = np.asarray(x0, dtype=np.float64)
         y0 = np.asarray(y0, dtype=np.float64)
+        particle_shape = x0.shape
         if x0.size == 0:
-            return x0.copy(), y0.copy()
+            return x0.copy(), y0.copy(), np.empty(0, dtype=np.int64)
 
         lower_u_adj, lower_v_adj = self._velocity_arrays(lower_u, lower_v, igeo)
         if weight <= 0.0:
@@ -152,23 +259,29 @@ class GridGeometry:
         else:
             upper_u_adj, upper_v_adj = self._velocity_arrays(upper_u, upper_v, igeo)
 
-        u1, v1 = self.interpolate_temporal_vector(lower_u_adj, lower_v_adj, upper_u_adj, upper_v_adj, weight, x0, y0)
-        x1 = x0 + 0.5 * u1 * dt
-        y1 = y0 + 0.5 * v1 * dt
-
-        u2, v2 = self.interpolate_temporal_vector(lower_u_adj, lower_v_adj, upper_u_adj, upper_v_adj, weight, x1, y1)
-        x2 = x0 + 0.5 * u2 * dt
-        y2 = y0 + 0.5 * v2 * dt
-
-        u3, v3 = self.interpolate_temporal_vector(lower_u_adj, lower_v_adj, upper_u_adj, upper_v_adj, weight, x2, y2)
-        x3 = x0 + u3 * dt
-        y3 = y0 + v3 * dt
-
-        u4, v4 = self.interpolate_temporal_vector(lower_u_adj, lower_v_adj, upper_u_adj, upper_v_adj, weight, x3, y3)
-
-        x_new = x0 + dt / 6.0 * (u1 + 2.0 * u2 + 2.0 * u3 + u4)
-        y_new = y0 + dt / 6.0 * (v1 + 2.0 * v2 + 2.0 * v3 + v4)
-        return x_new, y_new
+        starts = self.locate_points(x0, y0, simplex_ids)
+        x_new, y_new, new_simplices = _update_particles_temporal_numba(
+            x0.ravel(),
+            y0.ravel(),
+            np.asarray(lower_u_adj).ravel(),
+            np.asarray(lower_v_adj).ravel(),
+            np.asarray(upper_u_adj).ravel(),
+            np.asarray(upper_v_adj).ravel(),
+            float(weight),
+            float(dt),
+            starts,
+            self.triangles,
+            self.triangle_neighbors,
+            self.p0_x,
+            self.p0_y,
+            self.inv00,
+            self.inv01,
+            self.inv10,
+            self.inv11,
+            MAX_SIMPLEX_WALK_STEPS,
+            TRIANGLE_TOLERANCE,
+        )
+        return x_new.reshape(particle_shape), y_new.reshape(particle_shape), new_simplices
 
     def interpolate_vector(self, grid_u, grid_v, x_points, y_points):
         """Interpolate vector components at point coordinates."""
@@ -251,6 +364,329 @@ def _triangle_barycentric_weights(grid_x, grid_y, vertices, points):
     return weights, nondegenerate
 
 
+def _triangle_inverse_matrices(grid_x, grid_y, triangles):
+    x0 = grid_x[triangles[:, 0]]
+    y0 = grid_y[triangles[:, 0]]
+    x1 = grid_x[triangles[:, 1]]
+    y1 = grid_y[triangles[:, 1]]
+    x2 = grid_x[triangles[:, 2]]
+    y2 = grid_y[triangles[:, 2]]
+
+    m00 = x1 - x0
+    m01 = x2 - x0
+    m10 = y1 - y0
+    m11 = y2 - y0
+    det = m00 * m11 - m01 * m10
+
+    inv00 = np.zeros_like(det, dtype=np.float64)
+    inv01 = np.zeros_like(det, dtype=np.float64)
+    inv10 = np.zeros_like(det, dtype=np.float64)
+    inv11 = np.zeros_like(det, dtype=np.float64)
+    valid = np.abs(det) >= TRIANGLE_TOLERANCE
+    inv00[valid] = m11[valid] / det[valid]
+    inv01[valid] = -m01[valid] / det[valid]
+    inv10[valid] = -m10[valid] / det[valid]
+    inv11[valid] = m00[valid] / det[valid]
+
+    return x0, y0, inv00, inv01, inv10, inv11
+
+
+def _compute_triangle_neighbors(triangles):
+    neighbors = np.full((triangles.shape[0], 3), -1, dtype=np.int64)
+    edge_owner = {}
+    opposite_edges = ((1, 2), (0, 2), (0, 1))
+    for tri_index, triangle in enumerate(triangles):
+        for vertex_index, edge_vertices in enumerate(opposite_edges):
+            edge = tuple(sorted((int(triangle[edge_vertices[0]]), int(triangle[edge_vertices[1]]))))
+            previous = edge_owner.get(edge)
+            if previous is None:
+                edge_owner[edge] = (tri_index, vertex_index)
+            else:
+                other_tri, other_vertex = previous
+                neighbors[tri_index, vertex_index] = other_tri
+                neighbors[other_tri, other_vertex] = tri_index
+    return neighbors
+
+
+@njit(cache=True)
+def _weights_in_simplex(simplex, x, y, p0_x, p0_y, inv00, inv01, inv10, inv11):
+    dx = x - p0_x[simplex]
+    dy = y - p0_y[simplex]
+    w1 = inv00[simplex] * dx + inv01[simplex] * dy
+    w2 = inv10[simplex] * dx + inv11[simplex] * dy
+    w0 = 1.0 - w1 - w2
+    return w0, w1, w2
+
+
+@njit(cache=True)
+def _walk_simplex(start, x, y, neighbors, p0_x, p0_y, inv00, inv01, inv10, inv11, max_steps, tolerance):
+    n_triangles = neighbors.shape[0]
+    if start < 0 or start >= n_triangles:
+        return -1, 0.0, 0.0, 0.0
+
+    simplex = start
+    for _ in range(max_steps):
+        w0, w1, w2 = _weights_in_simplex(simplex, x, y, p0_x, p0_y, inv00, inv01, inv10, inv11)
+        if w0 >= -tolerance and w1 >= -tolerance and w2 >= -tolerance:
+            return simplex, w0, w1, w2
+
+        edge_index = 0
+        min_weight = w0
+        if w1 < min_weight:
+            edge_index = 1
+            min_weight = w1
+        if w2 < min_weight:
+            edge_index = 2
+
+        next_simplex = neighbors[simplex, edge_index]
+        if next_simplex < 0 or next_simplex == simplex:
+            break
+        simplex = next_simplex
+
+    return -1, 0.0, 0.0, 0.0
+
+
+@njit(cache=True, parallel=True)
+def _locate_points_walk_numba(
+    x_points,
+    y_points,
+    start_simplices,
+    neighbors,
+    p0_x,
+    p0_y,
+    inv00,
+    inv01,
+    inv10,
+    inv11,
+    max_steps,
+    tolerance,
+):
+    out = np.empty(start_simplices.shape[0], dtype=np.int64)
+    for i in prange(start_simplices.shape[0]):
+        simplex, _, _, _ = _walk_simplex(
+            start_simplices[i],
+            x_points[i],
+            y_points[i],
+            neighbors,
+            p0_x,
+            p0_y,
+            inv00,
+            inv01,
+            inv10,
+            inv11,
+            max_steps,
+            tolerance,
+        )
+        out[i] = simplex
+    return out
+
+
+@njit(cache=True)
+def _interpolate_temporal_velocity(
+    x,
+    y,
+    start_simplex,
+    lower_u,
+    lower_v,
+    upper_u,
+    upper_v,
+    weight,
+    triangles,
+    neighbors,
+    p0_x,
+    p0_y,
+    inv00,
+    inv01,
+    inv10,
+    inv11,
+    max_steps,
+    tolerance,
+):
+    simplex, w0, w1, w2 = _walk_simplex(
+        start_simplex,
+        x,
+        y,
+        neighbors,
+        p0_x,
+        p0_y,
+        inv00,
+        inv01,
+        inv10,
+        inv11,
+        max_steps,
+        tolerance,
+    )
+    if simplex < 0:
+        return 0.0, 0.0, -1
+
+    i0 = triangles[simplex, 0]
+    i1 = triangles[simplex, 1]
+    i2 = triangles[simplex, 2]
+    lower_u_value = w0 * lower_u[i0] + w1 * lower_u[i1] + w2 * lower_u[i2]
+    lower_v_value = w0 * lower_v[i0] + w1 * lower_v[i1] + w2 * lower_v[i2]
+    if weight <= 0.0:
+        return lower_u_value, lower_v_value, simplex
+
+    upper_u_value = w0 * upper_u[i0] + w1 * upper_u[i1] + w2 * upper_u[i2]
+    upper_v_value = w0 * upper_v[i0] + w1 * upper_v[i1] + w2 * upper_v[i2]
+    return (
+        lower_u_value + weight * (upper_u_value - lower_u_value),
+        lower_v_value + weight * (upper_v_value - lower_v_value),
+        simplex,
+    )
+
+
+@njit(cache=True, parallel=True)
+def _update_particles_temporal_numba(
+    x0,
+    y0,
+    lower_u,
+    lower_v,
+    upper_u,
+    upper_v,
+    weight,
+    dt,
+    start_simplices,
+    triangles,
+    neighbors,
+    p0_x,
+    p0_y,
+    inv00,
+    inv01,
+    inv10,
+    inv11,
+    max_steps,
+    tolerance,
+):
+    x_new = np.empty_like(x0, dtype=np.float64)
+    y_new = np.empty_like(y0, dtype=np.float64)
+    simplex_new = np.empty(start_simplices.shape[0], dtype=np.int64)
+
+    for i in prange(x0.shape[0]):
+        start = start_simplices[i]
+        u1, v1, s1 = _interpolate_temporal_velocity(
+            x0[i],
+            y0[i],
+            start,
+            lower_u,
+            lower_v,
+            upper_u,
+            upper_v,
+            weight,
+            triangles,
+            neighbors,
+            p0_x,
+            p0_y,
+            inv00,
+            inv01,
+            inv10,
+            inv11,
+            max_steps,
+            tolerance,
+        )
+        x1 = x0[i] + 0.5 * u1 * dt
+        y1 = y0[i] + 0.5 * v1 * dt
+
+        u2, v2, s2 = _interpolate_temporal_velocity(
+            x1,
+            y1,
+            s1 if s1 >= 0 else start,
+            lower_u,
+            lower_v,
+            upper_u,
+            upper_v,
+            weight,
+            triangles,
+            neighbors,
+            p0_x,
+            p0_y,
+            inv00,
+            inv01,
+            inv10,
+            inv11,
+            max_steps,
+            tolerance,
+        )
+        x2 = x0[i] + 0.5 * u2 * dt
+        y2 = y0[i] + 0.5 * v2 * dt
+
+        u3, v3, s3 = _interpolate_temporal_velocity(
+            x2,
+            y2,
+            s2 if s2 >= 0 else s1,
+            lower_u,
+            lower_v,
+            upper_u,
+            upper_v,
+            weight,
+            triangles,
+            neighbors,
+            p0_x,
+            p0_y,
+            inv00,
+            inv01,
+            inv10,
+            inv11,
+            max_steps,
+            tolerance,
+        )
+        x3 = x0[i] + u3 * dt
+        y3 = y0[i] + v3 * dt
+
+        u4, v4, s4 = _interpolate_temporal_velocity(
+            x3,
+            y3,
+            s3 if s3 >= 0 else s2,
+            lower_u,
+            lower_v,
+            upper_u,
+            upper_v,
+            weight,
+            triangles,
+            neighbors,
+            p0_x,
+            p0_y,
+            inv00,
+            inv01,
+            inv10,
+            inv11,
+            max_steps,
+            tolerance,
+        )
+
+        x_out = x0[i] + dt / 6.0 * (u1 + 2.0 * u2 + 2.0 * u3 + u4)
+        y_out = y0[i] + dt / 6.0 * (v1 + 2.0 * v2 + 2.0 * v3 + v4)
+        x_new[i] = x_out
+        y_new[i] = y_out
+
+        final_start = s4
+        if final_start < 0:
+            final_start = s3
+        if final_start < 0:
+            final_start = s2
+        if final_start < 0:
+            final_start = s1
+        if final_start < 0:
+            final_start = start
+        final_simplex, _, _, _ = _walk_simplex(
+            final_start,
+            x_out,
+            y_out,
+            neighbors,
+            p0_x,
+            p0_y,
+            inv00,
+            inv01,
+            inv10,
+            inv11,
+            max_steps,
+            tolerance,
+        )
+        simplex_new[i] = final_simplex
+
+    return x_new, y_new, simplex_new
+
+
 def create_grid_geometry(grid_x, grid_y, triangles=None) -> GridGeometry:
     """Create cached grid geometry for repeated particle interpolation."""
     return GridGeometry.from_points(grid_x, grid_y, triangles=triangles)
@@ -272,6 +708,8 @@ def create_numba_particle_calculator(grid_x, grid_y, triangles=None, grid_geomet
         'interpolate_fields': geometry.interpolate_fields,
         'update_particles': geometry.update_particles,
         'update_particles_temporal': geometry.update_particles_temporal,
+        'update_particles_with_simplex': geometry.update_particles_with_simplex,
+        'update_particles_temporal_with_simplex': geometry.update_particles_temporal_with_simplex,
         'update_particles_parallel': geometry.update_particles,
     }
 

--- a/src/sedtrails/particle_tracer/position_calculator_numba.py
+++ b/src/sedtrails/particle_tracer/position_calculator_numba.py
@@ -1,495 +1,264 @@
 """
-Numba-optimized ParticlePositionCalculator
+Particle position calculation on an unstructured triangular grid.
 
-This module provides a Numba-accelerated implementation of particle
-position calculation using a 4-stage Runge-Kutta integration scheme
-on unstructured grids. It replaces the matplotlib triangulation and
-multiprocessing approaches with Numba-compatible alternatives.
-
-Dependencies: numpy, numba, scipy (only for initial triangulation)
+The public factory name is kept for compatibility with existing callers, but
+the implementation now caches SciPy Delaunay geometry and uses its simplex
+search instead of scanning every triangle for every interpolation point when
+connectivity is not supplied explicitly.
 """
 
+from dataclasses import dataclass
+from typing import Any
+
 import numpy as np
-from numba import njit, prange
+from scipy.spatial import ConvexHull, Delaunay
 
 
-def create_numba_particle_calculator(grid_x, grid_y, triangles=None):
+TRIANGLE_TOLERANCE = 1e-10
+
+
+@dataclass
+class GridGeometry:
+    """Cached spatial geometry shared by particle populations on the same grid."""
+
+    grid_x: np.ndarray
+    grid_y: np.ndarray
+    triangulation: Any
+    triangles: np.ndarray
+    outer_envelope: np.ndarray
+    triangle_finder: Any = None
+
+    @classmethod
+    def from_points(cls, grid_x, grid_y, triangles=None):
+        x = np.asarray(grid_x, dtype=np.float64).ravel()
+        y = np.asarray(grid_y, dtype=np.float64).ravel()
+
+        if x.shape != y.shape:
+            raise ValueError(f'grid_x and grid_y must have the same shape, got {x.shape} and {y.shape}')
+
+        points = np.column_stack((x, y))
+        finite_points = points[np.isfinite(points).all(axis=1)]
+        if finite_points.shape[0] < 3:
+            raise ValueError('At least three finite grid points are required for particle interpolation')
+        if finite_points.shape[0] != points.shape[0]:
+            raise ValueError('grid_x and grid_y must contain only finite coordinates')
+
+        triangle_finder = None
+        if triangles is None:
+            # Delaunay owns the simplex search structure and affine transforms.
+            triangulation = Delaunay(points)
+            triangle_array = np.asarray(triangulation.simplices, dtype=np.int64)
+        else:
+            import matplotlib.tri as mtri
+
+            triangle_array = np.asarray(triangles, dtype=np.int64)
+            if triangle_array.ndim != 2 or triangle_array.shape[1] != 3:
+                raise ValueError('triangles must be an array with shape (n_triangles, 3)')
+            triangulation = None
+            triangle_finder = mtri.Triangulation(x, y, triangle_array).get_trifinder()
+
+        unique_points = np.unique(finite_points, axis=0)
+        if unique_points.shape[0] >= 3:
+            try:
+                outer_envelope = unique_points[ConvexHull(unique_points).vertices]
+            except Exception:
+                outer_envelope = _bounding_box(unique_points)
+        else:
+            outer_envelope = _bounding_box(unique_points)
+
+        return cls(
+            grid_x=x,
+            grid_y=y,
+            triangulation=triangulation,
+            triangles=triangle_array,
+            outer_envelope=outer_envelope,
+            triangle_finder=triangle_finder,
+        )
+
+    def find_triangle(self, x, y) -> int:
+        """Return the containing simplex index, or -1 outside the triangulation."""
+        if self.triangulation is not None:
+            simplex = self.triangulation.find_simplex(np.array([[x, y]], dtype=np.float64), tol=TRIANGLE_TOLERANCE)
+            return int(simplex[0])
+        return int(self.triangle_finder([x], [y])[0])
+
+    def barycentric_weights(self, x_points, y_points):
+        """Return simplex indices and barycentric weights for points."""
+        points = _points_array(x_points, y_points)
+        weights = np.zeros((points.shape[0], 3), dtype=np.float64)
+
+        if self.triangulation is not None:
+            simplices = self.triangulation.find_simplex(points, tol=TRIANGLE_TOLERANCE)
+            valid = simplices >= 0
+            if not np.any(valid):
+                return simplices, weights
+
+            transform = self.triangulation.transform[simplices[valid]]
+            delta = points[valid] - transform[:, 2, :]
+            first_two = np.einsum('ijk,ik->ij', transform[:, :2, :], delta)
+            weights[valid, :2] = first_two
+            weights[valid, 2] = 1.0 - first_two.sum(axis=1)
+            return simplices, weights
+
+        simplices = np.asarray(self.triangle_finder(points[:, 0], points[:, 1]), dtype=np.int64)
+        valid_indices = np.flatnonzero(simplices >= 0)
+        if valid_indices.size:
+            vertices = self.triangles[simplices[valid_indices]]
+            local_weights, nondegenerate = _triangle_barycentric_weights(
+                self.grid_x,
+                self.grid_y,
+                vertices,
+                points[valid_indices],
+            )
+            weights[valid_indices[nondegenerate]] = local_weights[nondegenerate]
+            simplices[valid_indices[~nondegenerate]] = -1
+
+        return simplices, weights
+
+    def interpolate_field(self, field, x_points, y_points):
+        """Barycentrically interpolate a nodal field at point coordinates."""
+        values = np.asarray(field, dtype=np.float64).ravel()
+        simplices, weights = self.barycentric_weights(x_points, y_points)
+        out = np.zeros(len(simplices), dtype=np.float64)
+
+        valid = simplices >= 0
+        if np.any(valid):
+            vertices = self.triangles[simplices[valid]]
+            out[valid] = np.sum(values[vertices] * weights[valid], axis=1)
+
+        return out
+
+    def update_particles(self, x0, y0, grid_u, grid_v, dt, igeo=0):
+        """Advance particle positions one RK4 step using barycentric velocity sampling."""
+        x0 = np.asarray(x0, dtype=np.float64)
+        y0 = np.asarray(y0, dtype=np.float64)
+        if x0.size == 0:
+            return x0.copy(), y0.copy()
+
+        grid_u_adj, grid_v_adj = self._velocity_arrays(grid_u, grid_v, igeo)
+
+        u1, v1 = self.interpolate_vector(grid_u_adj, grid_v_adj, x0, y0)
+        x1 = x0 + 0.5 * u1 * dt
+        y1 = y0 + 0.5 * v1 * dt
+
+        u2, v2 = self.interpolate_vector(grid_u_adj, grid_v_adj, x1, y1)
+        x2 = x0 + 0.5 * u2 * dt
+        y2 = y0 + 0.5 * v2 * dt
+
+        u3, v3 = self.interpolate_vector(grid_u_adj, grid_v_adj, x2, y2)
+        x3 = x0 + u3 * dt
+        y3 = y0 + v3 * dt
+
+        u4, v4 = self.interpolate_vector(grid_u_adj, grid_v_adj, x3, y3)
+
+        x_new = x0 + dt / 6.0 * (u1 + 2.0 * u2 + 2.0 * u3 + u4)
+        y_new = y0 + dt / 6.0 * (v1 + 2.0 * v2 + 2.0 * v3 + v4)
+        return x_new, y_new
+
+    def interpolate_vector(self, grid_u, grid_v, x_points, y_points):
+        """Interpolate vector components at point coordinates."""
+        return (
+            self.interpolate_field(grid_u, x_points, y_points),
+            self.interpolate_field(grid_v, x_points, y_points),
+        )
+
+    def _velocity_arrays(self, grid_u, grid_v, igeo):
+        grid_u = np.asarray(grid_u, dtype=np.float64).ravel()
+        grid_v = np.asarray(grid_v, dtype=np.float64).ravel()
+
+        if igeo != 1:
+            return grid_u, grid_v
+
+        geofac = 6378137.0
+        cos_lat = np.cos(np.deg2rad(self.grid_y))
+        return grid_u / (geofac * cos_lat), grid_v / geofac
+
+
+def _bounding_box(points):
+    if points.size == 0:
+        return np.empty((0, 2), dtype=np.float64)
+    min_x = float(np.min(points[:, 0]))
+    max_x = float(np.max(points[:, 0]))
+    min_y = float(np.min(points[:, 1]))
+    max_y = float(np.max(points[:, 1]))
+    return np.array([[min_x, min_y], [min_x, max_y], [max_x, max_y], [max_x, min_y]], dtype=np.float64)
+
+
+def _points_array(x_points, y_points):
+    x = np.asarray(x_points, dtype=np.float64)
+    y = np.asarray(y_points, dtype=np.float64)
+    if x.shape != y.shape:
+        raise ValueError(f'x_points and y_points must have the same shape, got {x.shape} and {y.shape}')
+    return np.column_stack((x.ravel(), y.ravel()))
+
+
+def _triangle_barycentric_weights(grid_x, grid_y, vertices, points):
+    x0 = grid_x[vertices[:, 0]]
+    y0 = grid_y[vertices[:, 0]]
+    x1 = grid_x[vertices[:, 1]]
+    y1 = grid_y[vertices[:, 1]]
+    x2 = grid_x[vertices[:, 2]]
+    y2 = grid_y[vertices[:, 2]]
+
+    denom = (y1 - y2) * (x0 - x2) + (x2 - x1) * (y0 - y2)
+    nondegenerate = np.abs(denom) >= TRIANGLE_TOLERANCE
+
+    weights = np.zeros((points.shape[0], 3), dtype=np.float64)
+    if np.any(nondegenerate):
+        x = points[nondegenerate, 0]
+        y = points[nondegenerate, 1]
+        denom_valid = denom[nondegenerate]
+        weights[nondegenerate, 0] = (
+            (y1[nondegenerate] - y2[nondegenerate]) * (x - x2[nondegenerate])
+            + (x2[nondegenerate] - x1[nondegenerate]) * (y - y2[nondegenerate])
+        ) / denom_valid
+        weights[nondegenerate, 1] = (
+            (y2[nondegenerate] - y0[nondegenerate]) * (x - x2[nondegenerate])
+            + (x0[nondegenerate] - x2[nondegenerate]) * (y - y2[nondegenerate])
+        ) / denom_valid
+        weights[nondegenerate, 2] = 1.0 - weights[nondegenerate, 0] - weights[nondegenerate, 1]
+
+    return weights, nondegenerate
+
+
+def create_grid_geometry(grid_x, grid_y, triangles=None) -> GridGeometry:
+    """Create cached grid geometry for repeated particle interpolation."""
+    return GridGeometry.from_points(grid_x, grid_y, triangles=triangles)
+
+
+def create_numba_particle_calculator(grid_x, grid_y, triangles=None, grid_geometry=None):
     """
-    Factory function to create a Numba-optimized particle calculator.
+    Create particle interpolation/update callables.
 
-    This function preprocesses the grid data and returns optimized Numba functions
-    for particle position calculation.
-
-    Parameters
-    ----------
-    grid_x, grid_y : array_like
-        Coordinates of grid nodes
-    triangles : array_like, optional
-        Triangle connectivity (node indices). If None, Delaunay triangulation
-        will be computed once (not using Numba).
-
-    Returns
-    -------
-    dict
-        Dictionary containing optimized Numba functions
+    The returned dictionary keeps the historical keys used by ParticlePopulation.
     """
-    # If triangles not provided, compute them once using scipy
-    if triangles is None:
-        from scipy.spatial import Delaunay
+    geometry = grid_geometry if grid_geometry is not None else create_grid_geometry(grid_x, grid_y, triangles)
 
-        points = np.column_stack((grid_x, grid_y))
-        triangulation = Delaunay(points)
-        triangles = triangulation.simplices
-
-    # Pre-compute triangle information for faster lookup
-    triangles = np.asarray(triangles, dtype=np.int64)
-
-    # Return the calculator functions WITHOUT trying to decorate them again
     return {
-        'triangles': triangles,
-        'find_triangle': lambda x, y: find_triangle(x, y, grid_x, grid_y, triangles),
-        'interpolate_field': lambda field, x, y: interpolate_field(field, x, y, grid_x, grid_y, triangles),
-        'update_particles': lambda x0, y0, grid_u, grid_v, dt, igeo=0: update_particles_rk4(
-            x0, y0, grid_u, grid_v, grid_x, grid_y, triangles, dt, igeo
-        ),
-        'update_particles_parallel': lambda x0, y0, grid_u, grid_v, dt, igeo=0: update_particles_rk4_parallel(
-            x0, y0, grid_u, grid_v, grid_x, grid_y, triangles, dt, igeo
-        ),
+        'geometry': geometry,
+        'triangles': geometry.triangles,
+        'find_triangle': geometry.find_triangle,
+        'interpolate_field': geometry.interpolate_field,
+        'update_particles': geometry.update_particles,
+        'update_particles_parallel': geometry.update_particles,
     }
 
 
-@njit
-def find_triangle(x, y, grid_x, grid_y, triangles):
-    """
-    Find which triangle contains the point (x, y).
-
-    Parameters
-    ----------
-    x, y : float
-        Coordinates of the point
-    grid_x, grid_y : array_like
-        Coordinates of grid nodes
-    triangles : array_like
-        Triangle connectivity (node indices)
-
-    Returns
-    -------
-    int
-        Triangle index or -1 if outside all triangles
-    """
-    for i in range(len(triangles)):
-        # Get triangle vertices
-        v0, v1, v2 = triangles[i]
-        x0, y0 = grid_x[v0], grid_y[v0]
-        x1, y1 = grid_x[v1], grid_y[v1]
-        x2, y2 = grid_x[v2], grid_y[v2]
-
-        # Barycentric coordinates calculation
-        denom = (y1 - y2) * (x0 - x2) + (x2 - x1) * (y0 - y2)
-        if abs(denom) < 1e-10:
-            continue
-
-        w1 = ((y1 - y2) * (x - x2) + (x2 - x1) * (y - y2)) / denom
-        w2 = ((y2 - y0) * (x - x2) + (x0 - x2) * (y - y2)) / denom
-        w3 = 1.0 - w1 - w2
-
-        # If all weights are between 0 and 1, point is inside triangle
-        if (w1 >= -1e-10) and (w2 >= -1e-10) and (w3 >= -1e-10):
-            return i
-
-    return -1
+def find_triangle(x, y, grid_x, grid_y, triangles=None):
+    """Compatibility wrapper for one-off triangle lookup."""
+    return create_grid_geometry(grid_x, grid_y, triangles=triangles).find_triangle(x, y)
 
 
-@njit
-def interpolate_field(field, x_points, y_points, grid_x, grid_y, triangles):
-    """
-    Interpolate field values at given points using barycentric coordinates.
-
-    Parameters
-    ----------
-    field : array_like
-        Field values at grid nodes
-    x_points, y_points : array_like
-        Coordinates of points where to interpolate
-    grid_x, grid_y : array_like
-        Coordinates of grid nodes
-    triangles : array_like
-        Triangle connectivity (node indices)
-
-    Returns
-    -------
-    array_like
-        Interpolated field values
-    """
-    n_points = len(x_points)
-    result = np.zeros(n_points, dtype=np.float64)
-
-    for i in range(n_points):
-        x, y = x_points[i], y_points[i]
-        # Find containing triangle
-        tri_idx = -1
-
-        for j in range(len(triangles)):
-            # Get triangle vertices
-            v0, v1, v2 = triangles[j]
-            x0, y0 = grid_x[v0], grid_y[v0]
-            x1, y1 = grid_x[v1], grid_y[v1]
-            x2, y2 = grid_x[v2], grid_y[v2]
-
-            # Barycentric coordinates calculation
-            denom = (y1 - y2) * (x0 - x2) + (x2 - x1) * (y0 - y2)
-            if abs(denom) < 1e-10:
-                continue
-
-            w1 = ((y1 - y2) * (x - x2) + (x2 - x1) * (y - y2)) / denom
-            w2 = ((y2 - y0) * (x - x2) + (x0 - x2) * (y - y2)) / denom
-            w3 = 1.0 - w1 - w2
-
-            # If all weights are between 0 and 1, point is inside triangle
-            if (w1 >= -1e-10) and (w2 >= -1e-10) and (w3 >= -1e-10):
-                tri_idx = j
-
-                # Compute interpolated value using barycentric coordinates
-                v0, v1, v2 = triangles[tri_idx]
-                result[i] = w1 * field[v0] + w2 * field[v1] + w3 * field[v2]
-                break
-
-    return result
+def interpolate_field(field, x_points, y_points, grid_x, grid_y, triangles=None):
+    """Compatibility wrapper for one-off scalar interpolation."""
+    return create_grid_geometry(grid_x, grid_y, triangles=triangles).interpolate_field(field, x_points, y_points)
 
 
-@njit
 def update_particles_rk4(x0, y0, grid_u, grid_v, grid_x, grid_y, triangles, dt, igeo=0):
-    """
-    Update particle positions using a 4-stage Runge-Kutta integration scheme.
-
-    Parameters
-    ----------
-    x0, y0 : array_like
-        Initial particle positions
-    grid_u, grid_v : array_like
-        Velocity components at grid nodes
-    grid_x, grid_y : array_like
-        Coordinates of grid nodes
-    triangles : array_like
-        Triangle connectivity (node indices)
-    dt : float
-        Time step
-    igeo : int, optional
-        Flag for geographic coordinates adjustment (default: 0)
-
-    Returns
-    -------
-    tuple
-        Updated particle positions (x_new, y_new)
-    """
-    # Convert inputs to arrays if they aren't already
-    x0 = np.asarray(x0, dtype=np.float64)
-    y0 = np.asarray(y0, dtype=np.float64)
-    grid_u = np.asarray(grid_u, dtype=np.float64)
-    grid_v = np.asarray(grid_v, dtype=np.float64)
-
-    n_particles = len(x0)
-    x_new = np.zeros(n_particles, dtype=np.float64)
-    y_new = np.zeros(n_particles, dtype=np.float64)
-
-    # Geographic adjustment factor
-    geofac = 6378137.0
-
-    # Adjust grid velocities if using geographic coordinates
-    grid_u_adj = np.copy(grid_u)
-    grid_v_adj = np.copy(grid_v)
-
-    if igeo == 1:
-        for i in range(len(grid_y)):
-            cos_lat = np.cos(np.deg2rad(grid_y[i]))
-            grid_u_adj[i] = grid_u[i] / (geofac * cos_lat)
-            grid_v_adj[i] = grid_v[i] / geofac
-
-    # RK4 integration for each particle
-    for i in range(n_particles):
-        xi, yi = x0[i], y0[i]
-
-        # Stage 1
-        up1 = 0.0
-        vp1 = 0.0
-        # tri_idx = -1
-
-        # Find containing triangle
-        for j in range(len(triangles)):
-            # Get triangle vertices
-            v0, v1, v2 = triangles[j]
-            x0_tri, y0_tri = grid_x[v0], grid_y[v0]
-            x1_tri, y1_tri = grid_x[v1], grid_y[v1]
-            x2_tri, y2_tri = grid_x[v2], grid_y[v2]
-
-            # Barycentric coordinates calculation
-            denom = (y1_tri - y2_tri) * (x0_tri - x2_tri) + (x2_tri - x1_tri) * (y0_tri - y2_tri)
-            if abs(denom) < 1e-10:
-                continue
-
-            w1 = ((y1_tri - y2_tri) * (xi - x2_tri) + (x2_tri - x1_tri) * (yi - y2_tri)) / denom
-            w2 = ((y2_tri - y0_tri) * (xi - x2_tri) + (x0_tri - x2_tri) * (yi - y2_tri)) / denom
-            w3 = 1.0 - w1 - w2
-
-            # If all weights are between 0 and 1, point is inside triangle
-            if (w1 >= -1e-10) and (w2 >= -1e-10) and (w3 >= -1e-10):
-                # tri_idx = j
-
-                # Interpolate velocity
-                up1 = w1 * grid_u_adj[v0] + w2 * grid_u_adj[v1] + w3 * grid_u_adj[v2]
-                vp1 = w1 * grid_v_adj[v0] + w2 * grid_v_adj[v1] + w3 * grid_v_adj[v2]
-                break
-
-        x1a = xi + 0.5 * up1 * dt
-        y1a = yi + 0.5 * vp1 * dt
-
-        # Stage 2
-        up2 = 0.0
-        vp2 = 0.0
-        # tri_idx = -1
-
-        # Find containing triangle
-        for j in range(len(triangles)):
-            v0, v1, v2 = triangles[j]
-            x0_tri, y0_tri = grid_x[v0], grid_y[v0]
-            x1_tri, y1_tri = grid_x[v1], grid_y[v1]
-            x2_tri, y2_tri = grid_x[v2], grid_y[v2]
-
-            denom = (y1_tri - y2_tri) * (x0_tri - x2_tri) + (x2_tri - x1_tri) * (y0_tri - y2_tri)
-            if abs(denom) < 1e-10:
-                continue
-
-            w1 = ((y1_tri - y2_tri) * (x1a - x2_tri) + (x2_tri - x1_tri) * (y1a - y2_tri)) / denom
-            w2 = ((y2_tri - y0_tri) * (x1a - x2_tri) + (x0_tri - x2_tri) * (y1a - y2_tri)) / denom
-            w3 = 1.0 - w1 - w2
-
-            if (w1 >= -1e-10) and (w2 >= -1e-10) and (w3 >= -1e-10):
-                # tri_idx = j
-                up2 = w1 * grid_u_adj[v0] + w2 * grid_u_adj[v1] + w3 * grid_u_adj[v2]
-                vp2 = w1 * grid_v_adj[v0] + w2 * grid_v_adj[v1] + w3 * grid_v_adj[v2]
-                break
-
-        x1b = xi + 0.5 * up2 * dt
-        y1b = yi + 0.5 * vp2 * dt
-
-        # Stage 3
-        up3 = 0.0
-        vp3 = 0.0
-        # tri_idx = -1
-
-        # Find containing triangle
-        for j in range(len(triangles)):
-            v0, v1, v2 = triangles[j]
-            x0_tri, y0_tri = grid_x[v0], grid_y[v0]
-            x1_tri, y1_tri = grid_x[v1], grid_y[v1]
-            x2_tri, y2_tri = grid_x[v2], grid_y[v2]
-
-            denom = (y1_tri - y2_tri) * (x0_tri - x2_tri) + (x2_tri - x1_tri) * (y0_tri - y2_tri)
-            if abs(denom) < 1e-10:
-                continue
-
-            w1 = ((y1_tri - y2_tri) * (x1b - x2_tri) + (x2_tri - x1_tri) * (y1b - y2_tri)) / denom
-            w2 = ((y2_tri - y0_tri) * (x1b - x2_tri) + (x0_tri - x2_tri) * (y1b - y2_tri)) / denom
-            w3 = 1.0 - w1 - w2
-
-            if (w1 >= -1e-10) and (w2 >= -1e-10) and (w3 >= -1e-10):
-                # tri_idx = j
-                up3 = w1 * grid_u_adj[v0] + w2 * grid_u_adj[v1] + w3 * grid_u_adj[v2]
-                vp3 = w1 * grid_v_adj[v0] + w2 * grid_v_adj[v1] + w3 * grid_v_adj[v2]
-                break
-
-        x1c = xi + up3 * dt
-        y1c = yi + vp3 * dt
-
-        # Stage 4
-        up4 = 0.0
-        vp4 = 0.0
-        # tri_idx = -1
-
-        # Find containing triangle
-        for j in range(len(triangles)):
-            v0, v1, v2 = triangles[j]
-            x0_tri, y0_tri = grid_x[v0], grid_y[v0]
-            x1_tri, y1_tri = grid_x[v1], grid_y[v1]
-            x2_tri, y2_tri = grid_x[v2], grid_y[v2]
-
-            denom = (y1_tri - y2_tri) * (x0_tri - x2_tri) + (x2_tri - x1_tri) * (y0_tri - y2_tri)
-            if abs(denom) < 1e-10:
-                continue
-
-            w1 = ((y1_tri - y2_tri) * (x1c - x2_tri) + (x2_tri - x1_tri) * (y1c - y2_tri)) / denom
-            w2 = ((y2_tri - y0_tri) * (x1c - x2_tri) + (x0_tri - x2_tri) * (y1c - y2_tri)) / denom
-            w3 = 1.0 - w1 - w2
-
-            if (w1 >= -1e-10) and (w2 >= -1e-10) and (w3 >= -1e-10):
-                # tri_idx = j
-                up4 = w1 * grid_u_adj[v0] + w2 * grid_u_adj[v1] + w3 * grid_u_adj[v2]
-                vp4 = w1 * grid_v_adj[v0] + w2 * grid_v_adj[v1] + w3 * grid_v_adj[v2]
-                break
-
-        # Combine stages (RK4 integration)
-        x_new[i] = xi + dt / 6.0 * (up1 + 2.0 * up2 + 2.0 * up3 + up4)
-        y_new[i] = yi + dt / 6.0 * (vp1 + 2.0 * vp2 + 2.0 * vp3 + vp4)
-
-    return x_new, y_new
+    """Compatibility wrapper for one-off RK4 particle updates."""
+    return create_grid_geometry(grid_x, grid_y, triangles=triangles).update_particles(x0, y0, grid_u, grid_v, dt, igeo)
 
 
-@njit(parallel=True)
 def update_particles_rk4_parallel(x0, y0, grid_u, grid_v, grid_x, grid_y, triangles, dt, igeo=0):
-    """
-    Parallel version of update_particles_rk4 using Numba's prange.
-
-    This function is optimized for large particle sets.
-
-    Parameters are the same as update_particles_rk4.
-    """
-    # Convert inputs to arrays if they aren't already
-    x0 = np.asarray(x0, dtype=np.float64)
-    y0 = np.asarray(y0, dtype=np.float64)
-    grid_u = np.asarray(grid_u, dtype=np.float64)
-    grid_v = np.asarray(grid_v, dtype=np.float64)
-
-    n_particles = len(x0)
-    x_new = np.zeros(n_particles, dtype=np.float64)
-    y_new = np.zeros(n_particles, dtype=np.float64)
-
-    # Geographic adjustment factor
-    geofac = 6378137.0
-
-    # Adjust grid velocities if using geographic coordinates
-    grid_u_adj = np.copy(grid_u)
-    grid_v_adj = np.copy(grid_v)
-
-    if igeo == 1:
-        for i in range(len(grid_y)):
-            cos_lat = np.cos(np.deg2rad(grid_y[i]))
-            grid_u_adj[i] = grid_u[i] / (geofac * cos_lat)
-            grid_v_adj[i] = grid_v[i] / geofac
-
-    # RK4 integration for each particle in parallel
-    for i in prange(n_particles):
-        xi, yi = x0[i], y0[i]
-
-        # Stage 1
-        up1 = 0.0
-        vp1 = 0.0
-        # tri_idx = -1
-
-        # Find containing triangle
-        for j in range(len(triangles)):
-            # Get triangle vertices
-            v0, v1, v2 = triangles[j]
-            x0_tri, y0_tri = grid_x[v0], grid_y[v0]
-            x1_tri, y1_tri = grid_x[v1], grid_y[v1]
-            x2_tri, y2_tri = grid_x[v2], grid_y[v2]
-
-            # Barycentric coordinates calculation
-            denom = (y1_tri - y2_tri) * (x0_tri - x2_tri) + (x2_tri - x1_tri) * (y0_tri - y2_tri)
-            if abs(denom) < 1e-10:
-                continue
-
-            w1 = ((y1_tri - y2_tri) * (xi - x2_tri) + (x2_tri - x1_tri) * (yi - y2_tri)) / denom
-            w2 = ((y2_tri - y0_tri) * (xi - x2_tri) + (x0_tri - x2_tri) * (yi - y2_tri)) / denom
-            w3 = 1.0 - w1 - w2
-
-            # If all weights are between 0 and 1, point is inside triangle
-            if (w1 >= -1e-10) and (w2 >= -1e-10) and (w3 >= -1e-10):
-                # tri_idx = j
-
-                # Interpolate velocity
-                up1 = w1 * grid_u_adj[v0] + w2 * grid_u_adj[v1] + w3 * grid_u_adj[v2]
-                vp1 = w1 * grid_v_adj[v0] + w2 * grid_v_adj[v1] + w3 * grid_v_adj[v2]
-                break
-
-        x1a = xi + 0.5 * up1 * dt
-        y1a = yi + 0.5 * vp1 * dt
-
-        # Stage 2
-        up2 = 0.0
-        vp2 = 0.0
-        # tri_idx = -1
-
-        # Find containing triangle
-        for j in range(len(triangles)):
-            v0, v1, v2 = triangles[j]
-            x0_tri, y0_tri = grid_x[v0], grid_y[v0]
-            x1_tri, y1_tri = grid_x[v1], grid_y[v1]
-            x2_tri, y2_tri = grid_x[v2], grid_y[v2]
-
-            denom = (y1_tri - y2_tri) * (x0_tri - x2_tri) + (x2_tri - x1_tri) * (y0_tri - y2_tri)
-            if abs(denom) < 1e-10:
-                continue
-
-            w1 = ((y1_tri - y2_tri) * (x1a - x2_tri) + (x2_tri - x1_tri) * (y1a - y2_tri)) / denom
-            w2 = ((y2_tri - y0_tri) * (x1a - x2_tri) + (x0_tri - x2_tri) * (y1a - y2_tri)) / denom
-            w3 = 1.0 - w1 - w2
-
-            if (w1 >= -1e-10) and (w2 >= -1e-10) and (w3 >= -1e-10):
-                # tri_idx = j
-                up2 = w1 * grid_u_adj[v0] + w2 * grid_u_adj[v1] + w3 * grid_u_adj[v2]
-                vp2 = w1 * grid_v_adj[v0] + w2 * grid_v_adj[v1] + w3 * grid_v_adj[v2]
-                break
-
-        x1b = xi + 0.5 * up2 * dt
-        y1b = yi + 0.5 * vp2 * dt
-
-        # Stage 3
-        up3 = 0.0
-        vp3 = 0.0
-        # tri_idx = -1
-
-        # Find containing triangle
-        for j in range(len(triangles)):
-            v0, v1, v2 = triangles[j]
-            x0_tri, y0_tri = grid_x[v0], grid_y[v0]
-            x1_tri, y1_tri = grid_x[v1], grid_y[v1]
-            x2_tri, y2_tri = grid_x[v2], grid_y[v2]
-
-            denom = (y1_tri - y2_tri) * (x0_tri - x2_tri) + (x2_tri - x1_tri) * (y0_tri - y2_tri)
-            if abs(denom) < 1e-10:
-                continue
-
-            w1 = ((y1_tri - y2_tri) * (x1b - x2_tri) + (x2_tri - x1_tri) * (y1b - y2_tri)) / denom
-            w2 = ((y2_tri - y0_tri) * (x1b - x2_tri) + (x0_tri - x2_tri) * (y1b - y2_tri)) / denom
-            w3 = 1.0 - w1 - w2
-
-            if (w1 >= -1e-10) and (w2 >= -1e-10) and (w3 >= -1e-10):
-                # tri_idx = j
-                up3 = w1 * grid_u_adj[v0] + w2 * grid_u_adj[v1] + w3 * grid_u_adj[v2]
-                vp3 = w1 * grid_v_adj[v0] + w2 * grid_v_adj[v1] + w3 * grid_v_adj[v2]
-                break
-
-        x1c = xi + up3 * dt
-        y1c = yi + vp3 * dt
-
-        # Stage 4
-        up4 = 0.0
-        vp4 = 0.0
-        # tri_idx = -1
-
-        # Find containing triangle
-        for j in range(len(triangles)):
-            v0, v1, v2 = triangles[j]
-            x0_tri, y0_tri = grid_x[v0], grid_y[v0]
-            x1_tri, y1_tri = grid_x[v1], grid_y[v1]
-            x2_tri, y2_tri = grid_x[v2], grid_y[v2]
-
-            denom = (y1_tri - y2_tri) * (x0_tri - x2_tri) + (x2_tri - x1_tri) * (y0_tri - y2_tri)
-            if abs(denom) < 1e-10:
-                continue
-
-            w1 = ((y1_tri - y2_tri) * (x1c - x2_tri) + (x2_tri - x1_tri) * (y1c - y2_tri)) / denom
-            w2 = ((y2_tri - y0_tri) * (x1c - x2_tri) + (x0_tri - x2_tri) * (y1c - y2_tri)) / denom
-            w3 = 1.0 - w1 - w2
-
-            if (w1 >= -1e-10) and (w2 >= -1e-10) and (w3 >= -1e-10):
-                # tri_idx = j
-                up4 = w1 * grid_u_adj[v0] + w2 * grid_u_adj[v1] + w3 * grid_u_adj[v2]
-                vp4 = w1 * grid_v_adj[v0] + w2 * grid_v_adj[v1] + w3 * grid_v_adj[v2]
-                break
-
-        # Combine stages (RK4 integration)
-        x_new[i] = xi + dt / 6.0 * (up1 + 2.0 * up2 + 2.0 * up3 + up4)
-        y_new[i] = yi + dt / 6.0 * (vp1 + 2.0 * vp2 + 2.0 * vp3 + vp4)
-
-    return x_new, y_new
+    """Compatibility wrapper for the historical parallel update function."""
+    return update_particles_rk4(x0, y0, grid_u, grid_v, grid_x, grid_y, triangles, dt, igeo)

--- a/src/sedtrails/particle_tracer/timer.py
+++ b/src/sedtrails/particle_tracer/timer.py
@@ -62,9 +62,20 @@ def convert_datetime_string_to_datetime64(datetime_str: str) -> np.datetime64:
     DateFormatError
         If the input string does not match the required format.
     """
+    datetime_str = str(datetime_str)
     if not re.match(r'^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$', datetime_str):
         raise DateFormatError(f"date string '{datetime_str}' does not match required format 'YYYY-MM-DD hh:mm:ss'")
     return np.datetime64(datetime_str, 's')
+
+
+def convert_reference_date_to_datetime64(reference_date: str) -> np.datetime64:
+    """
+    Convert a reference date to numpy.datetime64, accepting date-only strings as midnight.
+    """
+    reference_date = str(reference_date)
+    if re.match(r'^\d{4}-\d{2}-\d{2}$', reference_date):
+        reference_date = f'{reference_date} 00:00:00'
+    return convert_datetime_string_to_datetime64(reference_date)
 
 
 class Duration:
@@ -200,7 +211,7 @@ class Time:
     def start(self) -> int:
         """Returns the simulation start time as an integer representing seconds since the reference date."""
         start_datetime = convert_datetime_string_to_datetime64(self._start)
-        reference_datetime = convert_datetime_string_to_datetime64(self.reference_date)
+        reference_datetime = convert_reference_date_to_datetime64(self.reference_date)
         # Calculate the difference in seconds
         delta_seconds = (start_datetime - reference_datetime).astype('timedelta64[s]').astype(int)
         return delta_seconds

--- a/src/sedtrails/particle_tracer/timer.py
+++ b/src/sedtrails/particle_tracer/timer.py
@@ -413,9 +413,17 @@ class Timer:
             max_velocity = max(max_velocity, 1e-12)
 
             min_resolution = sedtrails_data.metadata.min_resolution
+            self.compute_cfl_timestep_from_max_velocity(max_velocity, min_resolution, sedtrails_data.metadata.timestep)
+
+    def compute_cfl_timestep_from_max_velocity(
+        self, max_velocity: float, min_resolution: float, data_timestep: float
+    ) -> None:
+        """Compute CFL timestep from a precomputed maximum velocity."""
+        if self.cfl_condition > 0:
+            max_velocity = max(max_velocity, 1e-12)
             cfl_timestep = self.cfl_condition * min_resolution / max_velocity
 
             # Ensure CFL timestep doesn't exceed sedtrails data timestep
-            cfl_timestep = min(cfl_timestep, sedtrails_data.metadata.timestep)
+            cfl_timestep = min(cfl_timestep, data_timestep)
 
             self.set_timestep(cfl_timestep)

--- a/src/sedtrails/particle_tracer/timer.py
+++ b/src/sedtrails/particle_tracer/timer.py
@@ -2,9 +2,10 @@
 Time related classes used internally to represent simulation time.
 """
 
-from dataclasses import dataclass, field
-import numpy as np
 import re
+from dataclasses import dataclass, field
+
+import numpy as np
 
 from sedtrails.exceptions.exceptions import DateFormatError, DurationFormatError, ZeroDuration
 
@@ -427,14 +428,17 @@ class Timer:
             self.compute_cfl_timestep_from_max_velocity(max_velocity, min_resolution, sedtrails_data.metadata.timestep)
 
     def compute_cfl_timestep_from_max_velocity(
-        self, max_velocity: float, min_resolution: float, data_timestep: float
+        self, max_velocity: float, min_resolution: float | None, data_timestep: float | None
     ) -> None:
         """Compute CFL timestep from a precomputed maximum velocity."""
         if self.cfl_condition > 0:
-            max_velocity = max(max_velocity, 1e-12)
+            if min_resolution is None or min_resolution <= 0:
+                return
+            max_velocity = max(max_velocity, 1e-4)
             cfl_timestep = self.cfl_condition * min_resolution / max_velocity
 
-            # Ensure CFL timestep doesn't exceed sedtrails data timestep
-            cfl_timestep = min(cfl_timestep, data_timestep)
+            # Ensure CFL timestep doesn't exceed sedtrails data timestep when valid
+            if data_timestep is not None and data_timestep > 0:
+                cfl_timestep = min(cfl_timestep, data_timestep)
 
             self.set_timestep(cfl_timestep)

--- a/src/sedtrails/particle_tracer/timer.py
+++ b/src/sedtrails/particle_tracer/timer.py
@@ -405,10 +405,12 @@ class Timer:
             for flow_data in flow_data_list:
                 magnitude = flow_data['magnitude']
 
-                # Handle NaNs by setting them to 0
-                magnitude_clean = np.nan_to_num(magnitude, nan=0.0)
-                max_velocity = max(max_velocity, np.max(magnitude_clean))
-                max_velocity = max(max_velocity, 1e-12)
+                if np.isnan(magnitude).all():
+                    continue
+
+                max_velocity = max(max_velocity, np.nanmax(magnitude))
+
+            max_velocity = max(max_velocity, 1e-12)
 
             min_resolution = sedtrails_data.metadata.min_resolution
             cfl_timestep = self.cfl_condition * min_resolution / max_velocity

--- a/src/sedtrails/pathway_visualizer/simulation_dashboard.py
+++ b/src/sedtrails/pathway_visualizer/simulation_dashboard.py
@@ -5,18 +5,40 @@ This module provides interactive dashboard capabilities for monitoring particle
 simulations with spatial and temporal visualizations.
 """
 
-import numpy as np
-import matplotlib.pyplot as plt
-from matplotlib.colors import ListedColormap
-import matplotlib.dates as mdates
-from collections import defaultdict
-from pathlib import Path
 import datetime
-from typing import Dict, Tuple
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+import matplotlib.dates as mdates
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.colors import ListedColormap
+from matplotlib.path import Path as MplPath
+from scipy.spatial import ConvexHull, QhullError, cKDTree
+
+
+@dataclass
+class RasterInterpolationWeights:
+    """Cached mapping from dashboard raster pixels to source grid faces."""
+
+    geometry_key: tuple
+    shape: tuple[int, int]
+    extent: tuple[float, float, float, float]
+    face_indices: np.ndarray
+    weights: np.ndarray
+    valid_mask: np.ndarray
+    quiver_indices: np.ndarray
 
 
 class SimulationDashboard:
     """Real-time visualization dashboard for particle simulations."""
+
+    LARGE_GRID_POINT_LIMIT = 5_000
+    LARGE_GRID_QUIVER_LIMIT = 100
+    RASTER_MAX_SIDE = 700
+    RASTER_K_NEIGHBORS = 4
 
     def __init__(self, reference_date: str = '1970-01-01'):
         """Initialize the dashboard."""
@@ -29,6 +51,10 @@ class SimulationDashboard:
         self.plot_initialized = False
         self.last_update_time = 0
         self.keep_open = True  # Control for keeping window open after simulation
+        self._raster_weights: RasterInterpolationWeights | None = None
+        self._raster_images = {}
+        self._spatial_quivers = {}
+        self._particle_artists = []
 
         # Store reference date for time conversions
         self.reference_date = datetime.datetime.fromisoformat(reference_date)
@@ -73,6 +99,10 @@ class SimulationDashboard:
 
         # Force display and bring to front
         self._show_and_raise_window()
+
+    def should_update(self, current_time: float, plot_interval: float) -> bool:
+        """Return whether the dashboard should redraw for the given simulation time."""
+        return current_time - self.last_update_time >= plot_interval
 
     def _show_and_raise_window(self):
         """Show window and bring it to front (cross-platform)."""
@@ -255,11 +285,11 @@ class SimulationDashboard:
         plot_interval: float,
         simulation_start_time: float = 0,
         simulation_end_time: float | None = None,
+        mesh_geometry: Dict[str, Any] | None = None,
     ) -> None:
         """Update dashboard with current simulation data."""
 
-        # Check if we should update based on plot_interval
-        if current_time - self.last_update_time < plot_interval:
+        if not self.should_update(current_time, plot_interval):
             return
 
         # Store trajectory data at this plot_interval
@@ -277,8 +307,8 @@ class SimulationDashboard:
             particle_data_with_initial['y_initial'] = self.trajectories['y'][0]
 
         # Update all plots
-        self._update_flowfield_plot(flow_field, bathymetry)
-        self._update_bathymetry_plot(flow_field, bathymetry, particle_data_with_initial)
+        self._update_flowfield_plot(flow_field, bathymetry, mesh_geometry=mesh_geometry)
+        self._update_bathymetry_plot(flow_field, bathymetry, particle_data_with_initial, mesh_geometry=mesh_geometry)
         self._update_time_series_plots()
         self._update_progress_bar(current_time, simulation_start_time, simulation_end_time)
 
@@ -331,32 +361,328 @@ class SimulationDashboard:
         else:
             self.data_store['mixing_depth'].append(0.0)
 
-    def _update_flowfield_plot(self, flow_field: Dict[str, np.ndarray], bathymetry: np.ndarray) -> None:
+    @classmethod
+    def _is_large_grid(cls, n_points: int) -> bool:
+        """Return whether the spatial plot should use the sampled large-grid path."""
+        return n_points > cls.LARGE_GRID_POINT_LIMIT
+
+    @classmethod
+    def _sample_indices(cls, n_points: int, limit: int) -> slice | np.ndarray:
+        """Return deterministic point indices for large-grid plotting."""
+        if n_points <= limit:
+            return slice(None)
+        return np.linspace(0, n_points - 1, limit, dtype=np.intp)
+
+    @staticmethod
+    def _flatten(values: np.ndarray) -> np.ndarray:
+        """Flatten field data for plotting without copying when possible."""
+        return np.asarray(values).ravel()
+
+    def _geometry_key(self, x: np.ndarray, y: np.ndarray, mesh_geometry: Dict[str, Any] | None) -> tuple:
+        extent = self._spatial_extent(x, y, mesh_geometry)
+        if mesh_geometry is None:
+            return (x.size, extent, None, None, self.RASTER_MAX_SIDE, self.RASTER_K_NEIGHBORS)
+
+        node_x = mesh_geometry.get('node_x')
+        face_node_connectivity = mesh_geometry.get('face_node_connectivity')
+        node_count = 0 if node_x is None else np.asarray(node_x).size
+        connectivity_shape = None if face_node_connectivity is None else np.asarray(face_node_connectivity).shape
+        return (x.size, extent, node_count, connectivity_shape, self.RASTER_MAX_SIDE, self.RASTER_K_NEIGHBORS)
+
+    def _spatial_extent(
+        self, x: np.ndarray, y: np.ndarray, mesh_geometry: Dict[str, Any] | None
+    ) -> tuple[float, float, float, float]:
+        if mesh_geometry is not None and mesh_geometry.get('node_x') is not None and mesh_geometry.get('node_y') is not None:
+            extent_x = self._flatten(mesh_geometry['node_x'])
+            extent_y = self._flatten(mesh_geometry['node_y'])
+        else:
+            extent_x = x
+            extent_y = y
+
+        valid = np.isfinite(extent_x) & np.isfinite(extent_y)
+        min_x = float(np.nanmin(extent_x[valid]))
+        max_x = float(np.nanmax(extent_x[valid]))
+        min_y = float(np.nanmin(extent_y[valid]))
+        max_y = float(np.nanmax(extent_y[valid]))
+
+        if min_x == max_x:
+            min_x -= 0.5
+            max_x += 0.5
+        if min_y == max_y:
+            min_y -= 0.5
+            max_y += 0.5
+
+        return (min_x, max_x, min_y, max_y)
+
+    def _raster_shape(self, extent: tuple[float, float, float, float]) -> tuple[int, int]:
+        min_x, max_x, min_y, max_y = extent
+        width = max_x - min_x
+        height = max_y - min_y
+        if width >= height:
+            n_cols = self.RASTER_MAX_SIDE
+            n_rows = max(2, int(round(self.RASTER_MAX_SIDE * height / width)))
+        else:
+            n_rows = self.RASTER_MAX_SIDE
+            n_cols = max(2, int(round(self.RASTER_MAX_SIDE * width / height)))
+        return n_rows, n_cols
+
+    def _get_raster_weights(
+        self, x: np.ndarray, y: np.ndarray, mesh_geometry: Dict[str, Any] | None
+    ) -> RasterInterpolationWeights:
+        geometry_key = self._geometry_key(x, y, mesh_geometry)
+        current_weights = getattr(self, '_raster_weights', None)
+        if current_weights is not None and current_weights.geometry_key == geometry_key:
+            return current_weights
+
+        weights = self._build_raster_weights(x, y, mesh_geometry, geometry_key)
+        self._raster_weights = weights
+        return weights
+
+    def _build_raster_weights(
+        self,
+        x: np.ndarray,
+        y: np.ndarray,
+        mesh_geometry: Dict[str, Any] | None,
+        geometry_key: tuple,
+    ) -> RasterInterpolationWeights:
+        extent = self._spatial_extent(x, y, mesh_geometry)
+        n_rows, n_cols = self._raster_shape(extent)
+        min_x, max_x, min_y, max_y = extent
+
+        pixel_x = np.linspace(min_x, max_x, n_cols, endpoint=False) + (max_x - min_x) / (2 * n_cols)
+        pixel_y = np.linspace(min_y, max_y, n_rows, endpoint=False) + (max_y - min_y) / (2 * n_rows)
+        pixel_xx, pixel_yy = np.meshgrid(pixel_x, pixel_y)
+        pixel_points = np.column_stack((pixel_xx.ravel(), pixel_yy.ravel()))
+
+        valid_faces = np.flatnonzero(np.isfinite(x) & np.isfinite(y))
+        face_points = np.column_stack((x[valid_faces], y[valid_faces]))
+        tree = cKDTree(face_points)
+        k_neighbors = min(self.RASTER_K_NEIGHBORS, valid_faces.size)
+        distances, local_indices = self._query_tree(tree, pixel_points, k_neighbors)
+        if k_neighbors == 1:
+            distances = distances[:, None]
+            local_indices = local_indices[:, None]
+
+        face_indices = valid_faces[local_indices]
+        interpolation_weights = self._inverse_distance_weights(distances)
+        valid_mask = self._raster_valid_mask(pixel_points, distances[:, 0], extent, mesh_geometry).reshape(n_rows, n_cols)
+        quiver_indices = self._sample_indices(x.size, self.LARGE_GRID_QUIVER_LIMIT)
+        if isinstance(quiver_indices, slice):
+            quiver_indices = np.arange(x.size)[quiver_indices]
+
+        return RasterInterpolationWeights(
+            geometry_key=geometry_key,
+            shape=(n_rows, n_cols),
+            extent=extent,
+            face_indices=face_indices,
+            weights=interpolation_weights,
+            valid_mask=valid_mask,
+            quiver_indices=quiver_indices,
+        )
+
+    @staticmethod
+    def _query_tree(tree: cKDTree, pixel_points: np.ndarray, k_neighbors: int) -> tuple[np.ndarray, np.ndarray]:
+        try:
+            return tree.query(pixel_points, k=k_neighbors, workers=-1)
+        except TypeError:
+            return tree.query(pixel_points, k=k_neighbors)
+
+    @staticmethod
+    def _inverse_distance_weights(distances: np.ndarray) -> np.ndarray:
+        zero_distance = distances <= np.finfo(float).eps
+        has_exact_match = np.any(zero_distance, axis=1)
+        weights = np.zeros_like(distances, dtype=float)
+
+        if np.any(has_exact_match):
+            exact = zero_distance[has_exact_match]
+            weights[has_exact_match] = exact / exact.sum(axis=1, keepdims=True)
+
+        remaining = ~has_exact_match
+        if np.any(remaining):
+            inverse_distance = 1.0 / np.maximum(distances[remaining], np.finfo(float).eps) ** 2
+            weights[remaining] = inverse_distance / inverse_distance.sum(axis=1, keepdims=True)
+
+        return weights
+
+    def _raster_valid_mask(
+        self,
+        pixel_points: np.ndarray,
+        nearest_distances: np.ndarray,
+        extent: tuple[float, float, float, float],
+        mesh_geometry: Dict[str, Any] | None,
+    ) -> np.ndarray:
+        mask = np.ones(pixel_points.shape[0], dtype=bool)
+        if mesh_geometry is not None:
+            hull_mask = self._mesh_hull_mask(pixel_points, mesh_geometry)
+            if hull_mask is not None:
+                mask &= hull_mask
+
+        cell_radius = self._representative_cell_radius(mesh_geometry)
+        min_x, max_x, min_y, max_y = extent
+        pixel_dx = (max_x - min_x) / max(1, self._raster_shape(extent)[1])
+        pixel_dy = (max_y - min_y) / max(1, self._raster_shape(extent)[0])
+        pixel_diagonal = float(np.hypot(pixel_dx, pixel_dy))
+        if cell_radius is not None and np.isfinite(cell_radius):
+            mask &= nearest_distances <= max(3.0 * cell_radius, 2.0 * pixel_diagonal)
+
+        return mask
+
+    def _mesh_hull_mask(self, pixel_points: np.ndarray, mesh_geometry: Dict[str, Any]) -> np.ndarray | None:
+        node_x = mesh_geometry.get('node_x')
+        node_y = mesh_geometry.get('node_y')
+        if node_x is None or node_y is None:
+            return None
+
+        coords = np.column_stack((self._flatten(node_x), self._flatten(node_y)))
+        finite = np.isfinite(coords).all(axis=1)
+        coords = coords[finite]
+        if coords.shape[0] < 3:
+            return None
+
+        try:
+            hull = ConvexHull(coords)
+        except QhullError:
+            return None
+
+        hull_path = MplPath(coords[hull.vertices])
+        return hull_path.contains_points(pixel_points)
+
+    def _representative_cell_radius(self, mesh_geometry: Dict[str, Any] | None) -> float | None:
+        if mesh_geometry is None:
+            return None
+
+        node_x = mesh_geometry.get('node_x')
+        node_y = mesh_geometry.get('node_y')
+        connectivity = mesh_geometry.get('face_node_connectivity')
+        if node_x is None or node_y is None or connectivity is None:
+            return None
+
+        node_x = self._flatten(node_x)
+        node_y = self._flatten(node_y)
+        connectivity = np.asarray(connectivity, dtype=np.int64)
+        if connectivity.size == 0:
+            return None
+
+        sample_size = min(connectivity.shape[0], 100_000)
+        sample_indices = np.linspace(0, connectivity.shape[0] - 1, sample_size, dtype=np.intp)
+        sampled_connectivity = connectivity[sample_indices]
+        valid = sampled_connectivity >= 0
+        clipped = np.clip(sampled_connectivity, 0, max(0, node_x.size - 1))
+        face_node_x = np.where(valid, node_x[clipped], np.nan)
+        face_node_y = np.where(valid, node_y[clipped], np.nan)
+        center_x = np.nanmean(face_node_x, axis=1)
+        center_y = np.nanmean(face_node_y, axis=1)
+        radius = np.nanmax(np.hypot(face_node_x - center_x[:, None], face_node_y - center_y[:, None]), axis=1)
+        radius = radius[np.isfinite(radius) & (radius > 0)]
+        if radius.size == 0:
+            return None
+        return float(np.nanmedian(radius))
+
+    def _rasterize_field(self, values: np.ndarray, weights: RasterInterpolationWeights) -> np.ndarray:
+        field = self._flatten(values)
+        sampled_values = field[weights.face_indices]
+        finite = np.isfinite(sampled_values)
+        weighted_values = np.where(finite, sampled_values * weights.weights, 0.0)
+        valid_weights = np.where(finite, weights.weights, 0.0)
+        denominator = valid_weights.sum(axis=1)
+
+        image = np.full(weights.face_indices.shape[0], np.nan, dtype=float)
+        valid = denominator > 0.0
+        image[valid] = weighted_values.sum(axis=1)[valid] / denominator[valid]
+        image[~weights.valid_mask.ravel()] = np.nan
+        return image.reshape(weights.shape)
+
+    def _update_image_artist(
+        self,
+        axis_name: str,
+        image: np.ndarray,
+        weights: RasterInterpolationWeights,
+        cmap,
+        vmin: float | None = None,
+        vmax: float | None = None,
+    ):
+        ax = self.axes[axis_name]
+        images = getattr(self, '_raster_images', {})
+        image_artist = images.get(axis_name)
+        if image_artist is None or image_artist.axes is not ax:
+            ax.clear()
+            image_artist = ax.imshow(
+                image,
+                origin='lower',
+                extent=weights.extent,
+                cmap=cmap,
+                vmin=vmin,
+                vmax=vmax,
+                interpolation='nearest',
+            )
+            images[axis_name] = image_artist
+            self._raster_images = images
+        else:
+            image_artist.set_data(image)
+            image_artist.set_extent(weights.extent)
+            image_artist.set_clim(vmin=vmin, vmax=vmax)
+        return image_artist
+
+    def _remove_spatial_artist(self, artist_key: str) -> None:
+        artists = getattr(self, artist_key, {})
+        if isinstance(artists, dict):
+            for artist in artists.values():
+                try:
+                    artist.remove()
+                except (AttributeError, NotImplementedError, ValueError):
+                    pass
+            artists.clear()
+        elif isinstance(artists, list):
+            for artist in artists:
+                try:
+                    artist.remove()
+                except (AttributeError, NotImplementedError, ValueError):
+                    pass
+            artists.clear()
+
+    def _update_flowfield_plot(
+        self,
+        flow_field: Dict[str, np.ndarray],
+        bathymetry: np.ndarray,
+        mesh_geometry: Dict[str, Any] | None = None,
+    ) -> None:
         """Update the flow field spatial plot."""
         ax = self.axes['flowfield']
-        ax.clear()
 
-        x, y, magnitude = flow_field['x'], flow_field['y'], flow_field['magnitude']
+        x = self._flatten(flow_field['x'])
+        y = self._flatten(flow_field['y'])
+        magnitude = self._flatten(flow_field['magnitude'])
+        u = self._flatten(flow_field['u'])
+        v = self._flatten(flow_field['v'])
+        bathymetry = self._flatten(bathymetry)
+        n_points = x.size
 
-        # Contour plot of magnitude
-        ax.tricontourf(x, y, magnitude, levels=15, cmap='viridis')
+        self._remove_spatial_artist('_spatial_quivers')
 
-        # Add z=0 bathymetry contour
-        ax.tricontour(x, y, bathymetry, levels=[0], colors='white', linewidths=2, linestyles='-')
+        if self._is_large_grid(n_points):
+            weights = self._get_raster_weights(x, y, mesh_geometry)
+            image = self._rasterize_field(magnitude, weights)
+            self._update_image_artist('flowfield', image, weights, cmap='viridis')
+            quiver_sampled = weights.quiver_indices
+        else:
+            getattr(self, '_raster_images', {}).pop('flowfield', None)
+            ax.clear()
+            ax.tricontourf(x, y, magnitude, levels=15, cmap='viridis')
+            ax.tricontour(x, y, bathymetry, levels=[0], colors='white', linewidths=2, linestyles='-')
+            downsample = max(1, n_points // 20)
+            quiver_sampled = slice(None, None, downsample)
 
-        # Add velocity vectors (more vectors - reduce downsample)
-        downsample = max(1, len(x) // 20)  # Reduced from 50 to 20 for more vectors
-        skip = slice(None, None, downsample)
-        ax.quiver(
-            x[skip],
-            y[skip],
-            flow_field['u'][skip],
-            flow_field['v'][skip],
+        quiver = ax.quiver(
+            x[quiver_sampled],
+            y[quiver_sampled],
+            u[quiver_sampled],
+            v[quiver_sampled],
             color='white',
             scale=10,
             width=0.004,
             alpha=0.8,
-        )  # Adjusted scale and width
+        )
+        self._spatial_quivers = {'flowfield': quiver}
 
         ax.set_xlabel('X (m)')
         ax.set_ylabel('Y (m)')
@@ -364,53 +690,88 @@ class SimulationDashboard:
         ax.set_title('(a) Flow Field (Latest)', fontsize=12, fontweight='bold')
 
     def _update_bathymetry_plot(
-        self, flow_field: Dict[str, np.ndarray], bathymetry: np.ndarray, particles: Dict[str, np.ndarray]
+        self,
+        flow_field: Dict[str, np.ndarray],
+        bathymetry: np.ndarray,
+        particles: Dict[str, np.ndarray],
+        mesh_geometry: Dict[str, Any] | None = None,
     ) -> None:
         """Update the bathymetry and particles spatial plot."""
         ax = self.axes['bathymetry']
-        ax.clear()
 
-        x, y = flow_field['x'], flow_field['y']
+        x = self._flatten(flow_field['x'])
+        y = self._flatten(flow_field['y'])
+        bathymetry = self._flatten(bathymetry)
 
-        # Bathymetry contour plot
-        ax.tricontourf(
-            x, y, bathymetry, levels=20, cmap=self.bathymetry_cmap, vmin=self.bathymetry_vmin, vmax=self.bathymetry_vmax
-        )
+        self._remove_spatial_artist('_particle_artists')
+        legend = ax.get_legend()
+        if legend is not None:
+            try:
+                legend.remove()
+            except (AttributeError, NotImplementedError, ValueError):
+                pass
 
-        # Add z=0 bathymetry contour
-        ax.tricontour(x, y, bathymetry, levels=[0], colors='black', linewidths=2, linestyles='-')
+        if self._is_large_grid(x.size):
+            weights = self._get_raster_weights(x, y, mesh_geometry)
+            image = self._rasterize_field(bathymetry, weights)
+            self._update_image_artist(
+                'bathymetry',
+                image,
+                weights,
+                cmap=self.bathymetry_cmap,
+                vmin=self.bathymetry_vmin,
+                vmax=self.bathymetry_vmax,
+            )
+        else:
+            getattr(self, '_raster_images', {}).pop('bathymetry', None)
+            ax.clear()
+            ax.tricontourf(
+                x,
+                y,
+                bathymetry,
+                levels=20,
+                cmap=self.bathymetry_cmap,
+                vmin=self.bathymetry_vmin,
+                vmax=self.bathymetry_vmax,
+            )
+            ax.tricontour(x, y, bathymetry, levels=[0], colors='black', linewidths=2, linestyles='-')
 
         # Plot particles
+        particle_artists = getattr(self, '_particle_artists', [])
         if len(particles['x']) > 0:
             # Current positions (white circles)
-            ax.scatter(
-                particles['x'],
-                particles['y'],
-                color='white',
-                s=50,
-                marker='o',
-                edgecolors='black',
-                linewidth=1,
-                label='Current',
-                zorder=5,
+            particle_artists.append(
+                ax.scatter(
+                    particles['x'],
+                    particles['y'],
+                    color='white',
+                    s=50,
+                    marker='o',
+                    edgecolors='black',
+                    linewidth=1,
+                    label='Current',
+                    zorder=5,
+                )
             )
 
             # Initial positions (white crosses)
             if 'x_initial' in particles:
-                ax.scatter(
-                    particles['x_initial'],
-                    particles['y_initial'],
-                    color='white',
-                    s=50,
-                    marker='x',
-                    linewidth=3,
-                    label='Initial',
-                    zorder=5,
+                particle_artists.append(
+                    ax.scatter(
+                        particles['x_initial'],
+                        particles['y_initial'],
+                        color='white',
+                        s=50,
+                        marker='x',
+                        linewidth=3,
+                        label='Initial',
+                        zorder=5,
+                    )
                 )
 
                 # Connect with lines
                 for i in range(len(particles['x'])):
-                    ax.plot(
+                    (line,) = ax.plot(
                         [particles['x_initial'][i], particles['x'][i]],
                         [particles['y_initial'][i], particles['y'][i]],
                         'w-',
@@ -418,8 +779,10 @@ class SimulationDashboard:
                         linewidth=1,
                         zorder=4,
                     )
+                    particle_artists.append(line)
 
             ax.legend(loc='upper right')
+        self._particle_artists = particle_artists
 
         ax.set_xlabel('X (m)')
         ax.set_ylabel('Y (m)')

--- a/src/sedtrails/simulation_orchestrator/simulation_manager.py
+++ b/src/sedtrails/simulation_orchestrator/simulation_manager.py
@@ -474,6 +474,32 @@ class Simulation:
                         _cache[cache_key] = _retriever.get_flow_field(_time, flow_field_name)
                 return _cache[cache_key]
 
+            def get_flow_field_bounds_cached(
+                flow_field_name: str,
+                profile_name: str,
+                _cache=field_cache,
+                _retriever=retriever,
+                _time=cache_time,
+            ):
+                cache_key = ('flow_bounds', _time, flow_field_name)
+                if cache_key not in _cache:
+                    with self._profile_section(profile_name):
+                        _cache[cache_key] = _retriever.get_flow_field_bounds(_time, flow_field_name)
+                return _cache[cache_key]
+
+            def get_flow_max_velocity_cached(
+                flow_field_name: str,
+                profile_name: str,
+                _cache=field_cache,
+                _retriever=retriever,
+                _time=cache_time,
+            ):
+                cache_key = ('flow_max_velocity', _time, flow_field_name)
+                if cache_key not in _cache:
+                    with self._profile_section(profile_name):
+                        _cache[cache_key] = _retriever.get_flow_max_velocity_bound(_time, flow_field_name)
+                return _cache[cache_key]
+
             def get_scalar_field_cached(
                 scalar_field_name: str,
                 profile_name: str,
@@ -487,13 +513,33 @@ class Simulation:
                         _cache[cache_key] = _retriever.get_scalar_field(_time, scalar_field_name)['magnitude']
                 return _cache[cache_key]
 
-            flow_data_list = []
+            def get_scalar_field_bounds_cached(
+                scalar_field_name: str,
+                profile_name: str,
+                _cache=field_cache,
+                _retriever=retriever,
+                _time=cache_time,
+            ):
+                cache_key = ('scalar_bounds', _time, scalar_field_name)
+                if cache_key not in _cache:
+                    with self._profile_section(profile_name):
+                        _cache[cache_key] = _retriever.get_scalar_field_bounds(_time, scalar_field_name)
+                return _cache[cache_key]
+
+            max_velocity = 0.0
             for flow_field_name in flow_field_names:
-                flow_data_list.append(get_flow_field_cached(flow_field_name, 'get_flow_field.cfl'))
+                max_velocity = max(
+                    max_velocity,
+                    get_flow_max_velocity_cached(flow_field_name, 'get_flow_max_velocity.cfl'),
+                )
 
             # Compute CFL-based timestep across all flow fields
             with self._profile_section('compute_cfl_timestep'):
-                timer.compute_cfl_timestep(flow_data_list, sedtrails_data)
+                timer.compute_cfl_timestep_from_max_velocity(
+                    max_velocity,
+                    sedtrails_data.metadata.min_resolution,
+                    sedtrails_data.metadata.timestep,
+                )
 
             # Main loop
             for ip, population in enumerate(populations):
@@ -506,20 +552,20 @@ class Simulation:
                 for flow_field_name in flow_field_names:
                     # Obtain scalar field information
                     # TODO: Consider moving van westen specific fields to the plugin itself
-                    bed_level = get_scalar_field_cached('bed_level', 'get_scalar_field.bed_level')
+                    bed_level = get_scalar_field_bounds_cached('bed_level', 'get_scalar_field.bed_level')
                     mixing_depth = None
                     if tracer_method == 'vanwesten':
-                        transport_prob = get_scalar_field_cached(
+                        transport_prob = get_scalar_field_bounds_cached(
                             flow_field_name.replace('velocity', 'probability'),
                             'get_scalar_field.transport_probability',
                         )
-                        mixing_depth = get_scalar_field_cached(
+                        mixing_depth = get_scalar_field_bounds_cached(
                             'mixing_layer_thickness',
                             'get_scalar_field.mixing_layer_thickness',
                         )
                     elif tracer_method == 'soulsby':
                         transport_prob = 1.0
-                        mixing_depth = get_scalar_field_cached(
+                        mixing_depth = get_scalar_field_bounds_cached(
                             'mixing_layer_thickness',
                             'get_scalar_field.mixing_layer_thickness',
                         )
@@ -543,7 +589,7 @@ class Simulation:
                     population.update_status()
 
                     # Get flow field information
-                    flow_field = get_flow_field_cached(flow_field_name, 'get_flow_field.update_position')
+                    flow_field = get_flow_field_bounds_cached(flow_field_name, 'get_flow_field.update_position')
 
                     # Update particle position
                     with self._profile_section('update_position'):
@@ -579,6 +625,7 @@ class Simulation:
                 }
                 # Get bathymetry data
                 bathymetry = get_scalar_field_cached('bed_level', 'get_scalar_field.dashboard_bed_level')
+                dashboard_flow_field = get_flow_field_cached(flow_field_names[0], 'get_flow_field.dashboard')
 
                 # Particle data including burial_depth and mixing_depth
 
@@ -589,7 +636,7 @@ class Simulation:
                 # Update dashboard with timing info
 
                 self.dashboard.update(
-                    flow_field,
+                    dashboard_flow_field,
                     bathymetry,
                     particle_data,
                     timer.current,

--- a/src/sedtrails/simulation_orchestrator/simulation_manager.py
+++ b/src/sedtrails/simulation_orchestrator/simulation_manager.py
@@ -200,6 +200,52 @@ class Simulation:
 
         return timer.step_count % stride == 0
 
+    def _dashboard_update_interval_seconds(self) -> int:
+        """Return the configured dashboard redraw interval in seconds."""
+        update_interval = self._controller.get('visualization.dashboard.update_interval', '1H')
+        return Duration(update_interval).seconds
+
+    def _create_simulation_time(self) -> Time:
+        """Build simulation time using the same reference date as the input data."""
+        return Time(
+            _start=self._controller.get('time.start'),
+            duration=Duration(self._controller.get('time.duration')),
+            time_step=Duration(self._controller.get('time.timestep')),
+            read_input_interval=Duration(self._controller.get('inputs.read_interval')),
+            reference_date=self._controller.get('general.input_model.reference_date', '1970-01-01 00:00:00'),
+        )
+
+    @staticmethod
+    def _needs_sedtrails_reload(sedtrails_data, current_time_seconds: float) -> bool:
+        """Return whether the current time is outside the loaded SedTRAILS data chunk."""
+        if sedtrails_data is None:
+            return True
+
+        times = np.asarray(sedtrails_data.times)
+        if times.size == 0:
+            return True
+
+        return current_time_seconds < times[0] or current_time_seconds > times[-1]
+
+    @staticmethod
+    def _is_after_loaded_sedtrails_data(sedtrails_data, current_time_seconds: float) -> bool:
+        """Return whether current time is after the last timestamp in the loaded data."""
+        if sedtrails_data is None:
+            return False
+
+        times = np.asarray(sedtrails_data.times)
+        if times.size == 0:
+            return False
+
+        return current_time_seconds > times[-1]
+
+    @classmethod
+    def _should_attempt_sedtrails_reload(
+        cls, sedtrails_data, current_time_seconds: float, input_data_exhausted: bool
+    ) -> bool:
+        """Return whether the loop should try to load another SedTRAILS data chunk."""
+        return not input_data_exhausted and cls._needs_sedtrails_reload(sedtrails_data, current_time_seconds)
+
     def _get_format_config(self):
         """
         Returns configuration parameters required for the format converter.
@@ -379,12 +425,7 @@ class Simulation:
             self._config_is_read = True
 
         # Time configuration
-        simulation_time = Time(
-            _start=self._controller.get('time.start'),
-            duration=Duration(self._controller.get('time.duration')),
-            time_step=Duration(self._controller.get('time.timestep')),
-            read_input_interval=Duration(self._controller.get('inputs.read_interval')),
-        )
+        simulation_time = self._create_simulation_time()
 
         timer = Timer(simulation_time=simulation_time, cfl_condition=self._controller.get('time.cfl_condition'))
 
@@ -451,10 +492,12 @@ class Simulation:
         self.data_manager.writer.add_metadata(xr_data, populations, flow_field_names)
 
         # Main simulation loop with variable timestep
+        input_data_exhausted = False
+        input_exhaustion_warning_logged = False
         while not timer.stop:
             # Check if current time is within loaded SedTRAILS data
             current_time_seconds = timer.current
-            if sedtrails_data is None or current_time_seconds > sedtrails_data.times[-2]:
+            if self._should_attempt_sedtrails_reload(sedtrails_data, current_time_seconds, input_data_exhausted):
                 # Avoid recreating SedTRAILS data if current time is before the first time step
                 if sedtrails_data is not None and current_time_seconds < sedtrails_data.times[0]:
                     timer.advance()
@@ -475,6 +518,17 @@ class Simulation:
 
                 # Create new FieldDataRetriever with updated data
                 retriever = FieldDataRetriever(sedtrails_data)  # TODO: should the retriever only be created once?
+
+                if self._is_after_loaded_sedtrails_data(sedtrails_data, current_time_seconds):
+                    input_data_exhausted = True
+                    if not input_exhaustion_warning_logged:
+                        self.logger.warning(
+                            'Simulation time %.3fs is beyond the final input field timestamp %.3fs; '
+                            'reusing the last available fields for remaining timesteps.',
+                            current_time_seconds,
+                            float(np.asarray(sedtrails_data.times)[-1]),
+                        )
+                        input_exhaustion_warning_logged = True
 
             # TODO: integrate loop over flow fields into CFL Condition
             # Collect flow fields for CFL computation
@@ -633,50 +687,45 @@ class Simulation:
             # Check if we need to expand the time dimension
             if timer.step_count >= max_timesteps - 10:  # 10-step safety margin
                 old_max = max_timesteps
-                max_timesteps = int(max_timesteps * 1.5)  # Expand by 50%
+                max_timesteps = int(max_timesteps * 2.0)  # Expand by 100%
                 self.logger.info(f'Expanding time dimension from {old_max} to {max_timesteps}')
                 xr_data = self._expand_time_dimension(xr_data, max_timesteps)
 
             # Update dashboard if enabled
             if self._should_update_dashboard(sedtrails_data, timer):
-                # For dashboard, use first population data
-                first_population = populations[0]
-                particle_data = {
-                    'x': first_population.particles['x'],
-                    'y': first_population.particles['y'],
-                    'burial_depth': [
-                        first_population.particles['burial_depth']
-                        if not np.all(np.isnan(first_population.particles['burial_depth']))
-                        else np.full(first_population.particles['x'].shape, np.nan)
-                    ],
-                    'mixing_depth': [
-                        first_population.particles['mixing_depth']
-                        if 'mixing_depth' in first_population.particles.keys()
-                        else np.full(first_population.particles['x'].shape, np.nan)
-                    ],
-                }
-                # Get bathymetry data
-                bathymetry = get_scalar_field_cached('bed_level', 'get_scalar_field.dashboard_bed_level')
-                dashboard_flow_field = get_flow_field_cached(flow_field_names[0], 'get_flow_field.dashboard')
+                plot_interval_seconds = self._dashboard_update_interval_seconds()
+                if self.dashboard.should_update(timer.current, plot_interval_seconds):
+                    # For dashboard, use first population data
+                    first_population = populations[0]
+                    particle_data = {
+                        'x': first_population.particles['x'],
+                        'y': first_population.particles['y'],
+                        'burial_depth': [
+                            first_population.particles['burial_depth']
+                            if not np.all(np.isnan(first_population.particles['burial_depth']))
+                            else np.full(first_population.particles['x'].shape, np.nan)
+                        ],
+                        'mixing_depth': [
+                            first_population.particles['mixing_depth']
+                            if 'mixing_depth' in first_population.particles.keys()
+                            else np.full(first_population.particles['x'].shape, np.nan)
+                        ],
+                    }
+                    bathymetry = get_scalar_field_cached('bed_level', 'get_scalar_field.dashboard_bed_level')
+                    dashboard_flow_field = get_flow_field_cached(flow_field_names[0], 'get_flow_field.dashboard')
+                    mesh_geometry = sedtrails_data.mesh_geometry() if hasattr(sedtrails_data, 'mesh_geometry') else None
 
-                # Particle data including burial_depth and mixing_depth
-
-                # Get simulation timing
-                # plot_interval_str = self._controller.get('output.plot_interval', '1H')
-                plot_interval_seconds = 3600  # self._parse_duration(plot_interval_str)
-
-                # Update dashboard with timing info
-
-                self.dashboard.update(
-                    dashboard_flow_field,
-                    bathymetry,
-                    particle_data,
-                    timer.current,
-                    timer.current_timestep,
-                    plot_interval_seconds,
-                    simulation_start_time=simulation_time.start,  # Add this
-                    simulation_end_time=simulation_time.end,  # Add this
-                )
+                    self.dashboard.update(
+                        dashboard_flow_field,
+                        bathymetry,
+                        particle_data,
+                        timer.current,
+                        timer.current_timestep,
+                        plot_interval_seconds,
+                        simulation_start_time=simulation_time.start,
+                        simulation_end_time=simulation_time.end,
+                        mesh_geometry=mesh_geometry,
+                    )
 
             timer.advance()
 

--- a/src/sedtrails/simulation_orchestrator/simulation_manager.py
+++ b/src/sedtrails/simulation_orchestrator/simulation_manager.py
@@ -605,10 +605,10 @@ class Simulation:
         for var_name in xr_data.data_vars:
             var = xr_data[var_name]
 
-            if 'time' in var.dims:
+            if 'n_timesteps' in var.dims:
                 # Get the shape and create padding
                 pad_shape = list(var.shape)
-                time_dim_idx = var.dims.index('time')
+                time_dim_idx = var.dims.index('n_timesteps')
                 pad_shape[time_dim_idx] = additional_steps
 
                 # Create NaN-filled array for padding
@@ -618,7 +618,7 @@ class Simulation:
                 # Build coordinates for the padded array
                 pad_coords = {}
                 for dim in var.dims:
-                    if dim == 'time':
+                    if dim == 'n_timesteps':
                         pad_coords[dim] = np.arange(current_size, new_max_timesteps)
                     else:
                         pad_coords[dim] = var.coords[dim]
@@ -626,7 +626,7 @@ class Simulation:
                 pad_array = xr.DataArray(pad_data, dims=var.dims, coords=pad_coords)
 
                 # Concatenate along time dimension
-                expanded_vars[var_name] = xr.concat([var, pad_array], dim='time')
+                expanded_vars[var_name] = xr.concat([var, pad_array], dim='n_timesteps')
             else:
                 # Keep non-time variables as is
                 expanded_vars[var_name] = var

--- a/src/sedtrails/simulation_orchestrator/simulation_manager.py
+++ b/src/sedtrails/simulation_orchestrator/simulation_manager.py
@@ -287,14 +287,12 @@ class Simulation:
 
         timer = Timer(simulation_time=simulation_time, cfl_condition=self._controller.get('time.cfl_condition'))
 
-        # Load SedTRAILS data for 'x' and 'y' (needed for population seeder)
-        sedtrails_data = self.format_converter.convert_to_sedtrails(
-            current_time=simulation_time._start, reading_interval=1
-        )
+        # Load only x/y field coordinates needed for the population seeder.
+        seeding_field_data = self.format_converter.get_seeding_field_data()
 
         populations_config = self._controller.get('particles.populations', [])
         seeder = ParticleSeeder(populations_config)  # intialize seeder with population config
-        populations = seeder.seed(sedtrails_data)  # seed particles for all populations using current sedtrails data
+        populations = seeder.seed(seeding_field_data)  # seed particles for all populations
 
         # Set initial values
         sedtrails_data = None
@@ -378,8 +376,8 @@ class Simulation:
             tracer_methods = {}
             # TODO: this loops over populations_config, but only the last one is used. This must be fixed
             # to handle multiple populations with different tracer methods and flow fields
-            for population in populations_config:
-                tracer_methods[population['name']] = population['tracer_methods']
+            for ip, population in enumerate(populations_config):
+                tracer_methods[ip] = population['tracer_methods']
 
             flow_data_list = []
             for flow_field_name in flow_field_names:
@@ -389,18 +387,26 @@ class Simulation:
             timer.compute_cfl_timestep(flow_data_list, sedtrails_data)
 
             # Main loop
-            for population in populations:
+            for ip, population in enumerate(populations):
                 for _method in tracer_methods.keys():
                     for flow_field_name in flow_field_names:
                         # Obtain scalar field information
                         # TODO: Consider moving van westen specific fields to the plugin itself
-                        mixing_depth = retriever.get_scalar_field(timer.current, 'mixing_layer_thickness')['magnitude']
                         bed_level = retriever.get_scalar_field(timer.current, 'bed_level')['magnitude']
-                        if tracer_methods[population] == 'vanwesten':
+                        mixing_depth = np.full(bed_level.shape, np.nan)
+                        if tracer_methods[ip] == 'vanwesten':
                             transport_prob = retriever.get_scalar_field(
                                 timer.current, flow_field_name.replace('velocity', 'probability')
                             )['magnitude']
-                        else:  # soulsby
+                            mixing_depth = retriever.get_scalar_field(timer.current, 'mixing_layer_thickness')[
+                                'magnitude'
+                            ]
+                        elif tracer_methods[ip] == 'soulsby':
+                            transport_prob = np.ones_like(bed_level)
+                            mixing_depth = retriever.get_scalar_field(timer.current, 'mixing_layer_thickness')[
+                                'magnitude'
+                            ]
+                        else:
                             transport_prob = np.ones_like(bed_level)
 
                         # Update information at particle positions
@@ -412,7 +418,7 @@ class Simulation:
                         )
 
                         # Update particle burial depth
-                        if tracer_methods[population] == 'vanwesten':
+                        if tracer_methods[ip] == 'vanwesten':
                             population.update_burial_depth()
 
                         # Determining status
@@ -441,8 +447,16 @@ class Simulation:
                 particle_data = {
                     'x': first_population.particles['x'],
                     'y': first_population.particles['y'],
-                    'burial_depth': first_population.particles['burial_depth'],
-                    'mixing_depth': first_population.particles['mixing_depth'],
+                    'burial_depth': [
+                        first_population.particles['burial_depth']
+                        if not np.all(np.isnan(first_population.particles['burial_depth']))
+                        else np.full(first_population.particles['x'].shape, np.nan)
+                    ],
+                    'mixing_depth': [
+                        first_population.particles['mixing_depth']
+                        if 'mixing_depth' in first_population.particles.keys()
+                        else np.full(first_population.particles['x'].shape, np.nan)
+                    ],
                 }
                 # Get bathymetry data
                 bathymetry = retriever.get_scalar_field(timer.current, 'bed_level')['magnitude']

--- a/src/sedtrails/simulation_orchestrator/simulation_manager.py
+++ b/src/sedtrails/simulation_orchestrator/simulation_manager.py
@@ -26,6 +26,9 @@ from sedtrails.transport_converter.physics_converter import PhysicsConverter
 class Simulation:
     """Class to encapsulate the particle simulation process."""
 
+    _DASHBOARD_FULL_GRID_CELL_LIMIT = 100_000
+    _DASHBOARD_LARGE_GRID_UPDATE_STRIDE = 10
+
     def __init__(self, config_file: str, enable_dashboard: Optional[bool] = None):
         """
         Initialize the simulation with the given configuration.
@@ -47,6 +50,7 @@ class Simulation:
         self._profile_timings = {}
         self._profile_summary_logged = False
         self._active_progress_bar = None
+        self._dashboard_throttle_logged = False
 
         # Validate config file exists early
         if not os.path.exists(config_file):
@@ -167,6 +171,34 @@ class Simulation:
             return dashboard
         else:
             return None
+
+    def _should_update_dashboard(self, sedtrails_data, timer) -> bool:
+        """Throttle full-grid dashboard redraws for large grids."""
+        if self.dashboard is None:
+            return False
+
+        grid_size = np.size(sedtrails_data.x)
+        if grid_size <= self._DASHBOARD_FULL_GRID_CELL_LIMIT:
+            return True
+
+        stride = self._controller.get(
+            'visualization.dashboard.large_grid_update_stride',
+            self._DASHBOARD_LARGE_GRID_UPDATE_STRIDE,
+        )
+        try:
+            stride = max(1, int(stride))
+        except (TypeError, ValueError):
+            stride = self._DASHBOARD_LARGE_GRID_UPDATE_STRIDE
+
+        if not self._dashboard_throttle_logged:
+            self.logger.info(
+                'Dashboard full-grid updates throttled to every %d steps for %d grid cells',
+                stride,
+                grid_size,
+            )
+            self._dashboard_throttle_logged = True
+
+        return timer.step_count % stride == 0
 
     def _get_format_config(self):
         """
@@ -606,7 +638,7 @@ class Simulation:
                 xr_data = self._expand_time_dimension(xr_data, max_timesteps)
 
             # Update dashboard if enabled
-            if self.dashboard is not None:
+            if self._should_update_dashboard(sedtrails_data, timer):
                 # For dashboard, use first population data
                 first_population = populations[0]
                 particle_data = {

--- a/src/sedtrails/simulation_orchestrator/simulation_manager.py
+++ b/src/sedtrails/simulation_orchestrator/simulation_manager.py
@@ -1,6 +1,8 @@
 import logging
 import os
 import sys
+import time
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Optional
 
@@ -41,6 +43,10 @@ class Simulation:
         self._start_time = None
         self._config_is_read = False
         self._populations_config = None
+        self._profile_enabled = self._is_profile_enabled()
+        self._profile_timings = {}
+        self._profile_summary_logged = False
+        self._active_progress_bar = None
 
         # Validate config file exists early
         if not os.path.exists(config_file):
@@ -79,6 +85,58 @@ class Simulation:
         setup_logging(output_dir=str(self.writer.output_dir))  # Initialize logging in the results directory
         self.logger = logging.getLogger(__name__)
         self.logger.info('Configuration loaded')
+        if self._profile_enabled:
+            self.logger.info('Profiling enabled via SEDTRAILS_PROFILE')
+
+    @staticmethod
+    def _is_profile_enabled() -> bool:
+        """Return whether lightweight simulation profiling is enabled."""
+        return os.environ.get('SEDTRAILS_PROFILE', '').strip().lower() in {'1', 'true', 'yes', 'on'}
+
+    @contextmanager
+    def _profile_section(self, name: str):
+        """Measure a section when profiling is enabled."""
+        if not self._profile_enabled:
+            yield
+            return
+
+        start = time.perf_counter()
+        try:
+            yield
+        finally:
+            elapsed = time.perf_counter() - start
+            stats = self._profile_timings.setdefault(name, {'count': 0, 'total': 0.0, 'max': 0.0})
+            stats['count'] += 1
+            stats['total'] += elapsed
+            stats['max'] = max(stats['max'], elapsed)
+
+    def _log_profile_summary(self, status: str = 'completed') -> None:
+        """Write the aggregated profiling timings to the simulation logger."""
+        if not self._profile_enabled:
+            return
+
+        if self._profile_summary_logged:
+            return
+
+        self._profile_summary_logged = True
+
+        if not self._profile_timings:
+            self.logger.info('Profiling enabled, but no sections were recorded (status=%s)', status)
+            return
+
+        self.logger.info('=== SEDTRAILS PROFILE SUMMARY (%s) ===', status)
+        for name, stats in sorted(self._profile_timings.items(), key=lambda item: item[1]['total'], reverse=True):
+            count = stats['count']
+            total = stats['total']
+            average = total / count if count else 0.0
+            self.logger.info(
+                'profile %-42s count=%6d total=%10.6fs avg=%10.6fs max=%10.6fs',
+                name,
+                count,
+                total,
+                average,
+                stats['max'],
+            )
 
     def _create_dashboard(self):
         """Create and return a dashboard instance."""
@@ -268,6 +326,17 @@ class Simulation:
         return value
 
     def run(self):
+        """Execute the simulation and flush profile timings on failure."""
+        try:
+            return self._run_impl()
+        except Exception:
+            if self._active_progress_bar is not None:
+                self._active_progress_bar.close()
+                self._active_progress_bar = None
+            self._log_profile_summary(status='interrupted')
+            raise
+
+    def _run_impl(self):
         """
         Executes the particle simulation workflow.
         """
@@ -288,7 +357,8 @@ class Simulation:
         timer = Timer(simulation_time=simulation_time, cfl_condition=self._controller.get('time.cfl_condition'))
 
         # Load only x/y field coordinates needed for the population seeder.
-        seeding_field_data = self.format_converter.get_seeding_field_data()
+        with self._profile_section('get_seeding_field_data'):
+            seeding_field_data = self.format_converter.get_seeding_field_data()
 
         populations_config = self._controller.get('particles.populations', [])
         seeder = ParticleSeeder(populations_config)  # intialize seeder with population config
@@ -304,6 +374,7 @@ class Simulation:
             unit='%',
             bar_format='{l_bar}{bar}| {n:.1f}% [{elapsed}<{remaining}, {postfix}]',
         )
+        self._active_progress_bar = pbar
 
         log_simulation_state(
             self.logger,
@@ -357,16 +428,18 @@ class Simulation:
                     timer.advance()
                     continue
                 # Convert to SedTRAILS format
-                sedtrails_data = self.format_converter.convert_to_sedtrails(
-                    current_time=current_time_seconds, reading_interval=simulation_time.read_input_interval.seconds
-                )
+                with self._profile_section('convert_to_sedtrails'):
+                    sedtrails_data = self.format_converter.convert_to_sedtrails(
+                        current_time=current_time_seconds, reading_interval=simulation_time.read_input_interval.seconds
+                    )
 
                 # Convert physics fields with transport probability configuration
                 for pop in self.populations_config:
-                    self.physics_converter.convert_physics(
-                        sedtrails_data=sedtrails_data,
-                        transport_probability_method=pop.get('transport_probability'),
-                    )
+                    with self._profile_section('convert_physics'):
+                        self.physics_converter.convert_physics(
+                            sedtrails_data=sedtrails_data,
+                            transport_probability_method=pop.get('transport_probability'),
+                        )
 
                 # Create new FieldDataRetriever with updated data
                 retriever = FieldDataRetriever(sedtrails_data)  # TODO: should the retriever only be created once?
@@ -387,10 +460,12 @@ class Simulation:
 
             flow_data_list = []
             for flow_field_name in flow_field_names:
-                flow_data_list.append(retriever.get_flow_field(timer.current, flow_field_name))
+                with self._profile_section('get_flow_field.cfl'):
+                    flow_data_list.append(retriever.get_flow_field(timer.current, flow_field_name))
 
             # Compute CFL-based timestep across all flow fields
-            timer.compute_cfl_timestep(flow_data_list, sedtrails_data)
+            with self._profile_section('compute_cfl_timestep'):
+                timer.compute_cfl_timestep(flow_data_list, sedtrails_data)
 
             # Main loop
             for ip, population in enumerate(populations):
@@ -403,26 +478,35 @@ class Simulation:
                 for flow_field_name in flow_field_names:
                     # Obtain scalar field information
                     # TODO: Consider moving van westen specific fields to the plugin itself
-                    bed_level = retriever.get_scalar_field(timer.current, 'bed_level')['magnitude']
+                    with self._profile_section('get_scalar_field.bed_level'):
+                        bed_level = retriever.get_scalar_field(timer.current, 'bed_level')['magnitude']
                     mixing_depth = np.full(bed_level.shape, np.nan)
                     if tracer_method == 'vanwesten':
-                        transport_prob = retriever.get_scalar_field(
-                            timer.current, flow_field_name.replace('velocity', 'probability')
-                        )['magnitude']
-                        mixing_depth = retriever.get_scalar_field(timer.current, 'mixing_layer_thickness')['magnitude']
+                        with self._profile_section('get_scalar_field.transport_probability'):
+                            transport_prob = retriever.get_scalar_field(
+                                timer.current, flow_field_name.replace('velocity', 'probability')
+                            )['magnitude']
+                        with self._profile_section('get_scalar_field.mixing_layer_thickness'):
+                            mixing_depth = retriever.get_scalar_field(timer.current, 'mixing_layer_thickness')[
+                                'magnitude'
+                            ]
                     elif tracer_method == 'soulsby':
                         transport_prob = np.ones_like(bed_level)
-                        mixing_depth = retriever.get_scalar_field(timer.current, 'mixing_layer_thickness')['magnitude']
+                        with self._profile_section('get_scalar_field.mixing_layer_thickness'):
+                            mixing_depth = retriever.get_scalar_field(timer.current, 'mixing_layer_thickness')[
+                                'magnitude'
+                            ]
                     else:
                         transport_prob = np.ones_like(bed_level)
 
                     # Update information at particle positions
-                    population.update_information(
-                        current_time=timer.current,
-                        mixing_depth=mixing_depth,
-                        bed_level=bed_level,
-                        transport_probability=transport_prob,
-                    )
+                    with self._profile_section('update_information'):
+                        population.update_information(
+                            current_time=timer.current,
+                            mixing_depth=mixing_depth,
+                            bed_level=bed_level,
+                            transport_probability=transport_prob,
+                        )
 
                     # Update particle burial depth
                     if tracer_method == 'vanwesten':
@@ -432,10 +516,12 @@ class Simulation:
                     population.update_status()
 
                     # Get flow field information
-                    flow_field = retriever.get_flow_field(timer.current, flow_field_name)
+                    with self._profile_section('get_flow_field.update_position'):
+                        flow_field = retriever.get_flow_field(timer.current, flow_field_name)
 
                     # Update particle position
-                    population.update_position(flow_field=flow_field, current_timestep=timer.current_timestep)
+                    with self._profile_section('update_position'):
+                        population.update_position(flow_field=flow_field, current_timestep=timer.current_timestep)
 
             # Collect data from all populations for this timestep using DataManager
             self.data_manager.collect_timestep_data(xr_data, populations, timer.step_count, timer.current)
@@ -466,7 +552,8 @@ class Simulation:
                     ],
                 }
                 # Get bathymetry data
-                bathymetry = retriever.get_scalar_field(timer.current, 'bed_level')['magnitude']
+                with self._profile_section('get_scalar_field.dashboard_bed_level'):
+                    bathymetry = retriever.get_scalar_field(timer.current, 'bed_level')['magnitude']
 
                 # Particle data including burial_depth and mixing_depth
 
@@ -544,6 +631,7 @@ class Simulation:
 
         # End of Simulation
         pbar.close()
+        self._active_progress_bar = None
         print('\nSimulation completed successfully!')
 
         # Write final results to NetCDF using DataManager's writer (composition)
@@ -552,6 +640,7 @@ class Simulation:
             xr_data, filename='sedtrails_results.nc', trim_to_actual_timesteps=True, actual_timesteps=actual_timesteps
         )
         print(f'Simulation results saved to: {output_file}')
+        self._log_profile_summary(status='completed')
 
         # Keep dashboard open after simulation ends
         if self.dashboard is not None:

--- a/src/sedtrails/simulation_orchestrator/simulation_manager.py
+++ b/src/sedtrails/simulation_orchestrator/simulation_manager.py
@@ -205,6 +205,36 @@ class Simulation:
         update_interval = self._controller.get('visualization.dashboard.update_interval', '1H')
         return Duration(update_interval).seconds
 
+    @staticmethod
+    def _missing_particle_field_like(particle_x: np.ndarray) -> np.ndarray:
+        """Return a same-shaped NaN particle field for unavailable dashboard data."""
+        return np.full(np.asarray(particle_x).shape, np.nan, dtype=float)
+
+    @classmethod
+    def _dashboard_particle_data(cls, population) -> dict[str, np.ndarray]:
+        """Build dashboard particle arrays from a population."""
+        particle_x = population.particles['x']
+        particle_data = {
+            'x': particle_x,
+            'y': population.particles['y'],
+        }
+
+        burial_depth = population.particles.get('burial_depth')
+        if burial_depth is None:
+            burial_depth = cls._missing_particle_field_like(particle_x)
+        else:
+            burial_depth = np.asarray(burial_depth)
+            if np.all(np.isnan(burial_depth)):
+                burial_depth = cls._missing_particle_field_like(particle_x)
+        particle_data['burial_depth'] = burial_depth
+
+        mixing_depth = population.particles.get('mixing_depth')
+        particle_data['mixing_depth'] = (
+            cls._missing_particle_field_like(particle_x) if mixing_depth is None else np.asarray(mixing_depth)
+        )
+
+        return particle_data
+
     def _create_simulation_time(self) -> Time:
         """Build simulation time using the same reference date as the input data."""
         return Time(
@@ -697,20 +727,7 @@ class Simulation:
                 if self.dashboard.should_update(timer.current, plot_interval_seconds):
                     # For dashboard, use first population data
                     first_population = populations[0]
-                    particle_data = {
-                        'x': first_population.particles['x'],
-                        'y': first_population.particles['y'],
-                        'burial_depth': [
-                            first_population.particles['burial_depth']
-                            if not np.all(np.isnan(first_population.particles['burial_depth']))
-                            else np.full(first_population.particles['x'].shape, np.nan)
-                        ],
-                        'mixing_depth': [
-                            first_population.particles['mixing_depth']
-                            if 'mixing_depth' in first_population.particles.keys()
-                            else np.full(first_population.particles['x'].shape, np.nan)
-                        ],
-                    }
+                    particle_data = self._dashboard_particle_data(first_population)
                     bathymetry = get_scalar_field_cached('bed_level', 'get_scalar_field.dashboard_bed_level')
                     dashboard_flow_field = get_flow_field_cached(flow_field_names[0], 'get_flow_field.dashboard')
                     mesh_geometry = sedtrails_data.mesh_geometry() if hasattr(sedtrails_data, 'mesh_geometry') else None

--- a/src/sedtrails/simulation_orchestrator/simulation_manager.py
+++ b/src/sedtrails/simulation_orchestrator/simulation_manager.py
@@ -560,90 +560,78 @@ class Simulation:
         # Finalize results
         # self.data_manager.dump()  # Write remaining data to disk. # TODO: not working
 
-    def _expand_time_dimension(self, xr_data: xr.Dataset, new_max_timesteps: int) -> xr.Dataset:
-        """
-        Expand the time dimension of the xarray dataset to accommodate more timesteps.
+    def _expand_time_dimension(
+        self,
+        xr_data: xr.Dataset,
+        new_max_timesteps: int,
+    ) -> xr.Dataset:
+        time_dim = 'n_timesteps' if 'n_timesteps' in xr_data.sizes else 'time'
 
-        This method is called when the number of timesteps approaches the allocated buffer size
-        due to adaptive CFL-based timestepping. It pads all time-dependent data variables with
-        NaN values and updates the time coordinate accordingly.
+        current_size = xr_data.sizes[time_dim]
 
-        Parameters
-        ----------
-        xr_data : xr.Dataset
-            The xarray dataset containing simulation results with time dimension.
-        new_max_timesteps : int
-            The new maximum number of timesteps to allocate. Must be larger than the current
-            time dimension size.
+        if new_max_timesteps <= current_size:
+            raise ValueError(f'new_max_timesteps={new_max_timesteps} must be larger than current size={current_size}')
 
-        Returns
-        -------
-        xr.Dataset
-            The expanded dataset with additional timesteps allocated along the time dimension.
-            New timestep values are filled with NaN.
+        # Replace/normalize the timestep coordinate to guarantee uniqueness
+        xr_data = xr_data.assign_coords({time_dim: np.arange(current_size)})
 
-        Notes
-        -----
-        - Only data variables that have a 'time' dimension are expanded.
-        - The time coordinate is updated to range from 0 to new_max_timesteps - 1.
-        - All newly allocated timesteps are filled with NaN values.
-        - This operation creates a copy of the dataset data in memory.
+        new_coord = np.arange(new_max_timesteps)
 
-        Examples
-        --------
-        >>> # Expand dataset from 1000 to 1500 timesteps
-        >>> expanded_data = self._expand_time_dimension(xr_data, 1500)
-        """
-
-        current_size = len(xr_data.time)
-        additional_steps = new_max_timesteps - current_size
-
-        # Create a dictionary to hold expanded data variables
         expanded_vars = {}
 
-        # Pad all data variables along time dimension
-        for var_name in xr_data.data_vars:
-            var = xr_data[var_name]
-
-            if 'n_timesteps' in var.dims:
-                # Get the shape and create padding
-                pad_shape = list(var.shape)
-                time_dim_idx = var.dims.index('n_timesteps')
-                pad_shape[time_dim_idx] = additional_steps
-
-                # Create NaN-filled array for padding
-                pad_data = np.full(pad_shape, np.nan, dtype=var.dtype)
-
-                # Create DataArray for padding with the same dimensions (except time)
-                # Build coordinates for the padded array
-                pad_coords = {}
-                for dim in var.dims:
-                    if dim == 'n_timesteps':
-                        pad_coords[dim] = np.arange(current_size, new_max_timesteps)
-                    else:
-                        pad_coords[dim] = var.coords[dim]
-
-                pad_array = xr.DataArray(pad_data, dims=var.dims, coords=pad_coords)
-
-                # Concatenate along time dimension
-                expanded_vars[var_name] = xr.concat([var, pad_array], dim='n_timesteps')
-            else:
-                # Keep non-time variables as is
+        for var_name, var in xr_data.data_vars.items():
+            if time_dim not in var.dims:
                 expanded_vars[var_name] = var
+                continue
 
-        # Create new dataset with expanded variables and all original coordinates (replace 'time')
+            time_axis = var.dims.index(time_dim)
+
+            pad_shape = list(var.shape)
+            pad_shape[time_axis] = new_max_timesteps - current_size
+
+            if np.issubdtype(var.dtype, np.floating) or np.issubdtype(var.dtype, np.complexfloating):
+                pad_data = np.full(
+                    pad_shape,
+                    np.nan,
+                    dtype=var.dtype,
+                )
+            else:
+                pad_data = np.zeros(
+                    pad_shape,
+                    dtype=var.dtype,
+                )
+
+            pad_coords = {}
+            for dim in var.dims:
+                if dim == time_dim:
+                    pad_coords[dim] = np.arange(current_size, new_max_timesteps)
+                elif dim in var.coords:
+                    pad_coords[dim] = var.coords[dim]
+
+            pad_array = xr.DataArray(
+                pad_data,
+                dims=var.dims,
+                coords=pad_coords,
+                attrs=var.attrs.copy(),
+            )
+
+            expanded_vars[var_name] = xr.concat(
+                [var, pad_array],
+                dim=time_dim,
+            )
+
+        coords = {}
+        for coord_name, coord in xr_data.coords.items():
+            if coord_name == time_dim:
+                coords[coord_name] = new_coord
+            elif time_dim not in coord.dims:
+                coords[coord_name] = coord
+
         expanded_dataset = xr.Dataset(
             expanded_vars,
-            coords={
-                coord: (np.arange(new_max_timesteps) if coord == 'time' else xr_data.coords[coord])
-                for coord in xr_data.coords
-            },
+            coords=coords,
+            attrs=xr_data.attrs.copy(),
         )
-        # Copy attributes
-        expanded_dataset.attrs = xr_data.attrs.copy()
-        for var_name in xr_data.data_vars:
-            if var_name in expanded_dataset.data_vars:
-                expanded_dataset[var_name].attrs = xr_data[var_name].attrs.copy()
 
         return expanded_dataset
 

--- a/src/sedtrails/simulation_orchestrator/simulation_manager.py
+++ b/src/sedtrails/simulation_orchestrator/simulation_manager.py
@@ -458,10 +458,38 @@ class Simulation:
                 else:
                     tracer_methods[ip] = 'passive_tracer'
 
+            field_cache = {}
+            cache_time = timer.current
+
+            def get_flow_field_cached(
+                flow_field_name: str,
+                profile_name: str,
+                _cache=field_cache,
+                _retriever=retriever,
+                _time=cache_time,
+            ):
+                cache_key = ('flow', _time, flow_field_name)
+                if cache_key not in _cache:
+                    with self._profile_section(profile_name):
+                        _cache[cache_key] = _retriever.get_flow_field(_time, flow_field_name)
+                return _cache[cache_key]
+
+            def get_scalar_field_cached(
+                scalar_field_name: str,
+                profile_name: str,
+                _cache=field_cache,
+                _retriever=retriever,
+                _time=cache_time,
+            ):
+                cache_key = ('scalar', _time, scalar_field_name)
+                if cache_key not in _cache:
+                    with self._profile_section(profile_name):
+                        _cache[cache_key] = _retriever.get_scalar_field(_time, scalar_field_name)['magnitude']
+                return _cache[cache_key]
+
             flow_data_list = []
             for flow_field_name in flow_field_names:
-                with self._profile_section('get_flow_field.cfl'):
-                    flow_data_list.append(retriever.get_flow_field(timer.current, flow_field_name))
+                flow_data_list.append(get_flow_field_cached(flow_field_name, 'get_flow_field.cfl'))
 
             # Compute CFL-based timestep across all flow fields
             with self._profile_section('compute_cfl_timestep'):
@@ -478,26 +506,25 @@ class Simulation:
                 for flow_field_name in flow_field_names:
                     # Obtain scalar field information
                     # TODO: Consider moving van westen specific fields to the plugin itself
-                    with self._profile_section('get_scalar_field.bed_level'):
-                        bed_level = retriever.get_scalar_field(timer.current, 'bed_level')['magnitude']
-                    mixing_depth = np.full(bed_level.shape, np.nan)
+                    bed_level = get_scalar_field_cached('bed_level', 'get_scalar_field.bed_level')
+                    mixing_depth = None
                     if tracer_method == 'vanwesten':
-                        with self._profile_section('get_scalar_field.transport_probability'):
-                            transport_prob = retriever.get_scalar_field(
-                                timer.current, flow_field_name.replace('velocity', 'probability')
-                            )['magnitude']
-                        with self._profile_section('get_scalar_field.mixing_layer_thickness'):
-                            mixing_depth = retriever.get_scalar_field(timer.current, 'mixing_layer_thickness')[
-                                'magnitude'
-                            ]
+                        transport_prob = get_scalar_field_cached(
+                            flow_field_name.replace('velocity', 'probability'),
+                            'get_scalar_field.transport_probability',
+                        )
+                        mixing_depth = get_scalar_field_cached(
+                            'mixing_layer_thickness',
+                            'get_scalar_field.mixing_layer_thickness',
+                        )
                     elif tracer_method == 'soulsby':
-                        transport_prob = np.ones_like(bed_level)
-                        with self._profile_section('get_scalar_field.mixing_layer_thickness'):
-                            mixing_depth = retriever.get_scalar_field(timer.current, 'mixing_layer_thickness')[
-                                'magnitude'
-                            ]
+                        transport_prob = 1.0
+                        mixing_depth = get_scalar_field_cached(
+                            'mixing_layer_thickness',
+                            'get_scalar_field.mixing_layer_thickness',
+                        )
                     else:
-                        transport_prob = np.ones_like(bed_level)
+                        transport_prob = 1.0
 
                     # Update information at particle positions
                     with self._profile_section('update_information'):
@@ -516,8 +543,7 @@ class Simulation:
                     population.update_status()
 
                     # Get flow field information
-                    with self._profile_section('get_flow_field.update_position'):
-                        flow_field = retriever.get_flow_field(timer.current, flow_field_name)
+                    flow_field = get_flow_field_cached(flow_field_name, 'get_flow_field.update_position')
 
                     # Update particle position
                     with self._profile_section('update_position'):
@@ -552,8 +578,7 @@ class Simulation:
                     ],
                 }
                 # Get bathymetry data
-                with self._profile_section('get_scalar_field.dashboard_bed_level'):
-                    bathymetry = retriever.get_scalar_field(timer.current, 'bed_level')['magnitude']
+                bathymetry = get_scalar_field_cached('bed_level', 'get_scalar_field.dashboard_bed_level')
 
                 # Particle data including burial_depth and mixing_depth
 

--- a/src/sedtrails/simulation_orchestrator/simulation_manager.py
+++ b/src/sedtrails/simulation_orchestrator/simulation_manager.py
@@ -64,7 +64,7 @@ class Simulation:
             # Global exception handler will catch and log this
             raise
 
-        for population in self.populations_config:
+        for population in self.populations_config:  # FIXME: this just keeps the last one
             tracer_config = population['tracer_methods']
         # Initialize other components
         self.format_converter = FormatConverter(self._get_format_config())
@@ -218,7 +218,7 @@ class Simulation:
 
         return self.format_converter.convert_to_sedtrails()
 
-    def validate_config(self) -> bool:  # TODO: this is not used anywhere
+    def validate_config(self) -> bool:
         """
         Validates the configuration file.
 
@@ -287,7 +287,7 @@ class Simulation:
 
         timer = Timer(simulation_time=simulation_time, cfl_condition=self._controller.get('time.cfl_condition'))
 
-        # Load SedTRAILS data for 'x' and 'y' (needed for population seerder)
+        # Load SedTRAILS data for 'x' and 'y' (needed for population seeder)
         sedtrails_data = self.format_converter.convert_to_sedtrails(
             current_time=simulation_time._start, reading_interval=1
         )
@@ -319,15 +319,19 @@ class Simulation:
         )
 
         # Determine flow field names from configuration
+        # tracer_methods is obligatory, so all these checks are not needed.
         flow_field_names = []
         for population in populations_config:
-            if 'tracer_methods' in population and (
-                'vanwesten' in population['tracer_methods'] or 'soulsby' in population['tracer_methods']
-            ):
+            # if 'tracer_methods' in population and (
+            #     'vanwesten' in population['tracer_methods'] or 'soulsby' in population['tracer_methods']
+            # ):
+            if 'tracer_methods' in population:
                 if 'vanwesten' in population['tracer_methods']:
                     flow_field_names = population['tracer_methods']['vanwesten']['flow_field_name']
                 elif 'soulsby' in population['tracer_methods']:
                     flow_field_names = population['tracer_methods']['soulsby']['flow_field_name']
+                elif 'passive_tracer' in population['tracer_methods']:
+                    flow_field_names = population['tracer_methods']['passive_tracer']['flow_field_name']
                 break  # Use the first population's flow fields for now
 
         # Create SedTrails dataset using DataManager's writer (composition)
@@ -375,7 +379,7 @@ class Simulation:
             # TODO: this loops over populations_config, but only the last one is used. This must be fixed
             # to handle multiple populations with different tracer methods and flow fields
             for population in populations_config:
-                tracer_methods = population['tracer_methods']
+                tracer_methods[population['name']] = population['tracer_methods']
 
             flow_data_list = []
             for flow_field_name in flow_field_names:
@@ -386,13 +390,13 @@ class Simulation:
 
             # Main loop
             for population in populations:
-                for _method in tracer_methods:
+                for _method in tracer_methods.keys():
                     for flow_field_name in flow_field_names:
                         # Obtain scalar field information
                         # TODO: Consider moving van westen specific fields to the plugin itself
                         mixing_depth = retriever.get_scalar_field(timer.current, 'mixing_layer_thickness')['magnitude']
                         bed_level = retriever.get_scalar_field(timer.current, 'bed_level')['magnitude']
-                        if self.physics_converter.config.tracer_method == 'vanwesten':
+                        if tracer_methods[population] == 'vanwesten':
                             transport_prob = retriever.get_scalar_field(
                                 timer.current, flow_field_name.replace('velocity', 'probability')
                             )['magnitude']
@@ -408,7 +412,7 @@ class Simulation:
                         )
 
                         # Update particle burial depth
-                        if self.physics_converter.config.tracer_method == 'vanwesten':
+                        if tracer_methods[population] == 'vanwesten':
                             population.update_burial_depth()
 
                         # Determining status

--- a/src/sedtrails/simulation_orchestrator/simulation_manager.py
+++ b/src/sedtrails/simulation_orchestrator/simulation_manager.py
@@ -377,7 +377,13 @@ class Simulation:
             # TODO: this loops over populations_config, but only the last one is used. This must be fixed
             # to handle multiple populations with different tracer methods and flow fields
             for ip, population in enumerate(populations_config):
-                tracer_methods[ip] = population['tracer_methods']
+                tracer_cfg = population.get('tracer_methods', {})
+                if isinstance(tracer_cfg, dict) and tracer_cfg:
+                    tracer_methods[ip] = next(iter(tracer_cfg.keys()))
+                elif isinstance(tracer_cfg, str):
+                    tracer_methods[ip] = tracer_cfg
+                else:
+                    tracer_methods[ip] = 'passive_tracer'
 
             flow_data_list = []
             for flow_field_name in flow_field_names:
@@ -388,47 +394,48 @@ class Simulation:
 
             # Main loop
             for ip, population in enumerate(populations):
-                for _method in tracer_methods.keys():
-                    for flow_field_name in flow_field_names:
-                        # Obtain scalar field information
-                        # TODO: Consider moving van westen specific fields to the plugin itself
-                        bed_level = retriever.get_scalar_field(timer.current, 'bed_level')['magnitude']
-                        mixing_depth = np.full(bed_level.shape, np.nan)
-                        if tracer_methods[ip] == 'vanwesten':
-                            transport_prob = retriever.get_scalar_field(
-                                timer.current, flow_field_name.replace('velocity', 'probability')
-                            )['magnitude']
-                            mixing_depth = retriever.get_scalar_field(timer.current, 'mixing_layer_thickness')[
-                                'magnitude'
-                            ]
-                        elif tracer_methods[ip] == 'soulsby':
-                            transport_prob = np.ones_like(bed_level)
-                            mixing_depth = retriever.get_scalar_field(timer.current, 'mixing_layer_thickness')[
-                                'magnitude'
-                            ]
-                        else:
-                            transport_prob = np.ones_like(bed_level)
+                if ip not in tracer_methods:
+                    raise ConfigurationError(
+                        f'Tracer method not configured for population {ip}. '
+                        f'Check that all populations have "tracer_methods" defined in configuration.'
+                    )
+                tracer_method = tracer_methods[ip]
+                for flow_field_name in flow_field_names:
+                    # Obtain scalar field information
+                    # TODO: Consider moving van westen specific fields to the plugin itself
+                    bed_level = retriever.get_scalar_field(timer.current, 'bed_level')['magnitude']
+                    mixing_depth = np.full(bed_level.shape, np.nan)
+                    if tracer_method == 'vanwesten':
+                        transport_prob = retriever.get_scalar_field(
+                            timer.current, flow_field_name.replace('velocity', 'probability')
+                        )['magnitude']
+                        mixing_depth = retriever.get_scalar_field(timer.current, 'mixing_layer_thickness')['magnitude']
+                    elif tracer_method == 'soulsby':
+                        transport_prob = np.ones_like(bed_level)
+                        mixing_depth = retriever.get_scalar_field(timer.current, 'mixing_layer_thickness')['magnitude']
+                    else:
+                        transport_prob = np.ones_like(bed_level)
 
-                        # Update information at particle positions
-                        population.update_information(
-                            current_time=timer.current,
-                            mixing_depth=mixing_depth,
-                            bed_level=bed_level,
-                            transport_probability=transport_prob,
-                        )
+                    # Update information at particle positions
+                    population.update_information(
+                        current_time=timer.current,
+                        mixing_depth=mixing_depth,
+                        bed_level=bed_level,
+                        transport_probability=transport_prob,
+                    )
 
-                        # Update particle burial depth
-                        if tracer_methods[ip] == 'vanwesten':
-                            population.update_burial_depth()
+                    # Update particle burial depth
+                    if tracer_method == 'vanwesten':
+                        population.update_burial_depth()
 
-                        # Determining status
-                        population.update_status()
+                    # Determining status
+                    population.update_status()
 
-                        # Get flow field information
-                        flow_field = retriever.get_flow_field(timer.current, flow_field_name)
+                    # Get flow field information
+                    flow_field = retriever.get_flow_field(timer.current, flow_field_name)
 
-                        # Update particle position
-                        population.update_position(flow_field=flow_field, current_timestep=timer.current_timestep)
+                    # Update particle position
+                    population.update_position(flow_field=flow_field, current_timestep=timer.current_timestep)
 
             # Collect data from all populations for this timestep using DataManager
             self.data_manager.collect_timestep_data(xr_data, populations, timer.step_count, timer.current)

--- a/src/sedtrails/transport_converter/format_converter.py
+++ b/src/sedtrails/transport_converter/format_converter.py
@@ -6,12 +6,23 @@ hydrodynamic models) and converts them into the SedtrailsData structure for
 use in the SedTRAILS particle tracking system.
 """
 
+from dataclasses import dataclass
 from types import ModuleType
 from typing import Dict, Optional, Union
 
 import numpy as np
 
 from sedtrails.transport_converter.sedtrails_data import SedtrailsData
+
+
+@dataclass
+class SeederFieldData:
+    """
+    Minimal field data needed by ParticleSeeder: only spatial coordinates.
+    """
+
+    x: np.ndarray
+    y: np.ndarray
 
 
 class FormatConverter:
@@ -132,6 +143,26 @@ class FormatConverter:
         sedtrails_data = plugin.convert(current_time, reading_interval, self.reference_date)
 
         return sedtrails_data
+
+    def get_seeding_field_data(self) -> SeederFieldData:
+        """
+        Read only the data required by ParticleSeeder.seed: x and y coordinates.
+
+        Returns
+        -------
+        SeederFieldData
+            Minimal coordinate container for seeding workflows.
+        """
+        plugin = self.format_plugin
+
+        if hasattr(plugin, 'get_seeding_coordinates'):
+            x, y = plugin.get_seeding_coordinates()
+        else:
+            # Backward-compatible fallback for plugins that only expose full conversion.
+            sedtrails_data = plugin.convert(None, None, self.reference_date)
+            x, y = sedtrails_data.x, sedtrails_data.y
+
+        return SeederFieldData(x=np.asarray(x), y=np.asarray(y))
 
 
 if __name__ == '__main__':

--- a/src/sedtrails/transport_converter/format_converter.py
+++ b/src/sedtrails/transport_converter/format_converter.py
@@ -6,7 +6,11 @@ hydrodynamic models) and converts them into the SedtrailsData structure for
 use in the SedTRAILS particle tracking system.
 """
 
-from typing import Union, Dict
+from types import ModuleType
+from typing import Dict, Optional, Union
+
+import numpy as np
+
 from sedtrails.transport_converter.sedtrails_data import SedtrailsData
 
 
@@ -65,12 +69,12 @@ class FormatConverter:
         return self._input_format
 
     @property
-    def reference_date(self) -> str:
+    def reference_date(self) -> np.datetime64:
         """Get the reference date as a numpy datetime64 object."""
 
         if self._reference_date is None:
             self._reference_date = self.config.get('reference_date', '1970-01-01')
-        return self._reference_date  # Default to Unix epoch
+        return np.datetime64(self._reference_date)  # Default to Unix epoch
 
     @property
     def morfac(self) -> float:
@@ -90,16 +94,16 @@ class FormatConverter:
         if self._format_plugin is None:
             # Dynamically import the format plugin based on the input type
             plugin_module_name = f'sedtrails.transport_converter.plugins.format.{self.input_format}'
+            plugin_module: Optional[ModuleType] = None
             try:
                 plugin_module = importlib.import_module(plugin_module_name)
+                # Initialize the format plugin with the input file and morfac
+                self._format_plugin = plugin_module.FormatPlugin(self.input_file, morfac=self.morfac)
             except ImportError as e:
                 raise ImportError(
                     f'Failed to import format plugin module: {plugin_module_name} '
                     f'Ensure the module exists and is correctly named.'
                 ) from e
-            else:
-                # Initialize the format plugin with the input file and morfac
-                self._format_plugin = plugin_module.FormatPlugin(self.input_file, morfac=self.morfac)
 
         return self._format_plugin
 
@@ -111,7 +115,7 @@ class FormatConverter:
         -----------
         current_time : float, optional
             Current simulation time in seconds
-        reading_interval : float, optional  
+        reading_interval : float, optional
             Reading interval in seconds
 
         Returns:
@@ -125,10 +129,8 @@ class FormatConverter:
         else:
             plugin = self._format_plugin
 
-        # print(f'Using {plugin.__class__.__name__} to convert data to SedtrailsData format...')
+        sedtrails_data = plugin.convert(current_time, reading_interval, self.reference_date)
 
-        sedtrails_data = plugin.convert(current_time, reading_interval)
-        # print('Successfully converted data to SedtrailsData format.')
         return sedtrails_data
 
 

--- a/src/sedtrails/transport_converter/physics_converter.py
+++ b/src/sedtrails/transport_converter/physics_converter.py
@@ -5,8 +5,8 @@ This module adds physics-based calculations to existing SedtrailsData objects
 using the physics library functions and allowing method selection.
 """
 
-from typing import Optional, Any, Dict
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, Optional
 
 # Import physics library
 from sedtrails.transport_converter import physics_lib
@@ -23,9 +23,11 @@ GRAIN_DIAMETER = 2.5e-4  # m (250 μm)
 # Morphological acceleration factor
 MORFAC = 1.0
 
+
 @dataclass
 class PhysicsConfig:
     """Configuration parameters for physics calculations."""
+
     # Physics methods
     tracer_method: str = 'vanwesten'  # name of method for
     gravity: float = GRAVITY
@@ -38,7 +40,9 @@ class PhysicsConfig:
     morfac: float = MORFAC
 
     @classmethod
-    def from_dict(cls, config: Optional[Dict[str, Any]] = None, tracer_config: Optional[Dict[str, Any]] = None) -> "PhysicsConfig":
+    def from_dict(
+        cls, config: Optional[Dict[str, Any]] = None, tracer_config: Optional[Dict[str, Any]] = None
+    ) -> 'PhysicsConfig':
         """
         Build a PhysicsConfig by merging:
         1) defaults (class fields),
@@ -51,16 +55,16 @@ class PhysicsConfig:
         # Apply base config
         if config:
             if isinstance(config, cls):
-                base = asdict(config)          # deep copy dataclass fields
+                base = asdict(config)  # deep copy dataclass fields
             elif isinstance(config, dict):
                 base = config
             else:
-                base = {k: v for k, v in vars(config).items() if not k.startswith("_")}
+                base = {k: v for k, v in vars(config).items() if not k.startswith('_')}
             for k, v in base.items():
                 setattr(obj, k, v)
         # Apply method-specific (flatten) from tracer_config
         if tracer_config:
-            method = getattr(config, "tracer_method", "vanwesten")
+            method = getattr(config, 'tracer_method', 'vanwesten')
             # If tracer_config is nested like {"soulsby": {...}}, pick the active method
             if isinstance(tracer_config.get(method, None), dict):
                 method_params = tracer_config[method]
@@ -71,9 +75,11 @@ class PhysicsConfig:
                 for k, v in tracer_config.items():
                     setattr(obj, k, v)
         return obj
+
     # Optional: expose a dict view when needed
     def as_dict(self) -> Dict[str, Any]:
         return dict(self.__dict__)
+
 
 class PhysicsConverter:
     """
@@ -152,9 +158,10 @@ class PhysicsConverter:
                     f'Ensure the module exists and is correctly named.'
                 ) from e
             else:
-                self._physics_plugin = plugin_module.PhysicsPlugin(self.config, self.tracer_config)  # all classes should be called the PhysicsPlugin
+                self._physics_plugin = plugin_module.PhysicsPlugin(
+                    self.config, self.tracer_config
+                )  # all classes should be called the PhysicsPlugin
         return self._physics_plugin
-
 
     def convert_physics(self, sedtrails_data, transport_probability_method: str = None) -> None:
         """

--- a/src/sedtrails/transport_converter/plugins/format/delft3d4_trim.py
+++ b/src/sedtrails/transport_converter/plugins/format/delft3d4_trim.py
@@ -20,4 +20,4 @@ class FormatPlugin(BaseFormatPlugin):
         **kwargs : dict
             Keyword arguments for conversion.
         """
-        raise NotImplementedError('NetCDF DFM conversion is not yet implemented.')
+        raise NotImplementedError('Delft3D trim file conversion is not yet implemented.')

--- a/src/sedtrails/transport_converter/plugins/format/fm_netcdf.py
+++ b/src/sedtrails/transport_converter/plugins/format/fm_netcdf.py
@@ -95,7 +95,9 @@ class FormatPlugin(BaseFormatPlugin):
 
         return decompressed_info
 
-    def convert(self, current_time=None, reading_interval=None) -> SedtrailsData:
+    def convert(
+        self, current_time=None, reading_interval=None, reference_date=np.datetime64('1970-01-01T00:00:00')
+    ) -> SedtrailsData:
         """
         Delft3D from Flexible Mesh NetCDF.
 
@@ -114,7 +116,7 @@ class FormatPlugin(BaseFormatPlugin):
 
         # Read the NetCDF file
         self.load()
-        time_info = self._get_time_info(self.input_data, reference_date=np.datetime64('1970-01-01T00:00:00'))
+        time_info = self._get_time_info(self.input_data, reference_date=reference_date)
 
         # Apply morfac decompression to time before time slicing
         time_info = self._decompress_time(time_info)

--- a/src/sedtrails/transport_converter/plugins/format/fm_netcdf.py
+++ b/src/sedtrails/transport_converter/plugins/format/fm_netcdf.py
@@ -1,13 +1,15 @@
 """A plugin for converting Delft3D Flexible Mesh NetCDF to SedTRAILS format."""
 
-import xugrid as xu
-import xarray as xr
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
 import numpy as np
+import xarray as xr
+import xugrid as xu
+
 from sedtrails.transport_converter.plugins import BaseFormatPlugin
 from sedtrails.transport_converter.sedtrails_data import SedtrailsData
 from sedtrails.transport_converter.sedtrails_metadata import SedtrailsMetadata
-from pathlib import Path
-from typing import Dict, Any, List, Union, Optional
 
 
 class FormatPlugin(BaseFormatPlugin):

--- a/src/sedtrails/transport_converter/plugins/format/fm_netcdf.py
+++ b/src/sedtrails/transport_converter/plugins/format/fm_netcdf.py
@@ -208,6 +208,17 @@ class FormatPlugin(BaseFormatPlugin):
 
         return sedtrails_data
 
+    def get_seeding_coordinates(self):
+        """
+        Return only the spatial coordinates required for particle seeding.
+        """
+        self.load()
+
+        if 'net_xcc' not in self.input_data or 'net_ycc' not in self.input_data:
+            raise KeyError("Required variables 'net_xcc' and/or 'net_ycc' not found in dataset")
+
+        return self.input_data['net_xcc'].values, self.input_data['net_ycc'].values
+
     def _calculate_time_slice(self, current_time, reading_interval, time_info):
         """Calculate time slice indices based on current time and reading interval."""
 

--- a/src/sedtrails/transport_converter/plugins/format/fm_netcdf.py
+++ b/src/sedtrails/transport_converter/plugins/format/fm_netcdf.py
@@ -266,7 +266,7 @@ class FormatPlugin(BaseFormatPlugin):
                     raise IOError(f'Failed to open NetCDF file: {e}') from e
 
                 else:
-                    print(f'Sucessfully loaded (Xarray): {self.input_file}')
+                    print(f'Successfully loaded (Xarray): {self.input_file}')
             else:
                 print('Successfully loaded (Xugrid)', self.input_file)
 

--- a/src/sedtrails/transport_converter/plugins/format/fm_netcdf.py
+++ b/src/sedtrails/transport_converter/plugins/format/fm_netcdf.py
@@ -96,7 +96,7 @@ class FormatPlugin(BaseFormatPlugin):
         return decompressed_info
 
     def convert(
-        self, current_time=None, reading_interval=None, reference_date=np.datetime64('1970-01-01T00:00:00')
+        self, current_time=None, reading_interval=None, reference_date: Optional[np.datetime64] = None
     ) -> SedtrailsData:
         """
         Delft3D from Flexible Mesh NetCDF.
@@ -113,6 +113,9 @@ class FormatPlugin(BaseFormatPlugin):
         SedtrailsData
             The converted SedtrailsData object.
         """
+
+        if reference_date is None:
+            reference_date = np.datetime64('1970-01-01T00:00:00')
 
         # Read the NetCDF file
         self.load()

--- a/src/sedtrails/transport_converter/plugins/format/sfincs.py
+++ b/src/sedtrails/transport_converter/plugins/format/sfincs.py
@@ -70,7 +70,7 @@ class FormatPlugin(BaseFormatPlugin):
         self,
         current_time=None,
         reading_interval=None,
-        reference_date=np.datetime64('1970-01-01T00:00:00'),
+        reference_date: Optional[np.datetime64] = None,
     ) -> SedtrailsData:
         """
         SedtrailsData from SFINCS Netcdf.
@@ -89,6 +89,9 @@ class FormatPlugin(BaseFormatPlugin):
         SedtrailsData
             The converted SedtrailsData object.
         """
+
+        if reference_date is None:
+            reference_date = np.datetime64('1970-01-01T00:00:00')
 
         # Read the NetCDF file
         self.load()
@@ -409,7 +412,7 @@ class FormatPlugin(BaseFormatPlugin):
         ]
 
         for key in time_dependent_vars:
-            var_name = variable_map.get(key, var_name if 'var_name' in locals() else None)
+            var_name = variable_map.get(key, key)
             try:
                 var = self._get_variable(var_name)
             except KeyError:

--- a/src/sedtrails/transport_converter/plugins/format/sfincs.py
+++ b/src/sedtrails/transport_converter/plugins/format/sfincs.py
@@ -1,0 +1,313 @@
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+import numpy as np
+import xarray as xr
+import xugrid as xu
+
+from sedtrails.transport_converter.plugins import BaseFormatPlugin
+from sedtrails.transport_converter.sedtrails_data import SedtrailsData
+
+
+class FormatPlugin(BaseFormatPlugin):
+    """
+    Plugin for converting SFINCS NetCDF to SedTRAILS format.
+    """
+
+    def __init__(self, input_file: str):
+        """
+        Initialize the plugin with the input file.
+
+        Parameters:
+        -----------
+        input_file : str
+            Path to the SFINCS NetCDF file.
+        """
+        super().__init__()
+        self.input_file = Path(input_file)
+        self.input_data = None  # holds Dataset after reading
+        self._input_variables: List[str] = []
+
+    def __post_init__(self):
+        # Check if the input file exists
+        if not self.input_file.exists():
+            raise FileNotFoundError(f'Input file not found: {self.input_file}')
+
+    @property
+    def variables(self) -> List[str]:
+        """
+        Get the variables in the input dataset.
+
+        Returns:
+        --------
+        List
+            List of variable names in the input dataset.
+        """
+
+        if self.input_data is None:  # Ensure input_data is loaded
+            self.load()
+
+        if not self._input_variables:  # Ensures variables are only loaded once
+            try:
+                self._input_variables = list(self.input_data.data_vars)
+            except AttributeError as e:
+                raise ValueError('Input data could not retrieve variables') from e
+            else:
+                print(f'Variables in {self.input_file}:')
+
+        return self._input_variables
+
+    def convert(self, current_time=None, reading_interval=None) -> SedtrailsData:
+        """
+        SedtrailsData from SFINCS Netcdf.
+
+        Parameters:
+        -----------
+        current_time : float, optional
+            Current simulation time in seconds
+        reading_interval : float, optional
+            Reading interval in seconds
+
+        Returns:
+        --------
+        SedtrailsData
+            The converted SedtrailsData object.
+        """
+
+        # Read the NetCDF file
+        self.load()
+        time_info = self._get_time_info(self.input_data, reference_date=np.datetime64('1970-01-01T00:00:00'))
+
+        # Determine if we need to slice based on current_time and reading_interval
+        time_start_idx, time_end_idx = self._calculate_time_slice(current_time, reading_interval, time_info)
+
+        # Apply time slicing if needed
+        if time_start_idx is not None or time_end_idx is not None:
+            time_slice = slice(time_start_idx, time_end_idx)
+            time_info = self._slice_time_info(time_info, time_slice)
+
+        # Map the variables to SedtrailsData structure
+        mapped_data = self._map_sfincs_variables(time_info, time_start_idx, time_end_idx)
+        seconds_since_ref = time_info['seconds_since_reference']
+        self.reference_date = time_info['reference_date']
+
+        # Calculate magnitudes for vector quantities
+        # Flow velocity magnitude
+        depth_avg_velocity_magnitude = np.sqrt(
+            mapped_data['flow_velocity_x'] ** 2 + mapped_data['flow_velocity_y'] ** 2
+        )
+
+        # Create dictionaries for vector quantities
+        depth_avg_flow_velocity = {
+            'x': mapped_data['flow_velocity_x'],
+            'y': mapped_data['flow_velocity_y'],
+            'magnitude': depth_avg_velocity_magnitude,
+        }
+
+        # Create SedtrailsMetadata object
+        metadata = SedtrailsMetadata(
+            flowfield_domain={
+                'x_min': np.min(mapped_data['x']),
+                'x_max': np.max(mapped_data['x']),
+                'y_min': np.min(mapped_data['y']),
+                'y_max': np.max(mapped_data['y']),
+            }
+        )
+
+        # Create SedtrailsData object
+        sedtrails_data = SedtrailsData(
+            times=seconds_since_ref,
+            reference_date=self.reference_date,
+            x=mapped_data['x'],
+            y=mapped_data['y'],
+            bed_level=mapped_data['bed_level'],
+            depth_avg_flow_velocity=depth_avg_flow_velocity,
+            fractions=0,  # Default to 0 fractions
+            # this has no meaning for SFINCS runs
+            bed_load_transport=None,
+            suspended_transport=None,
+            water_depth=mapped_data['water_depth'],
+            mean_bed_shear_stress=None,
+            max_bed_shear_stress=None,
+            sediment_concentration=None,
+            nonlinear_wave_velocity=None,
+            metadata=metadata,
+        )
+
+        return sedtrails_data
+
+    def load(self) -> Any:
+        """
+        Reads and loads a SFINCS NetCDF file using xugrid.
+        """
+
+        if self.input_data is None:
+            try:
+                # First try using xugrid's open_dataset which handles UGRID conventions
+                self.input_data = xu.open_dataset(self.input_file, decode_timedelta=True)
+            except Exception as e:
+                print(f'Could not open file with xugrid: {e} \n Trying with Xarray...')
+                # Fallback to regular xarray
+                try:
+                    self.input_data = xr.open_dataset(self.input_file, decode_timedelta=True)
+                except Exception as e:
+                    raise IOError(f'Failed to open NetCDF file: {e}') from e
+
+                else:
+                    print(f'Sucessfully loaded (Xarray): {self.input_file}')
+            else:
+                print(f'Sucessfully loaded (Xugrid): {self.input_file}')
+
+    def _get_time_info(self, input_data: Union[xu.UgridDataset, xr.Dataset], reference_date: np.datetime64) -> Dict:
+        """
+        Get and transforms time information of a dataset.
+
+        Parameters:
+        -----------
+        input_data : xu.UgridDataset
+            The input dataset containing time information.
+
+        reference_data : np.datetime64
+            The reference date to calculate time in seconds.
+
+        Returns:
+        --------
+        Dict
+            Dictionary containing time values, start time, end time,
+            and time in seconds since reference date
+        """
+
+        # check reference_date is a numpy datetime64
+        if not isinstance(reference_date, np.datetime64):
+            raise TypeError('reference_date must be a numpy datetime64 object')
+
+        if input_data is None:
+            raise ValueError('Dataset not loaded. Call read_netcdf_dfm() first.')
+
+        # Get the time variable
+        time_var = input_data['time']
+        time_values = time_var.values
+        time_start = time_values[0]
+        time_end = time_values[-1]
+
+        # Get original time units and calendar from the attributes
+        orig_units = getattr(time_var, 'units', None)
+        orig_calendar = getattr(time_var, 'calendar', 'standard')
+
+        # Convert time values to seconds since reference_date
+        seconds_since_ref = np.array([float((t - reference_date) / np.timedelta64(1, 's')) for t in time_values])
+
+        return {
+            'time_values': time_values,
+            'time_start': time_start,
+            'time_end': time_end,
+            'original_units': orig_units,
+            'original_calendar': orig_calendar,
+            'seconds_since_reference': seconds_since_ref,
+            'reference_date': reference_date,
+            'num_times': len(time_values),
+        }
+
+    
+    def _calculate_time_slice(self, current_time, reading_interval, time_info)
+
+    def _map_sfincs_variables(
+        self, time_info, time_start_idx: Optional[int] = None, time_end_idx: Optional[int] = None
+    ) -> Dict:
+        """
+        Map Delft3D Flexible Mesh variables to SedtrailsData structure.
+
+        Parameters:
+        -----------
+        time_info : Dict
+            Time information
+        time_start_idx : int, optional
+            Start time index for slicing
+        time_end_idx : int, optional
+            End time index for slicing
+
+        Returns:
+        --------
+        Dict
+            Dictionary with mapped variables
+        """
+        if self.input_data is None:
+            raise ValueError('Dataset not loaded. Call read_data() first.')
+
+        # Get time information
+        num_times = time_info['num_times']
+        time_slice = (
+            slice(time_start_idx, time_end_idx)
+            if time_start_idx is not None or time_end_idx is not None
+            else slice(None)
+        )
+
+        # Variable mapping for DFM files
+        variable_map = {
+            'x': 'net_xcc',  # X-coordinates
+            'y': 'net_ycc',  # Y-coordinates
+            'bed_level': 'bedlevel',  # Bed level
+            'water_depth': 'waterdepth',  # Water depth
+            'flow_velocity_x': 'sea_water_x_velocity',  # X-component of flow velocity
+            'flow_velocity_y': 'sea_water_y_velocity',  # Y-component of flow velocity
+            'mean_bed_shear_stress': 'mean_bss_magnitude',  # Mean bed shear stress
+            'max_bed_shear_stress': 'max_bss_magnitude',  # Max bed shear stress
+            'bed_load_transport_x': 'bedload_x_comp',  # X-component of bed load sediment transport
+            'bed_load_transport_y': 'bedload_y_comp',  # Y-component of bed load sediment transport
+            'suspended_transport_x': 'susload_x_comp',  # X-component of suspended sediment transport
+            'suspended_transport_y': 'susload_y_comp',  # Y-component of suspended sediment transport
+            'sediment_concentration': 'suspended_sed_conc',  # Suspended sediment concentration
+        }
+
+        # Extract data from dataset
+        data = {}
+
+        # First, get spatial coordinates (typically not time-dependent)
+        for key in ['x', 'y']:
+            var_name = variable_map[key]
+            if var_name in self.input_data:
+                data[key] = self.input_data[var_name].values
+            else:
+                raise KeyError(f"Required variable '{var_name}' not found in dataset")
+
+        # Determine the spatial grid dimensions
+        grid_shape = data['x'].shape
+
+        # Extract time-dependent variables
+        time_dependent_vars = [
+            'bed_level',
+            'water_depth',
+            'mean_bed_shear_stress',
+            'max_bed_shear_stress',
+            'sediment_concentration',
+            'flow_velocity_x',
+            'flow_velocity_y',
+            'bed_load_transport_x',
+            'bed_load_transport_y',
+            'suspended_transport_x',
+            'suspended_transport_y',
+        ]
+
+        for key in time_dependent_vars:
+            var_name = variable_map[key]
+            if var_name in self.input_data:
+                var = self.input_data[var_name]
+
+                # Check if variable has time dimension
+                if 'time' in var.dims:
+                    # Check if variable has layer dimension
+                    if 'layer' in var.dims:
+                        # For variables with time and layer, select layer 0 and apply time slice
+                        data[key] = var.isel(layer=0, time=time_slice).values
+                    else:
+                        # For variables with time but no layer, apply time slice
+                        data[key] = var.isel(time=time_slice).values
+                else:
+                    # For variables without time dimension, broadcast to all time steps
+                    data[key] = np.broadcast_to(var.values, (num_times, *var.shape))
+            else:
+                # Default to zeros if not found
+                data[key] = np.zeros((num_times, *grid_shape))
+                print(f"Warning: Variable '{var_name}' not found, using zeros")
+
+        return data

--- a/src/sedtrails/transport_converter/plugins/format/sfincs.py
+++ b/src/sedtrails/transport_converter/plugins/format/sfincs.py
@@ -25,13 +25,10 @@ class FormatPlugin(BaseFormatPlugin):
         """
         super().__init__()
         self.input_file = Path(input_file)
-        self.input_data = None  # holds Dataset after reading
-        self._input_variables: List[str] = []
-
-    def __post_init__(self):
-        # Check if the input file exists
         if not self.input_file.exists():
             raise FileNotFoundError(f'Input file not found: {self.input_file}')
+        self.input_data = None  # holds Dataset after reading
+        self._input_variables: List[str] = []
 
     @property
     def variables(self) -> List[str]:

--- a/src/sedtrails/transport_converter/plugins/format/sfincs.py
+++ b/src/sedtrails/transport_converter/plugins/format/sfincs.py
@@ -151,6 +151,10 @@ class FormatPlugin(BaseFormatPlugin):
             max_bed_shear_stress=None,
             sediment_concentration=None,
             nonlinear_wave_velocity=None,
+            node_x=mapped_data.get('node_x'),
+            node_y=mapped_data.get('node_y'),
+            face_node_connectivity=mapped_data.get('face_node_connectivity'),
+            face_node_fill_value=-1,
         )
 
         return sedtrails_data
@@ -168,13 +172,7 @@ class FormatPlugin(BaseFormatPlugin):
                 raise TypeError(f'Expected Ugrid2d, got {type(grid).__name__}')
             return grid.face_x, grid.face_y
 
-        # Fallback: compute centroids from node coordinates and face-node connectivity.
-        node_x_var = self._get_variable('mesh2d_node_x')
-        node_y_var = self._get_variable('mesh2d_node_y')
-        face_nodes_var = self._get_variable('mesh2d_face_nodes')
-
-        start_index = face_nodes_var.attrs.get('start_index', 0)
-        fill_value = face_nodes_var.encoding.get('_FillValue', face_nodes_var.attrs.get('_FillValue', -1))
+        node_x_var, node_y_var, face_nodes_var, start_index, fill_value = self._get_face_node_mesh_variables()
 
         return compute_face_centroids(
             node_x_var,
@@ -367,22 +365,15 @@ class FormatPlugin(BaseFormatPlugin):
             else slice(None)
         )
 
-        # Derive face coordinates using helper that handles xu.UgridDataset
-        node_x_var = self._get_variable('mesh2d_node_x')
-        node_y_var = self._get_variable('mesh2d_node_y')
-        grid = self.input_data.grid
-
-        if not isinstance(grid, xu.Ugrid2d):
-            raise TypeError(f'Expected Ugrid2d, got {type(grid).__name__}')
-
-        face_nodes_var = grid.face_node_connectivity
+        # Derive face coordinates and keep generic UGRID geometry for visualization.
+        node_x_var, node_y_var, face_nodes_var, start_index, fill_value = self._get_face_node_mesh_variables()
 
         face_x, face_y = compute_face_centroids(
             node_x_var,
             node_y_var,
             face_nodes_var,
-            start_index=1,
-            fill_value=-999,
+            start_index=start_index,
+            fill_value=fill_value,
         )
 
         # Variable mapping for SFINCS files
@@ -399,6 +390,13 @@ class FormatPlugin(BaseFormatPlugin):
         # First, get spatial coordinates (typically not time-dependent)
         data['x'] = face_x
         data['y'] = face_y
+        data['node_x'] = np.asarray(node_x_var)
+        data['node_y'] = np.asarray(node_y_var)
+        data['face_node_connectivity'] = normalize_face_node_connectivity(
+            face_nodes_var,
+            start_index=start_index,
+            fill_value=fill_value,
+        )
 
         # Determine the spatial grid dimensions
         grid_shape = data['x'].shape
@@ -436,6 +434,26 @@ class FormatPlugin(BaseFormatPlugin):
 
         return data
 
+    def _get_face_node_mesh_variables(self):
+        """Return UGRID node coordinates and face-node connectivity with indexing metadata."""
+        node_x_var = self._get_variable('mesh2d_node_x')
+        node_y_var = self._get_variable('mesh2d_node_y')
+
+        try:
+            face_nodes_var = self._get_variable('mesh2d_face_nodes')
+        except KeyError as err:
+            if not isinstance(self.input_data, xu.UgridDataset):
+                raise
+            grid = self.input_data.grid
+            if not isinstance(grid, xu.Ugrid2d):
+                raise TypeError(f'Expected Ugrid2d, got {type(grid).__name__}') from err
+            face_nodes_var = grid.face_node_connectivity
+            return node_x_var, node_y_var, face_nodes_var, 0, -1
+
+        start_index = face_nodes_var.attrs.get('start_index', 0)
+        fill_value = face_nodes_var.encoding.get('_FillValue', face_nodes_var.attrs.get('_FillValue', -1))
+        return node_x_var, node_y_var, face_nodes_var, start_index, fill_value
+
     def _calculate_time_slice(self, current_time, reading_interval, time_info):
         """Calculate time slice indices based on current time and reading interval."""
 
@@ -463,6 +481,17 @@ class FormatPlugin(BaseFormatPlugin):
         return start_idx, end_idx
 
 
+def normalize_face_node_connectivity(mesh2d_face_nodes, start_index=1, fill_value=-999):
+    """Return zero-based face-node connectivity with invalid entries set to -1."""
+    faces = np.asarray(mesh2d_face_nodes)
+    normalized = faces.astype(np.int64) - int(start_index)
+    invalid = normalized < 0
+    if fill_value is not None:
+        invalid |= faces == fill_value
+    normalized[invalid] = -1
+    return normalized
+
+
 def compute_face_centroids(mesh2d_node_x, mesh2d_node_y, mesh2d_face_nodes, start_index=1, fill_value=-999):
     """
     Compute face centroids from UGRID mesh node coordinates and face->node connectivity.
@@ -485,17 +514,14 @@ def compute_face_centroids(mesh2d_node_x, mesh2d_node_y, mesh2d_face_nodes, star
     """
     node_x = np.asarray(mesh2d_node_x)
     node_y = np.asarray(mesh2d_node_y)
-    faces = np.asarray(mesh2d_face_nodes)
-
-    # Convert to 0-based indexing
-    faces = faces.astype(np.int64) - start_index
+    faces = normalize_face_node_connectivity(mesh2d_face_nodes, start_index=start_index, fill_value=fill_value)
 
     face_x = np.empty(faces.shape[0], dtype=np.float64)
     face_y = np.empty(faces.shape[0], dtype=np.float64)
 
     for i, face in enumerate(faces):
         # Drop padded indices and out-of-range
-        valid = face[(face != (fill_value - start_index)) & (face >= 0)]
+        valid = face[face >= 0]
         if valid.size == 0:
             face_x[i] = np.nan
             face_y[i] = np.nan

--- a/src/sedtrails/transport_converter/plugins/format/sfincs.py
+++ b/src/sedtrails/transport_converter/plugins/format/sfincs.py
@@ -219,13 +219,13 @@ class FormatPlugin(BaseFormatPlugin):
                         except Exception as e:
                             raise IOError(f'Failed to open NetCDF file: {e}') from e
                         else:
-                            print(f'Sucessfully loaded (Xarray, decode_times=False): {self.input_file}')
+                            print(f'Successfully loaded (Xarray, decode_times=False): {self.input_file}')
                     else:
                         raise IOError(f'Failed to open NetCDF file: {e}') from e
                 else:
-                    print(f'Sucessfully loaded (Xarray): {self.input_file}')
+                    print(f'Successfully loaded (Xarray): {self.input_file}')
             else:
-                print(f'Sucessfully loaded (Xugrid): {self.input_file}')
+                print(f'Successfully loaded (Xugrid): {self.input_file}')
 
     def _get_variable(self, name: str):
         """

--- a/src/sedtrails/transport_converter/plugins/format/sfincs.py
+++ b/src/sedtrails/transport_converter/plugins/format/sfincs.py
@@ -152,6 +152,35 @@ class FormatPlugin(BaseFormatPlugin):
 
         return sedtrails_data
 
+    def get_seeding_coordinates(self):
+        """
+        Return only the spatial coordinates required for particle seeding.
+        """
+        self.load()
+
+        # Fast path: xugrid already provides face centroids.
+        if isinstance(self.input_data, xu.UgridDataset):
+            grid = self.input_data.grid
+            if not isinstance(grid, xu.Ugrid2d):
+                raise TypeError(f'Expected Ugrid2d, got {type(grid).__name__}')
+            return grid.face_x, grid.face_y
+
+        # Fallback: compute centroids from node coordinates and face-node connectivity.
+        node_x_var = self._get_variable('mesh2d_node_x')
+        node_y_var = self._get_variable('mesh2d_node_y')
+        face_nodes_var = self._get_variable('mesh2d_face_nodes')
+
+        start_index = face_nodes_var.attrs.get('start_index', 0)
+        fill_value = face_nodes_var.encoding.get('_FillValue', face_nodes_var.attrs.get('_FillValue', -1))
+
+        return compute_face_centroids(
+            node_x_var,
+            node_y_var,
+            face_nodes_var,
+            start_index=start_index,
+            fill_value=fill_value,
+        )
+
     def load(self) -> Any:
         """
         Reads and loads a SFINCS NetCDF file using xugrid.
@@ -160,7 +189,11 @@ class FormatPlugin(BaseFormatPlugin):
         if self.input_data is None:
             try:
                 # First try using xugrid's open_dataset which handles UGRID conventions
-                self.input_data = xu.open_dataset(self.input_file, decode_times=True, decode_timedelta=True)
+                self.input_data = xu.load_dataset(
+                    self.input_file,
+                    decode_times=True,
+                    decode_timedelta=True,
+                )
             except Exception as e:
                 print(f'Could not open file with xugrid: {e} \n Trying with Xarray...')
                 # Fallback to regular xarray
@@ -334,7 +367,13 @@ class FormatPlugin(BaseFormatPlugin):
         # Derive face coordinates using helper that handles xu.UgridDataset
         node_x_var = self._get_variable('mesh2d_node_x')
         node_y_var = self._get_variable('mesh2d_node_y')
-        face_nodes_var = self._get_variable('mesh2d_face_nodes')
+        grid = self.input_data.grid
+
+        if not isinstance(grid, xu.Ugrid2d):
+            raise TypeError(f'Expected Ugrid2d, got {type(grid).__name__}')
+
+        face_nodes_var = grid.face_node_connectivity
+
         face_x, face_y = compute_face_centroids(
             node_x_var,
             node_y_var,

--- a/src/sedtrails/transport_converter/plugins/format/sfincs.py
+++ b/src/sedtrails/transport_converter/plugins/format/sfincs.py
@@ -6,7 +6,7 @@ import xarray as xr
 import xugrid as xu
 
 from sedtrails.transport_converter.plugins import BaseFormatPlugin
-from sedtrails.transport_converter.sedtrails_data import SedtrailsData
+from sedtrails.transport_converter.sedtrails_data import SedtrailsData, SedtrailsMetadata
 
 
 class FormatPlugin(BaseFormatPlugin):
@@ -14,7 +14,7 @@ class FormatPlugin(BaseFormatPlugin):
     Plugin for converting SFINCS NetCDF to SedTRAILS format.
     """
 
-    def __init__(self, input_file: str):
+    def __init__(self, input_file: str, morfac: float = 1.0):
         """
         Initialize the plugin with the input file.
 
@@ -49,7 +49,16 @@ class FormatPlugin(BaseFormatPlugin):
 
         if not self._input_variables:  # Ensures variables are only loaded once
             try:
-                self._input_variables = list(self.input_data.data_vars)
+                ds = self.input_data
+                if isinstance(self.input_data, xu.UgridDataset):
+                    ds = (
+                        getattr(self.input_data, 'dataset', None)
+                        or getattr(self.input_data, '_dataset', None)
+                        or getattr(self.input_data, 'ds', None)
+                    )
+                    if ds is None:
+                        raise ValueError('Underlying xarray Dataset not found on UgridDataset')
+                self._input_variables = list(ds.data_vars)
             except AttributeError as e:
                 raise ValueError('Input data could not retrieve variables') from e
             else:
@@ -57,7 +66,12 @@ class FormatPlugin(BaseFormatPlugin):
 
         return self._input_variables
 
-    def convert(self, current_time=None, reading_interval=None) -> SedtrailsData:
+    def convert(
+        self,
+        current_time=None,
+        reading_interval=None,
+        reference_date=np.datetime64('1970-01-01T00:00:00'),
+    ) -> SedtrailsData:
         """
         SedtrailsData from SFINCS Netcdf.
 
@@ -67,6 +81,8 @@ class FormatPlugin(BaseFormatPlugin):
             Current simulation time in seconds
         reading_interval : float, optional
             Reading interval in seconds
+        reference_date : np.datetime64, optional
+            Reference date for converting time values
 
         Returns:
         --------
@@ -76,7 +92,7 @@ class FormatPlugin(BaseFormatPlugin):
 
         # Read the NetCDF file
         self.load()
-        time_info = self._get_time_info(self.input_data, reference_date=np.datetime64('1970-01-01T00:00:00'))
+        time_info = self._get_time_info(self.input_data, reference_date=reference_date)
 
         # Determine if we need to slice based on current_time and reading_interval
         time_start_idx, time_end_idx = self._calculate_time_slice(current_time, reading_interval, time_info)
@@ -122,16 +138,16 @@ class FormatPlugin(BaseFormatPlugin):
             y=mapped_data['y'],
             bed_level=mapped_data['bed_level'],
             depth_avg_flow_velocity=depth_avg_flow_velocity,
+            water_depth=mapped_data['water_depth'],
+            metadata=metadata,
             fractions=0,  # Default to 0 fractions
             # this has no meaning for SFINCS runs
             bed_load_transport=None,
             suspended_transport=None,
-            water_depth=mapped_data['water_depth'],
             mean_bed_shear_stress=None,
             max_bed_shear_stress=None,
             sediment_concentration=None,
             nonlinear_wave_velocity=None,
-            metadata=metadata,
         )
 
         return sedtrails_data
@@ -144,19 +160,57 @@ class FormatPlugin(BaseFormatPlugin):
         if self.input_data is None:
             try:
                 # First try using xugrid's open_dataset which handles UGRID conventions
-                self.input_data = xu.open_dataset(self.input_file, decode_timedelta=True)
+                self.input_data = xu.open_dataset(self.input_file, decode_times=True, decode_timedelta=True)
             except Exception as e:
                 print(f'Could not open file with xugrid: {e} \n Trying with Xarray...')
                 # Fallback to regular xarray
                 try:
-                    self.input_data = xr.open_dataset(self.input_file, decode_timedelta=True)
+                    try:
+                        self.input_data = xr.open_dataset(
+                            self.input_file, decode_times=True, use_cftime=True, decode_timedelta=True
+                        )
+                    except TypeError:
+                        # Older xarray versions may not support use_cftime
+                        self.input_data = xr.open_dataset(self.input_file, decode_times=True, decode_timedelta=True)
                 except Exception as e:
-                    raise IOError(f'Failed to open NetCDF file: {e}') from e
-
+                    # If time decoding fails, retry without decoding
+                    msg = str(e)
+                    if 'decode time' in msg or 'decode_times' in msg or 'cftime' in msg:
+                        try:
+                            self.input_data = xr.open_dataset(
+                                self.input_file, decode_times=False, decode_timedelta=False
+                            )
+                        except Exception as e:
+                            raise IOError(f'Failed to open NetCDF file: {e}') from e
+                        else:
+                            print(f'Sucessfully loaded (Xarray, decode_times=False): {self.input_file}')
+                    else:
+                        raise IOError(f'Failed to open NetCDF file: {e}') from e
                 else:
                     print(f'Sucessfully loaded (Xarray): {self.input_file}')
             else:
                 print(f'Sucessfully loaded (Xugrid): {self.input_file}')
+
+    def _get_variable(self, name: str):
+        """
+        Return an xarray DataArray for variable `name` for either xr.Dataset or xu.UgridDataset.
+        """
+        if self.input_data is None:
+            raise ValueError('Dataset not loaded. Call load() first.')
+
+        ds = self.input_data
+        #   if isinstance(self.input_data, xu.UgridDataset):
+        #       ds = (
+        #           getattr(self.input_data, 'dataset', None)
+        #           or getattr(self.input_data, '_dataset', None)
+        #           or getattr(self.input_data, 'ds', None)
+        #       )
+        #       if ds is None:
+        #           raise KeyError(f"Underlying xarray Dataset not found on UgridDataset for variable '{name}'")
+
+        if name in ds:
+            return ds[name]
+        raise KeyError(f"Variable '{name}' not found in dataset")
 
     def _get_time_info(self, input_data: Union[xu.UgridDataset, xr.Dataset], reference_date: np.datetime64) -> Dict:
         """
@@ -194,8 +248,35 @@ class FormatPlugin(BaseFormatPlugin):
         orig_units = getattr(time_var, 'units', None)
         orig_calendar = getattr(time_var, 'calendar', 'standard')
 
+        # Normalize time values if they are not already datetime-like
+        if not np.issubdtype(np.asarray(time_values).dtype, np.datetime64):
+            decoded = None
+            if orig_units is not None:
+                try:
+                    decoded = xr.coding.times.decode_cf_datetime(time_values, orig_units, orig_calendar)
+                except Exception:
+                    decoded = None
+            if decoded is not None:
+                try:
+                    decoded = xr.coding.times.cftime_to_nptime(decoded)
+                except Exception:
+                    pass
+                time_values = decoded
+            else:
+                # Fallback: treat numeric values as seconds since reference_date
+                time_values = reference_date + np.asarray(time_values, dtype=float) * np.timedelta64(1, 's')
+
         # Convert time values to seconds since reference_date
-        seconds_since_ref = np.array([float((t - reference_date) / np.timedelta64(1, 's')) for t in time_values])
+        try:
+            seconds_since_ref = np.array([float((t - reference_date) / np.timedelta64(1, 's')) for t in time_values])
+        except Exception:
+            try:
+                time_values = xr.coding.times.cftime_to_nptime(time_values)
+                seconds_since_ref = np.array(
+                    [float((t - reference_date) / np.timedelta64(1, 's')) for t in time_values]
+                )
+            except Exception as inner_e:
+                raise TypeError('Time values could not be converted to seconds since reference_date') from inner_e
 
         return {
             'time_values': time_values,
@@ -208,14 +289,22 @@ class FormatPlugin(BaseFormatPlugin):
             'num_times': len(time_values),
         }
 
-    
-    def _calculate_time_slice(self, current_time, reading_interval, time_info)
+    def _slice_time_info(self, time_info: Dict, time_slice: slice) -> Dict:
+        """Slice time info to specified range."""
+        sliced_info = time_info.copy()
+        sliced_info['time_values'] = time_info['time_values'][time_slice]
+        sliced_info['seconds_since_reference'] = time_info['seconds_since_reference'][time_slice]
+        sliced_info['num_times'] = len(sliced_info['time_values'])
+        if len(sliced_info['time_values']) > 0:
+            sliced_info['time_start'] = sliced_info['time_values'][0]
+            sliced_info['time_end'] = sliced_info['time_values'][-1]
+        return sliced_info
 
     def _map_sfincs_variables(
         self, time_info, time_start_idx: Optional[int] = None, time_end_idx: Optional[int] = None
     ) -> Dict:
         """
-        Map Delft3D Flexible Mesh variables to SedtrailsData structure.
+        Map SFINCS variables to SedtrailsData structure.
 
         Parameters:
         -----------
@@ -242,33 +331,32 @@ class FormatPlugin(BaseFormatPlugin):
             else slice(None)
         )
 
-        # Variable mapping for DFM files
+        # Derive face coordinates using helper that handles xu.UgridDataset
+        node_x_var = self._get_variable('mesh2d_node_x')
+        node_y_var = self._get_variable('mesh2d_node_y')
+        face_nodes_var = self._get_variable('mesh2d_face_nodes')
+        face_x, face_y = compute_face_centroids(
+            node_x_var,
+            node_y_var,
+            face_nodes_var,
+            start_index=1,
+            fill_value=-999,
+        )
+
+        # Variable mapping for SFINCS files
         variable_map = {
-            'x': 'net_xcc',  # X-coordinates
-            'y': 'net_ycc',  # Y-coordinates
-            'bed_level': 'bedlevel',  # Bed level
-            'water_depth': 'waterdepth',  # Water depth
-            'flow_velocity_x': 'sea_water_x_velocity',  # X-component of flow velocity
-            'flow_velocity_y': 'sea_water_y_velocity',  # Y-component of flow velocity
-            'mean_bed_shear_stress': 'mean_bss_magnitude',  # Mean bed shear stress
-            'max_bed_shear_stress': 'max_bss_magnitude',  # Max bed shear stress
-            'bed_load_transport_x': 'bedload_x_comp',  # X-component of bed load sediment transport
-            'bed_load_transport_y': 'bedload_y_comp',  # Y-component of bed load sediment transport
-            'suspended_transport_x': 'susload_x_comp',  # X-component of suspended sediment transport
-            'suspended_transport_y': 'susload_y_comp',  # Y-component of suspended sediment transport
-            'sediment_concentration': 'suspended_sed_conc',  # Suspended sediment concentration
+            'bed_level': 'zb',  # Bed level
+            'water_depth': 'h',  # Water depth
+            'flow_velocity_x': 'u',  # X-component of flow velocity
+            'flow_velocity_y': 'v',  # Y-component of flow velocity
         }
 
         # Extract data from dataset
         data = {}
 
         # First, get spatial coordinates (typically not time-dependent)
-        for key in ['x', 'y']:
-            var_name = variable_map[key]
-            if var_name in self.input_data:
-                data[key] = self.input_data[var_name].values
-            else:
-                raise KeyError(f"Required variable '{var_name}' not found in dataset")
+        data['x'] = face_x
+        data['y'] = face_y
 
         # Determine the spatial grid dimensions
         grid_shape = data['x'].shape
@@ -277,37 +365,100 @@ class FormatPlugin(BaseFormatPlugin):
         time_dependent_vars = [
             'bed_level',
             'water_depth',
-            'mean_bed_shear_stress',
-            'max_bed_shear_stress',
-            'sediment_concentration',
             'flow_velocity_x',
             'flow_velocity_y',
-            'bed_load_transport_x',
-            'bed_load_transport_y',
-            'suspended_transport_x',
-            'suspended_transport_y',
         ]
 
         for key in time_dependent_vars:
-            var_name = variable_map[key]
-            if var_name in self.input_data:
-                var = self.input_data[var_name]
-
-                # Check if variable has time dimension
-                if 'time' in var.dims:
-                    # Check if variable has layer dimension
-                    if 'layer' in var.dims:
-                        # For variables with time and layer, select layer 0 and apply time slice
-                        data[key] = var.isel(layer=0, time=time_slice).values
-                    else:
-                        # For variables with time but no layer, apply time slice
-                        data[key] = var.isel(time=time_slice).values
-                else:
-                    # For variables without time dimension, broadcast to all time steps
-                    data[key] = np.broadcast_to(var.values, (num_times, *var.shape))
-            else:
+            var_name = variable_map.get(key, var_name if 'var_name' in locals() else None)
+            try:
+                var = self._get_variable(var_name)
+            except KeyError:
                 # Default to zeros if not found
                 data[key] = np.zeros((num_times, *grid_shape))
                 print(f"Warning: Variable '{var_name}' not found, using zeros")
+                continue
+
+            # Check if variable has time dimension
+            if 'time' in var.dims:
+                # Check if variable has layer dimension
+                if 'layer' in var.dims:
+                    # For variables with time and layer, select layer 0 and apply time slice
+                    data[key] = var.isel(layer=0, time=time_slice).values
+                else:
+                    # For variables with time but no layer, apply time slice
+                    data[key] = var.isel(time=time_slice).values
+            else:
+                # For variables without time dimension, broadcast to all time steps
+                data[key] = np.broadcast_to(var.values, (num_times, *var.shape))
 
         return data
+
+    def _calculate_time_slice(self, current_time, reading_interval, time_info):
+        """Calculate time slice indices based on current time and reading interval."""
+
+        # If no chunking parameters provided, load entire file
+        if current_time is None or reading_interval is None:
+            return None, None
+
+        # If reading_interval is 0 or very large, load entire file
+        if reading_interval <= 0 or reading_interval >= time_info['seconds_since_reference'][-1]:
+            return None, None
+
+        times_array = time_info['seconds_since_reference']
+
+        # Find current time index
+        current_idx = np.searchsorted(times_array, current_time)
+
+        # Calculate chunk size based on reading interval and NetCDF timestep
+        netcdf_timestep = times_array[1] - times_array[0] if len(times_array) > 1 else 1.0
+        chunk_steps = max(10, int(reading_interval / netcdf_timestep))
+
+        # Calculate start and end indices with some buffer
+        start_idx = max(0, current_idx - chunk_steps // 4)
+        end_idx = min(len(times_array), current_idx + chunk_steps)
+
+        return start_idx, end_idx
+
+
+def compute_face_centroids(mesh2d_node_x, mesh2d_node_y, mesh2d_face_nodes, start_index=1, fill_value=-999):
+    """
+    Compute face centroids from UGRID mesh node coordinates and face->node connectivity.
+
+    Parameters
+    ----------
+    mesh2d_node_x : array-like, shape (nnode,)
+    mesh2d_node_y : array-like, shape (nnode,)
+    mesh2d_face_nodes : array-like, shape (nface, max_nodes_per_face)
+        Node indices per face; may be padded with fill_value.
+    start_index : int
+        0 or 1 depending on file convention.
+    fill_value : int
+        Padding value in mesh2d_face_nodes.
+
+    Returns
+    -------
+    face_x : np.ndarray, shape (nface,)
+    face_y : np.ndarray, shape (nface,)
+    """
+    node_x = np.asarray(mesh2d_node_x)
+    node_y = np.asarray(mesh2d_node_y)
+    faces = np.asarray(mesh2d_face_nodes)
+
+    # Convert to 0-based indexing
+    faces = faces.astype(np.int64) - start_index
+
+    face_x = np.empty(faces.shape[0], dtype=np.float64)
+    face_y = np.empty(faces.shape[0], dtype=np.float64)
+
+    for i, face in enumerate(faces):
+        # Drop padded indices and out-of-range
+        valid = face[(face != (fill_value - start_index)) & (face >= 0)]
+        if valid.size == 0:
+            face_x[i] = np.nan
+            face_y[i] = np.nan
+            continue
+        face_x[i] = node_x[valid].mean()
+        face_y[i] = node_y[valid].mean()
+
+    return face_x, face_y

--- a/src/sedtrails/transport_converter/plugins/physics/bertin.py
+++ b/src/sedtrails/transport_converter/plugins/physics/bertin.py
@@ -1,5 +1,9 @@
+import logging
+
 from sedtrails.transport_converter.plugins import BasePhysicsPlugin
 from sedtrails.transport_converter import SedtrailsData
+
+logger = logging.getLogger(__name__)
 
 
 class PhysicsPlugin(BasePhysicsPlugin):
@@ -22,7 +26,7 @@ class PhysicsPlugin(BasePhysicsPlugin):
         """
         Add physics using Bertin et al. (2023) approach.
         """
-        print('Using Bertin et al. (2023) to compute transport velocities and add to SedTRAILS data...')
+        logger.info('Using Bertin et al. (2023) to compute transport velocities and add to SedTRAILS data')
 
         raise NotImplementedError('Bertin et al. (2023) physics calculations not yet implemented.')
         # Implement Bertin et al. (2023) physics calculations here

--- a/src/sedtrails/transport_converter/plugins/physics/bertin.py
+++ b/src/sedtrails/transport_converter/plugins/physics/bertin.py
@@ -16,6 +16,8 @@ class PhysicsPlugin(BasePhysicsPlugin):
     def add_physics(
         self,
         sedtrails_data: SedtrailsData,
+        *args,
+        **kwargs,
     ):
         """
         Add physics using Bertin et al. (2023) approach.

--- a/src/sedtrails/transport_converter/plugins/physics/passive_tracer.py
+++ b/src/sedtrails/transport_converter/plugins/physics/passive_tracer.py
@@ -1,7 +1,11 @@
 """A plugin for passive tracer calculations."""
 
+import logging
+
 from sedtrails.transport_converter import SedtrailsData
 from sedtrails.transport_converter.plugins import BasePhysicsPlugin
+
+logger = logging.getLogger(__name__)
 
 
 class PhysicsPlugin(BasePhysicsPlugin):  # all clases should be called the PhysicsPlugin
@@ -21,7 +25,7 @@ class PhysicsPlugin(BasePhysicsPlugin):  # all clases should be called the Physi
         flow_velocity_y = sedtrails_data.depth_avg_flow_velocity['y']
         flow_velocity_magnitude = sedtrails_data.depth_avg_flow_velocity['magnitude']
 
-        print('Adding physics fields to SedtrailsData...')
+        logger.info('Adding physics fields to SedtrailsData')
 
         # Flow velocities (vector fields)
         sedtrails_data.add_physics_field(

--- a/src/sedtrails/transport_converter/plugins/physics/passive_tracer.py
+++ b/src/sedtrails/transport_converter/plugins/physics/passive_tracer.py
@@ -1,0 +1,30 @@
+"""A plugin for passive tracer calculations."""
+
+from sedtrails.transport_converter import SedtrailsData
+from sedtrails.transport_converter.plugins import BasePhysicsPlugin
+
+
+class PhysicsPlugin(BasePhysicsPlugin):  # all clases should be called the PhysicsPlugin
+    """
+    Plugin for passive tracer calculations.
+    """
+
+    def __init__(self, config, tracer_config):
+        super().__init__()
+        self.config = config
+
+    def add_physics(self, sedtrails_data: SedtrailsData, *args, **kwargs) -> None:
+        """
+        Add flow fields for passive tracer
+        """
+        flow_velocity_x = sedtrails_data.depth_avg_flow_velocity['x']
+        flow_velocity_y = sedtrails_data.depth_avg_flow_velocity['y']
+        flow_velocity_magnitude = sedtrails_data.depth_avg_flow_velocity['magnitude']
+
+        print('Adding physics fields to SedtrailsData...')
+
+        # Flow velocities (vector fields)
+        sedtrails_data.add_physics_field(
+            'depth_avg_flow_velocity',
+            {'x': flow_velocity_x, 'y': flow_velocity_y, 'magnitude': flow_velocity_magnitude},
+        )

--- a/src/sedtrails/transport_converter/plugins/physics/soulsby.py
+++ b/src/sedtrails/transport_converter/plugins/physics/soulsby.py
@@ -1,9 +1,13 @@
 """A plugin for Soulsby et al. (2011) sediment transport physics calculations."""
 
+import logging
+
 import numpy as np
 from sedtrails.transport_converter import physics_lib
 from sedtrails.transport_converter import SedtrailsData
 from sedtrails.transport_converter.plugins import BasePhysicsPlugin
+
+logger = logging.getLogger(__name__)
 
 
 class PhysicsPlugin(BasePhysicsPlugin):  # all clases should be called the PhysicsPlugin
@@ -25,7 +29,7 @@ class PhysicsPlugin(BasePhysicsPlugin):  # all clases should be called the Physi
         'See: Soulsby, R. L., et al. (2011). Lagrangian model for simulating '
         'the dispersal of sand-sized particles in coastal waters.'
         """
-        print('Using Soulsby et al. (2011) to compute transport velocities and add to SedTRAILS data...')
+        logger.info('Using Soulsby et al. (2011) to compute transport velocities and add to SedTRAILS data')
 
         # === LOAD: Extract data ===
 
@@ -213,7 +217,7 @@ class PhysicsPlugin(BasePhysicsPlugin):  # all clases should be called the Physi
 
         # === STORE ===
 
-        print('Adding physics fields to SedtrailsData...')
+        logger.info('Adding physics fields to SedtrailsData')
 
         # Sediment velocities (vector fields)
         sedtrails_data.add_physics_field(

--- a/src/sedtrails/transport_converter/plugins/physics/soulsby.py
+++ b/src/sedtrails/transport_converter/plugins/physics/soulsby.py
@@ -1,8 +1,8 @@
 """A plugin for Soulsby et al. (2011) sediment transport physics calculations."""
 
 import numpy as np
-from sedtrails.transport_converter import physics_lib
-from sedtrails.transport_converter import SedtrailsData
+
+from sedtrails.transport_converter import SedtrailsData, physics_lib
 from sedtrails.transport_converter.plugins import BasePhysicsPlugin
 
 
@@ -16,7 +16,9 @@ class PhysicsPlugin(BasePhysicsPlugin):  # all clases should be called the Physi
         super().__init__()
         self.config = config
 
-    def add_physics(self, sedtrails_data: SedtrailsData, grain_properties: dict[str, float], transport_probability_method: str) -> None:
+    def add_physics(
+        self, sedtrails_data: SedtrailsData, grain_properties: dict[str, float], transport_probability_method: str
+    ) -> None:
         """
         Add physics using Soulsby et al. (2011) approach.
         '1. Focus on individual particle tracking velocities\n'
@@ -50,14 +52,20 @@ class PhysicsPlugin(BasePhysicsPlugin):  # all clases should be called the Physi
         dimensionless_grain_size = grain_properties.get('dimensionless_grain_size')
         critical_shields = grain_properties.get('critical_shields')
         settling_velocity = grain_properties.get('settling_velocity')
-        
+
         # Validate required grain properties
         if critical_shields is None:
-            raise ValueError('critical_shields is required for Soulsby physics calculations but was not found in grain_properties')
+            raise ValueError(
+                'critical_shields is required for Soulsby physics calculations but was not found in grain_properties'
+            )
         if dimensionless_grain_size is None:
-            raise ValueError('dimensionless_grain_size is required for Soulsby physics calculations but was not found in grain_properties')
+            raise ValueError(
+                'dimensionless_grain_size is required for Soulsby physics calculations but was not found in grain_properties'
+            )
         if settling_velocity is None:
-            raise ValueError('settling_velocity is required for Soulsby physics calculations but was not found in grain_properties')
+            raise ValueError(
+                'settling_velocity is required for Soulsby physics calculations but was not found in grain_properties'
+            )
 
         # Extract flow velocities (we should be able to change these based on configuration)
         flow_velocity_x = sedtrails_data.depth_avg_flow_velocity['x']
@@ -124,79 +132,86 @@ class PhysicsPlugin(BasePhysicsPlugin):  # all clases should be called the Physi
             )
         )
 
-        # VECTORIZE THESE LOOPS!
-        # Compute the transition probability b [-] (Equations 3 and 4)
-        soulsby_b = np.zeros(theta_max.shape)
+        soulsby_b = np.zeros_like(theta_max, dtype=float)
+
         if transport_probability_method != 'no_probability':
-            for i in range(0, theta_max.shape[0]):
-                for j in range(0, theta_max.shape[1]):
-                    if background_theta_max[i][j] > background_theta_cr:
-                        soulsby_b[i][j] = soulsby_b_e * (
-                            1 - np.exp(-(background_theta_max[i][j] - background_theta_cr) / soulsby_theta_s)
-                        )
-                    else:
-                        soulsby_b[i][j] = 0
- 
-        # Compute the transition probability a [-] (Equation 5)
-        soulsby_a = soulsby_gamma_e * soulsby_b / (1 - soulsby_gamma_e)
+            mask_b = background_theta_max > background_theta_cr
+            delta_b = background_theta_max - background_theta_cr  # safe even if negative; mask controls use
+            # b = b_e * (1 - exp(-(theta - theta_cr)/theta_s)) for theta > theta_cr else 0
+            # (Assumes soulsby_theta_s > 0)
+            soulsby_b = np.where(
+                mask_b,
+                soulsby_b_e * (1.0 - np.exp(-delta_b / soulsby_theta_s)),
+                0.0,
+            )
 
+        # a (Eq. 5)  -- scalar denominator guard
+        den_gamma = 1.0 - soulsby_gamma_e
+        soulsby_a = np.divide(
+            soulsby_gamma_e * soulsby_b,
+            den_gamma,
+            out=np.zeros_like(soulsby_b),
+            where=(den_gamma != 0.0),
+        )
 
-        # VECTORIZE THESE LOOPS!
-        # Compute probability/proportion of time a particle is moving P [-] (Equation 6)
-        soulsby_P = np.zeros(theta_max.shape)
-        for i in range(0, theta_max.shape[0]):
-            for j in range(0, theta_max.shape[1]):
-                if theta_max[i][j] > theta_cr_exp:
-                    soulsby_P[i][j] = (1 + ((np.pi / (6 * soulsby_mu_d)) / (theta_max[i][j] - theta_cr_exp)) ** 4) ** (
-                        -1 / 4
-                    )
-                else:
-                    soulsby_P[i][j] = 0
+        delta_theta = theta_max - theta_cr_exp
+        mask_P = delta_theta > 0.0
 
-        # Compute a reduction factor which is applied on the flow velocities to obtain grain velocities
+        const_P = np.pi / (6.0 * soulsby_mu_d)
+        with np.errstate(divide='ignore', invalid='ignore', over='ignore', under='ignore'):
+            term = (const_P / delta_theta) ** 4
+            soulsby_P = np.where(mask_P, (1.0 + term) ** (-0.25), 0.0)
 
-        Rb = np.zeros(bed_load_velocity.shape)  # Bed load velocity reduction factor
-        Rs = np.zeros(bed_load_velocity.shape)  # Suspended load velocity reduction factor
-        soulsby_R = np.zeros(bed_load_velocity.shape)  # Final velocity reduction factor
+        # Clean any numerical junk
+        soulsby_P = np.nan_to_num(soulsby_P, nan=0.0, posinf=0.0, neginf=0.0)
 
-        # VECTORIZE THESE LOOPS!
-        # Compute Rb (Equation 8)
-        for i in range(0, theta_max.shape[0]):
-            for j in range(0, theta_max.shape[1]):
-                if theta_max[i][j] > theta_cr_exp:
-                    # print(bed_load_velocity[i][j] / flow_velocity_magnitude[i][j])
-                    Rb[i][j] = bed_load_velocity[i][j] / flow_velocity_magnitude[i][j]
-                    if Rb[i][j] > 1:
-                        Rb[i][j] = 1  # apply velocity limiter (grain velocity cannot exceed flow velocity)
-                    else:
-                        Rb[i][j] = 0
+        Rb = np.zeros_like(bed_load_velocity, dtype=float)
 
-        # VECTORIZE THESE LOOPS!
-        # Compute Rs (Equation 11)
-        for i in range(0, theta_max.shape[0]):
-            for j in range(0, theta_max.shape[1]):
-                if Rb[i][j] == 0:
-                    Rs[i][j] = 0
-                else:
-                    Rs[i][j] = (
-                        Rb[i][j] * (1 - rouse_number[i][j])
-                        / (8 / 7 - rouse_number[i][j])
-                        * ((8 / 7 * Rb[i][j]) ** (8 - 7 * rouse_number[i][j]) - 1)
-                        / ((8 / 7 * Rb[i][j]) ** (7 - 7 * rouse_number[i][j]) - 1)
-                    )
-                    if Rs[i][j] > 1:
-                        Rs[i][j] = 1  # Apply velocity limiter (grain velocity cannot exceed flow velocity)
-                    elif np.isnan(Rs[i][j]):
-                        Rs[i][j] = 0
-        
-        # VECTORIZE THESE LOOPS!
-        # Compute R
-        for i in range(0, theta_max.shape[0]):
-            for j in range(0, theta_max.shape[1]):
-                if rouse_number[i][j] < 2.5:  # if all material is in suspension use Rs (for suspended load)
-                    soulsby_R[i][j] = Rs[i][j]
-                else:  # otherwise use Rb (for bed load)
-                    soulsby_R[i][j] = Rb[i][j]
+        # Only compute where theta > theta_cr_exp AND flow_velocity_magnitude > 0 (improvement #1)
+        mask_Rb = (theta_max > theta_cr_exp) & (flow_velocity_magnitude > 0.0)
+
+        np.divide(
+            bed_load_velocity,
+            flow_velocity_magnitude,
+            out=Rb,
+            where=mask_Rb,
+        )
+
+        # Apply limiter and NaN handling (improvement #2)
+        Rb = np.nan_to_num(Rb, nan=0.0, posinf=0.0, neginf=0.0)
+        Rb = np.clip(Rb, 0.0, 1.0)
+
+        Rs = np.zeros_like(Rb, dtype=float)
+
+        rouse = rouse_number.astype(float)
+        base = (8.0 / 7.0) * Rb
+        denA = (8.0 / 7.0) - rouse
+
+        exp1 = 8.0 - 7.0 * rouse
+        exp2 = 7.0 - 7.0 * rouse
+
+        eps = 1e-12  # numerical safety threshold
+
+        with np.errstate(divide='ignore', invalid='ignore', over='ignore', under='ignore'):
+            pow1 = np.power(base, exp1)
+            pow2 = np.power(base, exp2)
+            denPow = pow2 - 1.0
+
+            Rs_calc = Rb * (1.0 - rouse) / denA * (pow1 - 1.0) / denPow
+
+        valid_Rs = (
+            (Rb > 0.0)
+            & np.isfinite(rouse)
+            & np.isfinite(Rb)
+            & (np.abs(denA) > eps)  # avoids 8/7 - rouse == 0 singularity
+            & (np.abs(denPow) > eps)  # avoids pow2 - 1 == 0 singularity (notably around rouse==1)
+        )
+
+        Rs = np.where(valid_Rs, Rs_calc, 0.0)
+        Rs = np.nan_to_num(Rs, nan=0.0, posinf=0.0, neginf=0.0)
+        Rs = np.clip(Rs, 0.0, 1.0)
+
+        soulsby_R = np.where(rouse < 2.5, Rs, Rb)
 
         # Compute grain velocities
         grain_velocity_magnitude = np.multiply(soulsby_P, soulsby_R, flow_velocity_magnitude)  # (Equation 1)

--- a/src/sedtrails/transport_converter/sedtrails_data.py
+++ b/src/sedtrails/transport_converter/sedtrails_data.py
@@ -1,6 +1,6 @@
 import warnings
 from dataclasses import dataclass
-from typing import Dict
+from typing import Any, Dict
 
 import numpy as np
 from scipy.spatial import ConvexHull, cKDTree
@@ -91,16 +91,44 @@ class SedtrailsData:
     sediment_concentration: np.ndarray
     nonlinear_wave_velocity: Dict[str, np.ndarray]
     metadata: SedtrailsMetadata
+    node_x: np.ndarray | None = None
+    node_y: np.ndarray | None = None
+    face_node_connectivity: np.ndarray | None = None
+    face_node_fill_value: int = -1
 
     def __post_init__(self):
         """Initialize container for dynamic physics fields and validate metadata."""
 
+        self._normalize_optional_mesh_geometry()
         # Validate metadata field
         self._validate_metadata()
         # TODO: do we also need to check that min max values are sensible? i.e. min <= max
         self._calculate_timestep()
         self._compute_grid_metadata()
         self._physics_fields: Dict[str, np.ndarray | Dict[str, np.ndarray]] = {}
+
+    def _normalize_optional_mesh_geometry(self) -> None:
+        """Normalize optional UGRID-style mesh geometry for dashboard consumers."""
+        if self.node_x is not None:
+            self.node_x = np.asarray(self.node_x)
+        if self.node_y is not None:
+            self.node_y = np.asarray(self.node_y)
+        if self.face_node_connectivity is not None:
+            self.face_node_connectivity = np.asarray(self.face_node_connectivity, dtype=np.int64)
+
+    def mesh_geometry(self) -> Dict[str, Any] | None:
+        """Return optional face-node mesh geometry for visualization code."""
+        if self.node_x is None or self.node_y is None or self.face_node_connectivity is None:
+            return None
+
+        return {
+            'x': self.x,
+            'y': self.y,
+            'node_x': self.node_x,
+            'node_y': self.node_y,
+            'face_node_connectivity': self.face_node_connectivity,
+            'face_node_fill_value': self.face_node_fill_value,
+        }
 
     def _calculate_timestep(self):
         """Calculate median timestep and add to metadata."""

--- a/src/sedtrails/transport_converter/sedtrails_data.py
+++ b/src/sedtrails/transport_converter/sedtrails_data.py
@@ -1,9 +1,11 @@
-import numpy as np
-from typing import Dict
-from dataclasses import dataclass
 import warnings
+from dataclasses import dataclass
+from typing import Dict
+
+import numpy as np
+from scipy.spatial import ConvexHull, cKDTree
 from scipy.spatial.distance import pdist
-from scipy.spatial import ConvexHull
+
 from sedtrails.transport_converter.sedtrails_metadata import SedtrailsMetadata
 
 
@@ -17,7 +19,7 @@ class SedtrailsData:
 
     Attributes:
     -----------
-    
+
     times: np.ndarray
         Array of time values in seconds since reference_date
     reference_date: np.datetime64
@@ -93,7 +95,7 @@ class SedtrailsData:
 
     def __post_init__(self):
         """Initialize container for dynamic physics fields and validate metadata."""
-        
+
         # Validate metadata field
         self._validate_metadata()
         # TODO: do we also need to check that min max values are sensible? i.e. min <= max
@@ -103,7 +105,7 @@ class SedtrailsData:
 
     def _calculate_timestep(self):
         """Calculate median timestep and add to metadata."""
-        
+
         if len(self.times) < 2:
             # Cannot calculate timestep with fewer than 2 time points
             timestep = None
@@ -136,17 +138,35 @@ class SedtrailsData:
         - min_resolution: minimum distance between any two grid points
         - outer_envelope: convex hull vertices of the grid points
         """
-        
+
         # Stack coordinates for distance calculations
         coords = np.column_stack((self.x.flatten(), self.y.flatten()))
 
-        # Compute minimum resolution (minimum distance between any two points)
-        distances = pdist(coords)
-        min_resolution = float(np.min(distances))
+        # Remove invalid points (e.g., NaNs from mesh construction)
+        valid_mask = np.isfinite(coords).all(axis=1)
+        coords = coords[valid_mask]
 
-        # Compute outer envelope using convex hull
-        hull = ConvexHull(coords)
-        outer_envelope = coords[hull.vertices].tolist()  # Convert to list for JSON serialization
+        if coords.shape[0] < 2:
+            self.metadata.add('min_resolution', None)
+            self.metadata.add('outer_envelope', [])
+            return
+
+        # Compute minimum resolution using nearest-neighbor search
+        tree = cKDTree(coords)
+        distances, _ = tree.query(coords, k=2)
+        min_resolution = float(np.min(distances[:, 1]))
+
+        # Compute outer envelope using convex hull; fallback to bbox on failure
+        try:
+            hull = ConvexHull(coords)
+            outer_envelope = coords[hull.vertices].tolist()
+        except Exception as e:
+            warnings.warn(f'Convex hull failed ({e}); using bounding box instead.', stacklevel=1)
+            min_x = float(np.min(coords[:, 0]))
+            max_x = float(np.max(coords[:, 0]))
+            min_y = float(np.min(coords[:, 1]))
+            max_y = float(np.max(coords[:, 1]))
+            outer_envelope = [[min_x, min_y], [min_x, max_y], [max_x, max_y], [max_x, min_y]]
 
         # Add to metadata
         self.metadata.add('min_resolution', min_resolution)
@@ -154,7 +174,7 @@ class SedtrailsData:
 
     def _validate_metadata(self):
         """Validate that metadata field exists and is the correct type."""
-        
+
         # Only check that metadata is the right type
         if not isinstance(self.metadata, SedtrailsMetadata):
             raise TypeError(f'metadata must be an instance of SedtrailsMetadata, got {type(self.metadata).__name__}')
@@ -165,29 +185,29 @@ class SedtrailsData:
 
         Parameters
         ----------
-        
+
         name : str
             Name of the physics field
         data : np.ndarray or dict
             Physics data (scalar array or dict with 'x', 'y', 'magnitude' for vectors)
         """
-        
+
         self._physics_fields[name] = data
         setattr(self, name, data)
 
     def has_physics_field(self, name: str) -> bool:
         """Check if a specific physics field exists."""
-        
+
         return name in self._physics_fields
 
     def get_physics_fields(self) -> list:
         """Get list of available physics field names."""
-        
+
         return list(self._physics_fields.keys())
 
     def has_physics_data(self) -> bool:
         """Check if any physics fields have been added."""
-        
+
         return len(self._physics_fields) > 0
 
     # ------------------------------------------------------------------
@@ -199,21 +219,21 @@ class SedtrailsData:
 
         Parameters
         ----------
-        
+
         time_index : int
             Time index to extract
 
         Returns
         -------
-        
+
         Dict
             Dictionary containing all data for the specified time index
         """
-        
+
         if time_index < 0 or time_index >= len(self.times):
             raise IndexError(f'Time index {time_index} out of bounds (0-{len(self.times) - 1})')
 
-        # Core fields
+        # Core fields (only include optional fields when present)
         data = {
             'time': self.times[time_index],
             'reference_date': self.reference_date,
@@ -221,31 +241,47 @@ class SedtrailsData:
             'y': self.y,
             'bed_level': self.bed_level,  # typically time-independent
             'fractions': self.fractions,
-            'water_depth': self.water_depth[time_index],
-            'mean_bed_shear_stress': self.mean_bed_shear_stress[time_index],
-            'max_bed_shear_stress': self.max_bed_shear_stress[time_index],
-            'sediment_concentration': self.sediment_concentration[time_index],
-            'depth_avg_flow_velocity': {
+        }
+
+        if self.water_depth is not None:
+            data['water_depth'] = self.water_depth[time_index]
+
+        if self.mean_bed_shear_stress is not None:
+            data['mean_bed_shear_stress'] = self.mean_bed_shear_stress[time_index]
+
+        if self.max_bed_shear_stress is not None:
+            data['max_bed_shear_stress'] = self.max_bed_shear_stress[time_index]
+
+        if self.sediment_concentration is not None:
+            data['sediment_concentration'] = self.sediment_concentration[time_index]
+
+        if self.depth_avg_flow_velocity is not None:
+            data['depth_avg_flow_velocity'] = {
                 'x': self.depth_avg_flow_velocity['x'][time_index],
                 'y': self.depth_avg_flow_velocity['y'][time_index],
                 'magnitude': self.depth_avg_flow_velocity['magnitude'][time_index],
-            },
-            'bed_load_transport': {
+            }
+
+        if self.bed_load_transport is not None:
+            data['bed_load_transport'] = {
                 'x': self.bed_load_transport['x'][time_index],
                 'y': self.bed_load_transport['y'][time_index],
                 'magnitude': self.bed_load_transport['magnitude'][time_index],
-            },
-            'suspended_transport': {
+            }
+
+        if self.suspended_transport is not None:
+            data['suspended_transport'] = {
                 'x': self.suspended_transport['x'][time_index],
                 'y': self.suspended_transport['y'][time_index],
                 'magnitude': self.suspended_transport['magnitude'][time_index],
-            },
-            'nonlinear_wave_velocity': {
+            }
+
+        if self.nonlinear_wave_velocity is not None:
+            data['nonlinear_wave_velocity'] = {
                 'x': self.nonlinear_wave_velocity['x'][time_index],
                 'y': self.nonlinear_wave_velocity['y'][time_index],
                 'magnitude': self.nonlinear_wave_velocity['magnitude'][time_index],
-            },
-        }
+            }
 
         # Dynamic physics fields
         for name, value in self._physics_fields.items():

--- a/src/sedtrails/transport_converter/sedtrails_data.py
+++ b/src/sedtrails/transport_converter/sedtrails_data.py
@@ -151,21 +151,34 @@ class SedtrailsData:
             self.metadata.add('outer_envelope', [])
             return
 
-        # Compute minimum resolution using nearest-neighbor search
-        tree = cKDTree(coords)
-        distances, _ = tree.query(coords, k=2)
-        min_resolution = float(np.min(distances[:, 1]))
+        # Drop duplicate points: repeated coordinates are not additional spatial resolution.
+        unique_coords = np.unique(coords, axis=0)
+        if unique_coords.shape[0] < 2:
+            self.metadata.add('min_resolution', None)
+            self.metadata.add('outer_envelope', [])
+            return
+
+        # Compute minimum resolution using nearest-neighbor search on unique points.
+        tree = cKDTree(unique_coords)
+        distances, _ = tree.query(unique_coords, k=2)
+        nearest_distances = distances[:, 1]
+        positive_distances = nearest_distances[nearest_distances > 0.0]
+
+        if positive_distances.size == 0:
+            min_resolution = None
+        else:
+            min_resolution = float(np.min(positive_distances))
 
         # Compute outer envelope using convex hull; fallback to bbox on failure
         try:
-            hull = ConvexHull(coords)
-            outer_envelope = coords[hull.vertices].tolist()
+            hull = ConvexHull(unique_coords)
+            outer_envelope = unique_coords[hull.vertices].tolist()
         except Exception as e:
             warnings.warn(f'Convex hull failed ({e}); using bounding box instead.', stacklevel=1)
-            min_x = float(np.min(coords[:, 0]))
-            max_x = float(np.max(coords[:, 0]))
-            min_y = float(np.min(coords[:, 1]))
-            max_y = float(np.max(coords[:, 1]))
+            min_x = float(np.min(unique_coords[:, 0]))
+            max_x = float(np.max(unique_coords[:, 0]))
+            min_y = float(np.min(unique_coords[:, 1]))
+            max_y = float(np.max(unique_coords[:, 1]))
             outer_envelope = [[min_x, min_y], [min_x, max_y], [max_x, max_y], [max_x, min_y]]
 
         # Add to metadata

--- a/src/sedtrails/transport_converter/sedtrails_data.py
+++ b/src/sedtrails/transport_converter/sedtrails_data.py
@@ -4,7 +4,6 @@ from typing import Dict
 
 import numpy as np
 from scipy.spatial import ConvexHull, cKDTree
-from scipy.spatial.distance import pdist
 
 from sedtrails.transport_converter.sedtrails_metadata import SedtrailsMetadata
 

--- a/src/sedtrails/transport_converter/sedtrails_metadata.py
+++ b/src/sedtrails/transport_converter/sedtrails_metadata.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Any, Dict, Mapping
 
+
 @dataclass
 class SedtrailsMetadata:
     """
@@ -15,25 +16,27 @@ class SedtrailsMetadata:
     flowfield_domain : dict
         Required dictionary containing:
         - x_min : float
-        - x_max : float  
+        - x_max : float
         - y_min : float
         - y_max : float
+    timestep : float
+        Timestep of the Sedtrails simulation
     """
-    
+
     flowfield_domain: Dict[str, float]
-    
-    REQUIRED_DOMAIN_KEYS = {"x_min", "x_max", "y_min", "y_max"}
-    RESERVED_KEYS = {"flowfield_domain"}
+
+    REQUIRED_DOMAIN_KEYS = {'x_min', 'x_max', 'y_min', 'y_max'}
+    RESERVED_KEYS = {'flowfield_domain'}
 
     def __post_init__(self):
         """Validate that flowfield_domain contains required keys."""
         if not isinstance(self.flowfield_domain, dict):
-            raise TypeError("flowfield_domain must be a dictionary")
-        
+            raise TypeError('flowfield_domain must be a dictionary')
+
         missing_keys = self.REQUIRED_DOMAIN_KEYS - set(self.flowfield_domain.keys())
         if missing_keys:
-            raise ValueError(f"flowfield_domain missing required keys: {missing_keys}")
-        
+            raise ValueError(f'flowfield_domain missing required keys: {missing_keys}')
+
         # Ensure all values are float
         for key in self.REQUIRED_DOMAIN_KEYS:
             self.flowfield_domain[key] = float(self.flowfield_domain[key])
@@ -51,7 +54,7 @@ class SedtrailsMetadata:
     def update(self, metadata_dict: Mapping[str, Any]):
         """Update metadata with a dictionary of key-value pairs."""
         for key, value in metadata_dict.items():
-            self.add(key, value) 
+            self.add(key, value)
 
     def get(self, key: str, default=None) -> Any:
         """Get metadata value by key."""
@@ -60,7 +63,7 @@ class SedtrailsMetadata:
     def to_dict(self) -> Dict[str, Any]:
         """
         Export all metadata as dictionary.
-        
+
         Returns
         -------
         dict
@@ -71,6 +74,7 @@ class SedtrailsMetadata:
             if not key.startswith('_'):  # Skip private attributes
                 result[key] = value
         return result
+
 
 # Example usage
 # 1. Create with flowfield_domain dictionary

--- a/tests/converters/test_format_converter.py
+++ b/tests/converters/test_format_converter.py
@@ -99,6 +99,37 @@ def test_sfincs_get_seeding_coordinates_fallback_computes_centroids(monkeypatch)
     np.testing.assert_allclose(y, np.array([1.0]))
 
 
+def test_sfincs_convert_stores_face_node_mesh_geometry(monkeypatch):
+    ds = xr.Dataset(
+        data_vars={
+            'mesh2d_node_x': (('node',), np.array([0.0, 2.0, 2.0, 0.0])),
+            'mesh2d_node_y': (('node',), np.array([0.0, 0.0, 2.0, 2.0])),
+            'mesh2d_face_nodes': (('face', 'nmax'), np.array([[1, 2, 3, 4]], dtype=np.int64)),
+            'zb': (('face',), np.array([-1.0])),
+            'h': (('time', 'face'), np.array([[1.0], [2.0]])),
+            'u': (('time', 'face'), np.array([[0.1], [0.2]])),
+            'v': (('time', 'face'), np.array([[0.0], [0.0]])),
+        },
+        coords={'time': np.array(['2024-01-01T00:00:00', '2024-01-01T00:01:00'], dtype='datetime64[ns]')},
+    )
+    ds['mesh2d_face_nodes'].attrs['start_index'] = 1
+    ds['mesh2d_face_nodes'].encoding['_FillValue'] = -999
+
+    def fake_load(self):
+        self.input_data = ds
+
+    monkeypatch.setattr(sfincs.FormatPlugin, 'load', fake_load)
+
+    plugin = sfincs.FormatPlugin('dummy.nc')
+    sedtrails_data = plugin.convert(reference_date=np.datetime64('2024-01-01T00:00:00'))
+
+    np.testing.assert_array_equal(sedtrails_data.node_x, np.array([0.0, 2.0, 2.0, 0.0]))
+    np.testing.assert_array_equal(sedtrails_data.node_y, np.array([0.0, 0.0, 2.0, 2.0]))
+    np.testing.assert_array_equal(sedtrails_data.face_node_connectivity, np.array([[0, 1, 2, 3]]))
+    assert sedtrails_data.face_node_fill_value == -1
+    assert sedtrails_data.mesh_geometry()['face_node_connectivity'].shape == (1, 4)
+
+
 def test_sfincs_get_seeding_coordinates_raises_on_non_ugrid2d(monkeypatch):
     class FakeNonUgrid2d:
         pass

--- a/tests/converters/test_format_converter.py
+++ b/tests/converters/test_format_converter.py
@@ -9,32 +9,45 @@ from sedtrails.transport_converter.plugins.format import sfincs
 
 
 def _existing_input_path():
+    """Returns a guaranteed-existing file path for plugin constructor inputs."""
     return __file__
 
 
 class _PluginWithCoordinateReader:
+    """Test double exposing get_seeding_coordinates to bypass conversion."""
+
     def __init__(self):
+        """Tracks whether convert was called unexpectedly."""
         self.convert_called = False
 
     def get_seeding_coordinates(self):
+        """Provides deterministic coordinate arrays for seeding tests."""
         return [1.0, 2.0], [3.0, 4.0]
 
     def convert(self, *_args, **_kwargs):
+        """Fails if fallback conversion is invoked when direct coordinates exist."""
         self.convert_called = True
         raise RuntimeError('convert should not be called when get_seeding_coordinates is available')
 
 
 class _PluginWithConvertOnly:
+    """Test double that only supports convert-based seeding field retrieval."""
+
     class _SedtrailsLike:
+        """Minimal Sedtrails-like object exposing x/y coordinates."""
+
         def __init__(self, x, y):
+            """Stores coordinate arrays returned by the fake conversion step."""
             self.x = x
             self.y = y
 
     def convert(self, *_args, **_kwargs):
+        """Returns a minimal converted object for fallback seeding logic."""
         return self._SedtrailsLike(x=(10.0, 20.0), y=(30.0, 40.0))
 
 
 def test_get_seeding_field_data_prefers_coordinate_reader():
+    """Ensures coordinate-reader plugins are used without calling convert."""
     converter = FormatConverter({'input_file': 'dummy.nc', 'input_format': 'dummy'})
     plugin = _PluginWithCoordinateReader()
     converter._format_plugin = plugin
@@ -47,6 +60,7 @@ def test_get_seeding_field_data_prefers_coordinate_reader():
 
 
 def test_get_seeding_field_data_falls_back_to_convert():
+    """Ensures convert fallback is used when no coordinate reader is available."""
     converter = FormatConverter({'input_file': 'dummy.nc', 'input_format': 'dummy'})
     converter._format_plugin = _PluginWithConvertOnly()
 
@@ -57,16 +71,22 @@ def test_get_seeding_field_data_falls_back_to_convert():
 
 
 def test_sfincs_get_seeding_coordinates_uses_ugrid_face_coordinates(monkeypatch):
+    """Checks SFINCS seeding coordinates come directly from UGRID face centers."""
     class FakeUgrid2d:
+        """Minimal UGRID-like grid with predefined face coordinates."""
+
         def __init__(self):
             self.face_x = np.array([1.0, 2.0, 3.0])
             self.face_y = np.array([4.0, 5.0, 6.0])
 
     class FakeUgridDataset:
+        """Dataset wrapper exposing a single UGRID-like grid object."""
+
         def __init__(self):
             self.grid = FakeUgrid2d()
 
     def fake_load(self):
+        """Injects synthetic UGRID input data into the plugin."""
         self.input_data = FakeUgridDataset()
 
     monkeypatch.setattr(sfincs.xu, 'UgridDataset', FakeUgridDataset)
@@ -81,6 +101,7 @@ def test_sfincs_get_seeding_coordinates_uses_ugrid_face_coordinates(monkeypatch)
 
 
 def test_sfincs_get_seeding_coordinates_fallback_computes_centroids(monkeypatch):
+    """Verifies centroid fallback from face-node connectivity when UGRID is unavailable."""
     ds = xr.Dataset(
         data_vars={
             'mesh2d_node_x': (('node',), np.array([0.0, 2.0, 2.0, 0.0])),
@@ -92,6 +113,7 @@ def test_sfincs_get_seeding_coordinates_fallback_computes_centroids(monkeypatch)
     ds['mesh2d_face_nodes'].encoding['_FillValue'] = -999
 
     def fake_load(self):
+        """Injects synthetic mesh dataset into the plugin."""
         self.input_data = ds
 
     monkeypatch.setattr(sfincs.FormatPlugin, 'load', fake_load)
@@ -104,6 +126,7 @@ def test_sfincs_get_seeding_coordinates_fallback_computes_centroids(monkeypatch)
 
 
 def test_sfincs_convert_stores_face_node_mesh_geometry(monkeypatch):
+    """Checks convert stores node coordinates and normalized face connectivity."""
     ds = xr.Dataset(
         data_vars={
             'mesh2d_node_x': (('node',), np.array([0.0, 2.0, 2.0, 0.0])),
@@ -120,6 +143,7 @@ def test_sfincs_convert_stores_face_node_mesh_geometry(monkeypatch):
     ds['mesh2d_face_nodes'].encoding['_FillValue'] = -999
 
     def fake_load(self):
+        """Injects synthetic SFINCS dataset for conversion testing."""
         self.input_data = ds
 
     monkeypatch.setattr(sfincs.FormatPlugin, 'load', fake_load)
@@ -135,14 +159,20 @@ def test_sfincs_convert_stores_face_node_mesh_geometry(monkeypatch):
 
 
 def test_sfincs_get_seeding_coordinates_raises_on_non_ugrid2d(monkeypatch):
+    """Ensures non-UGRID grids raise a clear TypeError in coordinate retrieval."""
     class FakeNonUgrid2d:
+        """Placeholder grid type that intentionally does not match Ugrid2d."""
+
         pass
 
     class FakeUgridDataset:
+        """Dataset wrapper exposing an invalid grid type."""
+
         def __init__(self):
             self.grid = FakeNonUgrid2d()
 
     def fake_load(self):
+        """Injects non-UGRID dataset into the plugin to trigger validation."""
         self.input_data = FakeUgridDataset()
 
     monkeypatch.setattr(sfincs.xu, 'UgridDataset', FakeUgridDataset)

--- a/tests/converters/test_format_converter.py
+++ b/tests/converters/test_format_converter.py
@@ -8,6 +8,10 @@ from sedtrails.transport_converter.format_converter import FormatConverter
 from sedtrails.transport_converter.plugins.format import sfincs
 
 
+def _existing_input_path():
+    return __file__
+
+
 class _PluginWithCoordinateReader:
     def __init__(self):
         self.convert_called = False
@@ -69,7 +73,7 @@ def test_sfincs_get_seeding_coordinates_uses_ugrid_face_coordinates(monkeypatch)
     monkeypatch.setattr(sfincs.xu, 'Ugrid2d', FakeUgrid2d)
     monkeypatch.setattr(sfincs.FormatPlugin, 'load', fake_load)
 
-    plugin = sfincs.FormatPlugin('dummy.nc')
+    plugin = sfincs.FormatPlugin(_existing_input_path())
     x, y = plugin.get_seeding_coordinates()
 
     np.testing.assert_array_equal(x, np.array([1.0, 2.0, 3.0]))
@@ -92,7 +96,7 @@ def test_sfincs_get_seeding_coordinates_fallback_computes_centroids(monkeypatch)
 
     monkeypatch.setattr(sfincs.FormatPlugin, 'load', fake_load)
 
-    plugin = sfincs.FormatPlugin('dummy.nc')
+    plugin = sfincs.FormatPlugin(_existing_input_path())
     x, y = plugin.get_seeding_coordinates()
 
     np.testing.assert_allclose(x, np.array([1.0]))
@@ -120,7 +124,7 @@ def test_sfincs_convert_stores_face_node_mesh_geometry(monkeypatch):
 
     monkeypatch.setattr(sfincs.FormatPlugin, 'load', fake_load)
 
-    plugin = sfincs.FormatPlugin('dummy.nc')
+    plugin = sfincs.FormatPlugin(_existing_input_path())
     sedtrails_data = plugin.convert(reference_date=np.datetime64('2024-01-01T00:00:00'))
 
     np.testing.assert_array_equal(sedtrails_data.node_x, np.array([0.0, 2.0, 2.0, 0.0]))
@@ -145,7 +149,7 @@ def test_sfincs_get_seeding_coordinates_raises_on_non_ugrid2d(monkeypatch):
     monkeypatch.setattr(sfincs.xu, 'Ugrid2d', type('OtherGrid', (), {}))
     monkeypatch.setattr(sfincs.FormatPlugin, 'load', fake_load)
 
-    plugin = sfincs.FormatPlugin('dummy.nc')
+    plugin = sfincs.FormatPlugin(_existing_input_path())
 
     with pytest.raises(TypeError, match='Expected Ugrid2d'):
         plugin.get_seeding_coordinates()

--- a/tests/converters/test_format_converter.py
+++ b/tests/converters/test_format_converter.py
@@ -1,7 +1,120 @@
-"""Test for the Format Converter"""
+"""Tests for the format converter."""
 
-def test_blank():
-    """
-    This is a placeholder test function 
-    """
-    assert 1 + 1 == 2
+import numpy as np
+import pytest
+import xarray as xr
+
+from sedtrails.transport_converter.format_converter import FormatConverter
+from sedtrails.transport_converter.plugins.format import sfincs
+
+
+class _PluginWithCoordinateReader:
+    def __init__(self):
+        self.convert_called = False
+
+    def get_seeding_coordinates(self):
+        return [1.0, 2.0], [3.0, 4.0]
+
+    def convert(self, *_args, **_kwargs):
+        self.convert_called = True
+        raise RuntimeError('convert should not be called when get_seeding_coordinates is available')
+
+
+class _PluginWithConvertOnly:
+    class _SedtrailsLike:
+        def __init__(self, x, y):
+            self.x = x
+            self.y = y
+
+    def convert(self, *_args, **_kwargs):
+        return self._SedtrailsLike(x=(10.0, 20.0), y=(30.0, 40.0))
+
+
+def test_get_seeding_field_data_prefers_coordinate_reader():
+    converter = FormatConverter({'input_file': 'dummy.nc', 'input_format': 'dummy'})
+    plugin = _PluginWithCoordinateReader()
+    converter._format_plugin = plugin
+
+    field_data = converter.get_seeding_field_data()
+
+    np.testing.assert_array_equal(field_data.x, np.array([1.0, 2.0]))
+    np.testing.assert_array_equal(field_data.y, np.array([3.0, 4.0]))
+    assert not plugin.convert_called
+
+
+def test_get_seeding_field_data_falls_back_to_convert():
+    converter = FormatConverter({'input_file': 'dummy.nc', 'input_format': 'dummy'})
+    converter._format_plugin = _PluginWithConvertOnly()
+
+    field_data = converter.get_seeding_field_data()
+
+    np.testing.assert_array_equal(field_data.x, np.array([10.0, 20.0]))
+    np.testing.assert_array_equal(field_data.y, np.array([30.0, 40.0]))
+
+
+def test_sfincs_get_seeding_coordinates_uses_ugrid_face_coordinates(monkeypatch):
+    class FakeUgrid2d:
+        def __init__(self):
+            self.face_x = np.array([1.0, 2.0, 3.0])
+            self.face_y = np.array([4.0, 5.0, 6.0])
+
+    class FakeUgridDataset:
+        def __init__(self):
+            self.grid = FakeUgrid2d()
+
+    def fake_load(self):
+        self.input_data = FakeUgridDataset()
+
+    monkeypatch.setattr(sfincs.xu, 'UgridDataset', FakeUgridDataset)
+    monkeypatch.setattr(sfincs.xu, 'Ugrid2d', FakeUgrid2d)
+    monkeypatch.setattr(sfincs.FormatPlugin, 'load', fake_load)
+
+    plugin = sfincs.FormatPlugin('dummy.nc')
+    x, y = plugin.get_seeding_coordinates()
+
+    np.testing.assert_array_equal(x, np.array([1.0, 2.0, 3.0]))
+    np.testing.assert_array_equal(y, np.array([4.0, 5.0, 6.0]))
+
+
+def test_sfincs_get_seeding_coordinates_fallback_computes_centroids(monkeypatch):
+    ds = xr.Dataset(
+        data_vars={
+            'mesh2d_node_x': (('node',), np.array([0.0, 2.0, 2.0, 0.0])),
+            'mesh2d_node_y': (('node',), np.array([0.0, 0.0, 2.0, 2.0])),
+            'mesh2d_face_nodes': (('face', 'nmax'), np.array([[1, 2, 3, 4]], dtype=np.int64)),
+        }
+    )
+    ds['mesh2d_face_nodes'].attrs['start_index'] = 1
+    ds['mesh2d_face_nodes'].encoding['_FillValue'] = -999
+
+    def fake_load(self):
+        self.input_data = ds
+
+    monkeypatch.setattr(sfincs.FormatPlugin, 'load', fake_load)
+
+    plugin = sfincs.FormatPlugin('dummy.nc')
+    x, y = plugin.get_seeding_coordinates()
+
+    np.testing.assert_allclose(x, np.array([1.0]))
+    np.testing.assert_allclose(y, np.array([1.0]))
+
+
+def test_sfincs_get_seeding_coordinates_raises_on_non_ugrid2d(monkeypatch):
+    class FakeNonUgrid2d:
+        pass
+
+    class FakeUgridDataset:
+        def __init__(self):
+            self.grid = FakeNonUgrid2d()
+
+    def fake_load(self):
+        self.input_data = FakeUgridDataset()
+
+    monkeypatch.setattr(sfincs.xu, 'UgridDataset', FakeUgridDataset)
+    monkeypatch.setattr(sfincs.xu, 'Ugrid2d', type('OtherGrid', (), {}))
+    monkeypatch.setattr(sfincs.FormatPlugin, 'load', fake_load)
+
+    plugin = sfincs.FormatPlugin('dummy.nc')
+
+    with pytest.raises(TypeError, match='Expected Ugrid2d'):
+        plugin.get_seeding_coordinates()

--- a/tests/data_manager/test_xarray_dataset.py
+++ b/tests/data_manager/test_xarray_dataset.py
@@ -4,7 +4,11 @@ from sedtrails.data_manager.xarray_dataset import collect_timestep_data, create_
 
 
 class MockPopulation:
+    """Minimal population stub exposing particle arrays used by dataset export."""
+
     def __init__(self):
+        """Provides deterministic particle state for a single-timestep test."""
+        # Keys mirror the particle fields consumed by collect_timestep_data.
         self.particles = {
             'x': np.array([1.0, 2.0]),
             'y': np.array([3.0, 4.0]),
@@ -14,6 +18,7 @@ class MockPopulation:
 
 
 def test_collect_timestep_data_exports_is_mobile_status():
+    """Checks boolean mobility flags are written as integer status values."""
     ds = create_sedtrails_dataset(N_particles=2, N_populations=1, N_timesteps=1, N_flowfields=1)
 
     collect_timestep_data(ds, [MockPopulation()], timestep=0, current_time=12.0)

--- a/tests/data_manager/test_xarray_dataset.py
+++ b/tests/data_manager/test_xarray_dataset.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+from sedtrails.data_manager.xarray_dataset import collect_timestep_data, create_sedtrails_dataset
+
+
+class MockPopulation:
+    def __init__(self):
+        self.particles = {
+            'x': np.array([1.0, 2.0]),
+            'y': np.array([3.0, 4.0]),
+            'burial_depth': np.array([0.0, 0.1]),
+            'is_mobile': np.array([True, False]),
+        }
+
+
+def test_collect_timestep_data_exports_is_mobile_status():
+    ds = create_sedtrails_dataset(N_particles=2, N_populations=1, N_timesteps=1, N_flowfields=1)
+
+    collect_timestep_data(ds, [MockPopulation()], timestep=0, current_time=12.0)
+
+    np.testing.assert_array_equal(ds['status_mobile'].values[:, 0], np.array([1, 0]))

--- a/tests/particle_tracer/test_data_retriever.py
+++ b/tests/particle_tracer/test_data_retriever.py
@@ -1,0 +1,83 @@
+import numpy as np
+
+from sedtrails.particle_tracer.data_retriever import FieldDataRetriever
+from sedtrails.transport_converter.sedtrails_data import SedtrailsData
+from sedtrails.transport_converter.sedtrails_metadata import SedtrailsMetadata
+
+
+def build_sedtrails_data():
+    x = np.array([0.0, 1.0, 1.0, 0.0])
+    y = np.array([0.0, 0.0, 1.0, 1.0])
+    lower_u = np.array([1.0, 1.0, 1.0, 1.0])
+    upper_u = np.array([3.0, 3.0, 3.0, 3.0])
+    lower_v = np.array([0.5, 0.5, 0.5, 0.5])
+    upper_v = np.array([1.5, 1.5, 1.5, 1.5])
+    lower_mag = np.array([1.0, 2.0, 1.0, 2.0])
+    upper_mag = np.array([4.0, 1.0, 4.0, 1.0])
+    scalar = np.array([[0.0, 1.0, 2.0, 1.0], [2.0, 3.0, 4.0, 3.0]])
+    zeros_time_space = np.zeros((2, x.size), dtype=float)
+    zero_vector = {
+        'x': zeros_time_space.copy(),
+        'y': zeros_time_space.copy(),
+        'magnitude': zeros_time_space.copy(),
+    }
+    metadata = SedtrailsMetadata(
+        flowfield_domain={
+            'x_min': float(np.min(x)),
+            'x_max': float(np.max(x)),
+            'y_min': float(np.min(y)),
+            'y_max': float(np.max(y)),
+        }
+    )
+
+    return SedtrailsData(
+        times=np.array([0.0, 10.0], dtype=float),
+        reference_date=np.datetime64('1970-01-01T00:00:00'),
+        x=x,
+        y=y,
+        bed_level=scalar[0],
+        depth_avg_flow_velocity={
+            'x': np.vstack([lower_u, upper_u]),
+            'y': np.vstack([lower_v, upper_v]),
+            'magnitude': np.vstack([lower_mag, upper_mag]),
+        },
+        fractions=1,
+        bed_load_transport=zero_vector,
+        suspended_transport=zero_vector,
+        water_depth=scalar,
+        mean_bed_shear_stress=zeros_time_space.copy(),
+        max_bed_shear_stress=zeros_time_space.copy(),
+        sediment_concentration=zeros_time_space.copy(),
+        nonlinear_wave_velocity=zero_vector,
+        metadata=metadata,
+    )
+
+
+def test_flow_field_bounds_defer_full_grid_interpolation():
+    retriever = FieldDataRetriever(build_sedtrails_data())
+
+    bounds = retriever.get_flow_field_bounds(2.5, 'depth_avg_flow_velocity')
+
+    assert bounds['weight'] == 0.25
+    np.testing.assert_allclose(bounds['lower']['u'], 1.0)
+    np.testing.assert_allclose(bounds['upper']['u'], 3.0)
+
+
+def test_scalar_field_bounds_defer_full_grid_interpolation():
+    retriever = FieldDataRetriever(build_sedtrails_data())
+
+    bounds = retriever.get_scalar_field_bounds(2.5, 'water_depth')
+
+    assert bounds['weight'] == 0.25
+    np.testing.assert_allclose(bounds['lower'], [0.0, 1.0, 2.0, 1.0])
+    np.testing.assert_allclose(bounds['upper'], [2.0, 3.0, 4.0, 3.0])
+
+
+def test_flow_max_velocity_bound_is_conservative():
+    retriever = FieldDataRetriever(build_sedtrails_data())
+    exact = retriever.get_flow_field(2.5, 'depth_avg_flow_velocity')['magnitude']
+
+    bound = retriever.get_flow_max_velocity_bound(2.5, 'depth_avg_flow_velocity')
+
+    assert bound >= np.nanmax(exact)
+    assert bound == 2.5

--- a/tests/particle_tracer/test_data_retriever.py
+++ b/tests/particle_tracer/test_data_retriever.py
@@ -6,6 +6,7 @@ from sedtrails.transport_converter.sedtrails_metadata import SedtrailsMetadata
 
 
 def build_sedtrails_data():
+    """Builds a minimal two-time-slice SedtrailsData fixture for retriever tests."""
     x = np.array([0.0, 1.0, 1.0, 0.0])
     y = np.array([0.0, 0.0, 1.0, 1.0])
     lower_u = np.array([1.0, 1.0, 1.0, 1.0])
@@ -30,6 +31,8 @@ def build_sedtrails_data():
         }
     )
 
+    # Assemble the minimal model input used by the tests: one flow field, one scalar field,
+    # and two timesteps to exercise lower/upper bounds and temporal weighting logic.
     return SedtrailsData(
         times=np.array([0.0, 10.0], dtype=float),
         reference_date=np.datetime64('1970-01-01T00:00:00'),
@@ -54,6 +57,7 @@ def build_sedtrails_data():
 
 
 def test_flow_field_bounds_defer_full_grid_interpolation():
+    """Checks flow bounds return lower/upper slices and interpolation weight."""
     retriever = FieldDataRetriever(build_sedtrails_data())
 
     bounds = retriever.get_flow_field_bounds(2.5, 'depth_avg_flow_velocity')
@@ -64,6 +68,7 @@ def test_flow_field_bounds_defer_full_grid_interpolation():
 
 
 def test_scalar_field_bounds_defer_full_grid_interpolation():
+    """Checks scalar bounds return lower/upper slices and interpolation weight."""
     retriever = FieldDataRetriever(build_sedtrails_data())
 
     bounds = retriever.get_scalar_field_bounds(2.5, 'water_depth')
@@ -74,6 +79,7 @@ def test_scalar_field_bounds_defer_full_grid_interpolation():
 
 
 def test_flow_max_velocity_bound_is_conservative():
+    """Verifies max-velocity bound is conservative relative to exact interpolation."""
     retriever = FieldDataRetriever(build_sedtrails_data())
     exact = retriever.get_flow_field(2.5, 'depth_avg_flow_velocity')['magnitude']
 

--- a/tests/particle_tracer/test_particle_seeder.py
+++ b/tests/particle_tracer/test_particle_seeder.py
@@ -1149,3 +1149,27 @@ class TestParticlePopulation:
         )
 
         np.testing.assert_allclose(population.particles['bed_level'], 0.5)
+
+    def test_update_position_carries_cached_simplex_ids(self, point_config_simple):
+        """Position updates should reuse and refresh particle simplex ids."""
+        population = ParticlePopulation(
+            field_x=np.array([0.0, 1.0, 1.0, 0.0]),
+            field_y=np.array([0.0, 0.0, 1.0, 1.0]),
+            population_config=point_config_simple,
+        )
+        old_simplices = population._particle_simplices.copy()
+        population.particles['is_mobile'] = np.ones(len(population.particles['x']), dtype=bool)
+
+        population.update_position(
+            flow_field={'u': np.ones(4), 'v': np.zeros(4)},
+            current_timestep=0.1,
+        )
+
+        np.testing.assert_allclose(population.particles['x'], [0.1])
+        np.testing.assert_allclose(population.particles['y'], [0.0])
+        expected_simplices = population.grid_geometry.locate_points(
+            population.particles['x'],
+            population.particles['y'],
+            old_simplices,
+        )
+        np.testing.assert_array_equal(population._particle_simplices, expected_simplices)

--- a/tests/particle_tracer/test_particle_seeder.py
+++ b/tests/particle_tracer/test_particle_seeder.py
@@ -1130,3 +1130,22 @@ class TestParticlePopulation:
         np.testing.assert_allclose(population.particles['transport_probability'], 1.0)
         np.testing.assert_allclose(population.particles['bed_level'], 0.0)
         assert 'mixing_depth' not in population.particles
+
+    def test_update_information_accepts_temporal_scalar_bounds(self, point_config_simple):
+        """Temporal scalar bounds should match preblended-grid interpolation."""
+        population = ParticlePopulation(
+            field_x=np.array([0.0, 1.0, 1.0, 0.0]),
+            field_y=np.array([0.0, 0.0, 1.0, 1.0]),
+            population_config=point_config_simple,
+        )
+        lower = np.array([0.0, 1.0, 2.0, 1.0])
+        upper = np.array([2.0, 3.0, 4.0, 3.0])
+
+        population.update_information(
+            current_time=0.0,
+            mixing_depth=None,
+            transport_probability=1.0,
+            bed_level={'lower': lower, 'upper': upper, 'weight': 0.25},
+        )
+
+        np.testing.assert_allclose(population.particles['bed_level'], 0.5)

--- a/tests/particle_tracer/test_particle_seeder.py
+++ b/tests/particle_tracer/test_particle_seeder.py
@@ -1110,3 +1110,23 @@ class TestParticlePopulation:
         assert population is not None
         assert len(population.particles['x']) == 10  # 2 nlocations * 5 quantity
         assert len(population.particles['y']) == 10  # 2 nlocations * 5 quantity
+
+    def test_update_information_accepts_scalar_transport_probability(self, point_config_simple):
+        """Scalar fields should update particles without allocating full grid fields."""
+        population = ParticlePopulation(
+            field_x=np.array([0.0, 1.0, 1.0, 0.0]),
+            field_y=np.array([0.0, 0.0, 1.0, 1.0]),
+            population_config=point_config_simple,
+        )
+        bed_level = np.array([0.0, 1.0, 2.0, 1.0])
+
+        population.update_information(
+            current_time=0.0,
+            mixing_depth=None,
+            transport_probability=1.0,
+            bed_level=bed_level,
+        )
+
+        np.testing.assert_allclose(population.particles['transport_probability'], 1.0)
+        np.testing.assert_allclose(population.particles['bed_level'], 0.0)
+        assert 'mixing_depth' not in population.particles

--- a/tests/particle_tracer/test_position_calculator_numba.py
+++ b/tests/particle_tracer/test_position_calculator_numba.py
@@ -1,0 +1,58 @@
+import numpy as np
+
+from sedtrails.particle_tracer.position_calculator_numba import create_grid_geometry, create_numba_particle_calculator
+
+
+def square_grid():
+    grid_x = np.array([0.0, 1.0, 1.0, 0.0])
+    grid_y = np.array([0.0, 0.0, 1.0, 1.0])
+    return grid_x, grid_y
+
+
+def test_cached_geometry_reused_by_calculator():
+    grid_x, grid_y = square_grid()
+    geometry = create_grid_geometry(grid_x, grid_y)
+
+    calculator = create_numba_particle_calculator(grid_x, grid_y, grid_geometry=geometry)
+
+    assert calculator['geometry'] is geometry
+    assert calculator['triangles'].shape[1] == 3
+
+
+def test_linear_field_interpolation_uses_cached_delaunay_locator():
+    grid_x, grid_y = square_grid()
+    calculator = create_numba_particle_calculator(grid_x, grid_y)
+    field = 2.0 * grid_x + 3.0 * grid_y
+
+    x_points = np.array([0.25, 0.75, 1.0])
+    y_points = np.array([0.25, 0.75, 0.5])
+    expected = 2.0 * x_points + 3.0 * y_points
+
+    interpolated = calculator['interpolate_field'](field, x_points, y_points)
+
+    np.testing.assert_allclose(interpolated, expected, rtol=1e-12, atol=1e-12)
+
+
+def test_explicit_triangle_connectivity_is_preserved():
+    grid_x, grid_y = square_grid()
+    triangles = np.array([[0, 1, 2], [0, 2, 3]])
+
+    calculator = create_numba_particle_calculator(grid_x, grid_y, triangles=triangles)
+
+    np.testing.assert_array_equal(calculator['triangles'], triangles)
+
+
+def test_rk4_update_with_constant_velocity():
+    grid_x, grid_y = square_grid()
+    calculator = create_numba_particle_calculator(grid_x, grid_y)
+    grid_u = np.ones_like(grid_x)
+    grid_v = np.full_like(grid_y, 0.5)
+
+    x0 = np.array([0.2, 0.4])
+    y0 = np.array([0.2, 0.3])
+    dt = 0.1
+
+    x_new, y_new = calculator['update_particles'](x0, y0, grid_u, grid_v, dt)
+
+    np.testing.assert_allclose(x_new, x0 + dt, rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(y_new, y0 + 0.5 * dt, rtol=1e-12, atol=1e-12)

--- a/tests/particle_tracer/test_position_calculator_numba.py
+++ b/tests/particle_tracer/test_position_calculator_numba.py
@@ -33,6 +33,32 @@ def test_linear_field_interpolation_uses_cached_delaunay_locator():
     np.testing.assert_allclose(interpolated, expected, rtol=1e-12, atol=1e-12)
 
 
+def test_multi_field_interpolation_reuses_single_point_location():
+    grid_x, grid_y = square_grid()
+    geometry = create_grid_geometry(grid_x, grid_y)
+    call_count = 0
+    original_barycentric_weights = geometry.barycentric_weights
+
+    def counted_barycentric_weights(x_points, y_points):
+        nonlocal call_count
+        call_count += 1
+        return original_barycentric_weights(x_points, y_points)
+
+    geometry.barycentric_weights = counted_barycentric_weights
+    field_a = grid_x + grid_y
+    field_b = 2.0 * grid_x - grid_y
+
+    values_a, values_b = geometry.interpolate_fields(
+        (field_a, field_b),
+        np.array([0.25, 0.75]),
+        np.array([0.25, 0.25]),
+    )
+
+    assert call_count == 1
+    np.testing.assert_allclose(values_a, [0.5, 1.0])
+    np.testing.assert_allclose(values_b, [0.25, 1.25])
+
+
 def test_explicit_triangle_connectivity_is_preserved():
     grid_x, grid_y = square_grid()
     triangles = np.array([[0, 1, 2], [0, 2, 3]])
@@ -91,3 +117,42 @@ def test_temporal_rk4_update_matches_preblended_grid():
 
     np.testing.assert_allclose(x_temporal, x_blended, rtol=1e-12, atol=1e-12)
     np.testing.assert_allclose(y_temporal, y_blended, rtol=1e-12, atol=1e-12)
+
+
+def test_temporal_rk4_uses_one_point_location_per_stage():
+    grid_x, grid_y = square_grid()
+    geometry = create_grid_geometry(grid_x, grid_y)
+    call_count = 0
+    original_barycentric_weights = geometry.barycentric_weights
+
+    def counted_barycentric_weights(x_points, y_points):
+        nonlocal call_count
+        call_count += 1
+        return original_barycentric_weights(x_points, y_points)
+
+    geometry.barycentric_weights = counted_barycentric_weights
+
+    geometry.update_particles_temporal(
+        np.array([0.2, 0.4]),
+        np.array([0.2, 0.3]),
+        np.ones_like(grid_x),
+        np.full_like(grid_y, 0.5),
+        np.full_like(grid_x, 3.0),
+        np.full_like(grid_y, 1.5),
+        0.25,
+        0.1,
+    )
+
+    assert call_count == 4
+
+
+def test_velocity_arrays_do_not_copy_non_geographic_float32_fields():
+    grid_x, grid_y = square_grid()
+    geometry = create_grid_geometry(grid_x, grid_y)
+    grid_u = np.ones_like(grid_x, dtype=np.float32)
+    grid_v = np.ones_like(grid_y, dtype=np.float32)
+
+    grid_u_adj, grid_v_adj = geometry._velocity_arrays(grid_u, grid_v, igeo=0)
+
+    assert np.shares_memory(grid_u_adj, grid_u)
+    assert np.shares_memory(grid_v_adj, grid_v)

--- a/tests/particle_tracer/test_position_calculator_numba.py
+++ b/tests/particle_tracer/test_position_calculator_numba.py
@@ -119,18 +119,18 @@ def test_temporal_rk4_update_matches_preblended_grid():
     np.testing.assert_allclose(y_temporal, y_blended, rtol=1e-12, atol=1e-12)
 
 
-def test_temporal_rk4_uses_one_point_location_per_stage():
+def test_temporal_rk4_uses_one_point_location_pass_per_update():
     grid_x, grid_y = square_grid()
     geometry = create_grid_geometry(grid_x, grid_y)
     call_count = 0
-    original_barycentric_weights = geometry.barycentric_weights
+    original_locate_points = geometry.locate_points
 
-    def counted_barycentric_weights(x_points, y_points):
+    def counted_locate_points(x_points, y_points, start_simplices=None):
         nonlocal call_count
         call_count += 1
-        return original_barycentric_weights(x_points, y_points)
+        return original_locate_points(x_points, y_points, start_simplices)
 
-    geometry.barycentric_weights = counted_barycentric_weights
+    geometry.locate_points = counted_locate_points
 
     geometry.update_particles_temporal(
         np.array([0.2, 0.4]),
@@ -143,7 +143,49 @@ def test_temporal_rk4_uses_one_point_location_per_stage():
         0.1,
     )
 
-    assert call_count == 4
+    assert call_count == 1
+
+
+def test_temporal_update_returns_reusable_simplex_ids():
+    grid_x, grid_y = square_grid()
+    geometry = create_grid_geometry(grid_x, grid_y)
+    starts = geometry.locate_points(np.array([0.2, 0.4]), np.array([0.2, 0.3]))
+
+    x_new, y_new, new_simplices = geometry.update_particles_temporal_with_simplex(
+        np.array([0.2, 0.4]),
+        np.array([0.2, 0.3]),
+        np.ones_like(grid_x),
+        np.full_like(grid_y, 0.5),
+        np.full_like(grid_x, 3.0),
+        np.full_like(grid_y, 1.5),
+        0.25,
+        0.1,
+        simplex_ids=starts,
+    )
+
+    np.testing.assert_allclose(x_new, [0.35, 0.55])
+    np.testing.assert_allclose(y_new, [0.275, 0.375])
+    np.testing.assert_array_equal(new_simplices, geometry.locate_points(x_new, y_new, new_simplices))
+
+
+def test_position_update_preserves_particle_array_shape():
+    grid_x, grid_y = square_grid()
+    geometry = create_grid_geometry(grid_x, grid_y)
+    x0 = np.array([[0.2, 0.4]])
+    y0 = np.array([[0.2, 0.3]])
+
+    x_new, y_new = geometry.update_particles(
+        x0,
+        y0,
+        np.ones_like(grid_x),
+        np.full_like(grid_y, 0.5),
+        0.1,
+    )
+
+    assert x_new.shape == x0.shape
+    assert y_new.shape == y0.shape
+    np.testing.assert_allclose(x_new, x0 + 0.1)
+    np.testing.assert_allclose(y_new, y0 + 0.05)
 
 
 def test_velocity_arrays_do_not_copy_non_geographic_float32_fields():

--- a/tests/particle_tracer/test_position_calculator_numba.py
+++ b/tests/particle_tracer/test_position_calculator_numba.py
@@ -56,3 +56,38 @@ def test_rk4_update_with_constant_velocity():
 
     np.testing.assert_allclose(x_new, x0 + dt, rtol=1e-12, atol=1e-12)
     np.testing.assert_allclose(y_new, y0 + 0.5 * dt, rtol=1e-12, atol=1e-12)
+
+
+def test_temporal_rk4_update_matches_preblended_grid():
+    grid_x, grid_y = square_grid()
+    calculator = create_numba_particle_calculator(grid_x, grid_y)
+    lower_u = np.ones_like(grid_x)
+    lower_v = np.full_like(grid_y, 0.5)
+    upper_u = np.full_like(grid_x, 3.0)
+    upper_v = np.full_like(grid_y, 1.5)
+    weight = 0.25
+
+    x0 = np.array([0.2, 0.4])
+    y0 = np.array([0.2, 0.3])
+    dt = 0.1
+
+    x_temporal, y_temporal = calculator['update_particles_temporal'](
+        x0,
+        y0,
+        lower_u,
+        lower_v,
+        upper_u,
+        upper_v,
+        weight,
+        dt,
+    )
+    x_blended, y_blended = calculator['update_particles'](
+        x0,
+        y0,
+        lower_u + weight * (upper_u - lower_u),
+        lower_v + weight * (upper_v - lower_v),
+        dt,
+    )
+
+    np.testing.assert_allclose(x_temporal, x_blended, rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(y_temporal, y_blended, rtol=1e-12, atol=1e-12)

--- a/tests/particle_tracer/test_position_calculator_numba.py
+++ b/tests/particle_tracer/test_position_calculator_numba.py
@@ -10,6 +10,7 @@ def square_grid():
 
 
 def test_cached_geometry_reused_by_calculator():
+    """Ensures the calculator reuses a provided GridGeometry instance."""
     grid_x, grid_y = square_grid()
     geometry = create_grid_geometry(grid_x, grid_y)
 
@@ -20,6 +21,7 @@ def test_cached_geometry_reused_by_calculator():
 
 
 def test_linear_field_interpolation_uses_cached_delaunay_locator():
+    """Checks linear nodal fields interpolate to exact values at query points."""
     grid_x, grid_y = square_grid()
     calculator = create_numba_particle_calculator(grid_x, grid_y)
     field = 2.0 * grid_x + 3.0 * grid_y
@@ -34,6 +36,7 @@ def test_linear_field_interpolation_uses_cached_delaunay_locator():
 
 
 def test_multi_field_interpolation_reuses_single_point_location():
+    """Verifies multiple fields share one barycentric point-location pass."""
     grid_x, grid_y = square_grid()
     geometry = create_grid_geometry(grid_x, grid_y)
     call_count = 0
@@ -60,6 +63,7 @@ def test_multi_field_interpolation_reuses_single_point_location():
 
 
 def test_explicit_triangle_connectivity_is_preserved():
+    """Confirms user-supplied triangle connectivity is used unchanged."""
     grid_x, grid_y = square_grid()
     triangles = np.array([[0, 1, 2], [0, 2, 3]])
 
@@ -69,6 +73,7 @@ def test_explicit_triangle_connectivity_is_preserved():
 
 
 def test_rk4_update_with_constant_velocity():
+    """Validates RK4 advection matches constant-velocity analytical motion."""
     grid_x, grid_y = square_grid()
     calculator = create_numba_particle_calculator(grid_x, grid_y)
     grid_u = np.ones_like(grid_x)
@@ -85,6 +90,7 @@ def test_rk4_update_with_constant_velocity():
 
 
 def test_temporal_rk4_update_matches_preblended_grid():
+    """Ensures temporal RK4 equals RK4 on a preblended velocity field."""
     grid_x, grid_y = square_grid()
     calculator = create_numba_particle_calculator(grid_x, grid_y)
     lower_u = np.ones_like(grid_x)
@@ -120,6 +126,7 @@ def test_temporal_rk4_update_matches_preblended_grid():
 
 
 def test_temporal_rk4_uses_one_point_location_pass_per_update():
+    """Checks temporal updates call point-location only once per update."""
     grid_x, grid_y = square_grid()
     geometry = create_grid_geometry(grid_x, grid_y)
     call_count = 0
@@ -147,6 +154,7 @@ def test_temporal_rk4_uses_one_point_location_pass_per_update():
 
 
 def test_temporal_update_returns_reusable_simplex_ids():
+    """Confirms temporal updates return simplex ids usable as next-step seeds."""
     grid_x, grid_y = square_grid()
     geometry = create_grid_geometry(grid_x, grid_y)
     starts = geometry.locate_points(np.array([0.2, 0.4]), np.array([0.2, 0.3]))
@@ -169,6 +177,7 @@ def test_temporal_update_returns_reusable_simplex_ids():
 
 
 def test_position_update_preserves_particle_array_shape():
+    """Ensures particle update keeps input array dimensionality intact."""
     grid_x, grid_y = square_grid()
     geometry = create_grid_geometry(grid_x, grid_y)
     x0 = np.array([[0.2, 0.4]])
@@ -189,6 +198,7 @@ def test_position_update_preserves_particle_array_shape():
 
 
 def test_velocity_arrays_do_not_copy_non_geographic_float32_fields():
+    """Verifies non-geographic velocity arrays are returned without copies."""
     grid_x, grid_y = square_grid()
     geometry = create_grid_geometry(grid_x, grid_y)
     grid_u = np.ones_like(grid_x, dtype=np.float32)

--- a/tests/particle_tracer/test_timer.py
+++ b/tests/particle_tracer/test_timer.py
@@ -227,6 +227,23 @@ class TestTimer:
         with pytest.raises(RuntimeWarning):
             timer.advance()
 
+    def test_compute_cfl_timestep_skips_all_nan_flow_fields(self):
+        """All-NaN velocity fields should not require a full nan_to_num grid copy."""
+
+        class Metadata:
+            min_resolution = 2.0
+            timestep = 10.0
+
+        class SedtrailsData:
+            metadata = Metadata()
+
+        time = Time(_start='2023-01-01 12:00:00', time_step=Duration('1H'))
+        timer = Timer(simulation_time=time, cfl_condition=0.5)
+
+        timer.compute_cfl_timestep([{'magnitude': np.array([np.nan, np.nan])}], SedtrailsData())
+
+        assert timer.current_timestep == 10.0
+
 
 class TestTime:
     """Test cases for the Time class."""

--- a/tests/particle_tracer/test_timer.py
+++ b/tests/particle_tracer/test_timer.py
@@ -244,6 +244,14 @@ class TestTimer:
 
         assert timer.current_timestep == 10.0
 
+    def test_compute_cfl_timestep_from_precomputed_max_velocity(self):
+        time = Time(_start='2023-01-01 12:00:00', time_step=Duration('1H'))
+        timer = Timer(simulation_time=time, cfl_condition=0.5)
+
+        timer.compute_cfl_timestep_from_max_velocity(max_velocity=2.0, min_resolution=4.0, data_timestep=10.0)
+
+        assert timer.current_timestep == 1.0
+
 
 class TestTime:
     """Test cases for the Time class."""

--- a/tests/particle_tracer/test_timer.py
+++ b/tests/particle_tracer/test_timer.py
@@ -2,6 +2,8 @@
 Unit tests for the Timer class in the timer.py module of the sedtrails package.
 """
 
+import datetime as dt
+
 import pytest
 import numpy as np
 from sedtrails.particle_tracer.timer import Duration, Timer, Time
@@ -275,6 +277,18 @@ class TestTime:
         time = Time(_start='2023-01-01 12:00:00', reference_date='2023-01-01 00:00:00')
         # 12 hours = 12 * 3600 = 43200 seconds
         assert time.start == 43200
+
+    def test_start_property_accepts_date_only_reference(self):
+        """Date-only reference dates should mean midnight of that date."""
+        time = Time(_start='2024-05-01 00:00:00', reference_date='2024-05-01')
+
+        assert time.start == 0
+
+    def test_start_property_accepts_datetime_like_config_values(self):
+        """YAML loaders may return datetime/date objects instead of strings."""
+        time = Time(_start=dt.datetime(2024, 5, 1), reference_date=dt.date(2024, 5, 1))
+
+        assert time.start == 0
 
     def test_end_property(self):
         """Test end property calculation."""

--- a/tests/pathway_visualizer/test_simulation_dashboard.py
+++ b/tests/pathway_visualizer/test_simulation_dashboard.py
@@ -1,0 +1,172 @@
+import numpy as np
+
+from sedtrails.pathway_visualizer.simulation_dashboard import SimulationDashboard
+
+
+class FakeArtist:
+    def __init__(self, axis=None):
+        self.axes = axis
+
+    def remove(self):
+        self.axes = None
+
+
+class FakeImage(FakeArtist):
+    def set_data(self, image):
+        pass
+
+    def set_extent(self, extent):
+        pass
+
+    def set_clim(self, vmin=None, vmax=None):
+        pass
+
+
+class NonRemovableArtist:
+    def remove(self):
+        raise NotImplementedError('cannot remove artist')
+
+
+class FakeAxis:
+    def __init__(self):
+        self.scatter_sizes = []
+        self.quiver_size = None
+        self.imshow_shapes = []
+        self.tricontourf_called = False
+        self.tricontour_called = False
+
+    def clear(self):
+        pass
+
+    def scatter(self, x, y, *args, **kwargs):
+        self.scatter_sizes.append(len(x))
+        return FakeArtist(self)
+
+    def quiver(self, x, y, u, v, *args, **kwargs):
+        self.quiver_size = len(x)
+        return FakeArtist(self)
+
+    def imshow(self, image, *args, **kwargs):
+        self.imshow_shapes.append(image.shape)
+        return FakeImage(self)
+
+    def tricontourf(self, *args, **kwargs):
+        self.tricontourf_called = True
+
+    def tricontour(self, *args, **kwargs):
+        self.tricontour_called = True
+
+    def set_xlabel(self, label):
+        pass
+
+    def set_ylabel(self, label):
+        pass
+
+    def set_aspect(self, aspect):
+        pass
+
+    def set_title(self, title, *args, **kwargs):
+        pass
+
+    def get_legend(self):
+        return None
+
+    def legend(self, *args, **kwargs):
+        return FakeArtist(self)
+
+
+def _dashboard_with_axis(axis_name, axis):
+    dashboard = object.__new__(SimulationDashboard)
+    dashboard.axes = {axis_name: axis}
+    dashboard.bathymetry_cmap = 'viridis'
+    dashboard.bathymetry_vmin = -12
+    dashboard.bathymetry_vmax = 6
+    return dashboard
+
+
+def _flow_field(n_points):
+    x = np.arange(n_points, dtype=float)
+    y = np.zeros(n_points, dtype=float)
+    return {
+        'x': x,
+        'y': y,
+        'magnitude': np.ones(n_points),
+        'u': np.ones(n_points),
+        'v': np.zeros(n_points),
+    }
+
+
+def test_dashboard_should_update_uses_plot_interval():
+    dashboard = object.__new__(SimulationDashboard)
+    dashboard.last_update_time = 100.0
+
+    assert not dashboard.should_update(129.0, 30.0)
+    assert dashboard.should_update(130.0, 30.0)
+
+
+def test_spatial_artist_cleanup_ignores_already_cleared_artists():
+    dashboard = object.__new__(SimulationDashboard)
+    dashboard._particle_artists = [NonRemovableArtist()]
+
+    dashboard._remove_spatial_artist('_particle_artists')
+
+    assert dashboard._particle_artists == []
+
+
+def test_large_grid_flowfield_plot_uses_raster_path():
+    axis = FakeAxis()
+    dashboard = _dashboard_with_axis('flowfield', axis)
+    n_points = SimulationDashboard.LARGE_GRID_POINT_LIMIT + 1
+
+    dashboard._update_flowfield_plot(_flow_field(n_points), np.zeros(n_points))
+
+    assert axis.imshow_shapes
+    assert axis.scatter_sizes == []
+    assert axis.quiver_size == SimulationDashboard.LARGE_GRID_QUIVER_LIMIT
+    assert not axis.tricontourf_called
+    assert not axis.tricontour_called
+
+
+def test_small_grid_flowfield_plot_keeps_contour_path():
+    axis = FakeAxis()
+    dashboard = _dashboard_with_axis('flowfield', axis)
+    n_points = SimulationDashboard.LARGE_GRID_POINT_LIMIT
+
+    dashboard._update_flowfield_plot(_flow_field(n_points), np.zeros(n_points))
+
+    assert axis.scatter_sizes == []
+    assert axis.tricontourf_called
+    assert axis.tricontour_called
+
+
+def test_large_grid_bathymetry_plot_uses_raster_path():
+    axis = FakeAxis()
+    dashboard = _dashboard_with_axis('bathymetry', axis)
+    n_points = SimulationDashboard.LARGE_GRID_POINT_LIMIT + 1
+    particles = {'x': np.array([]), 'y': np.array([])}
+
+    dashboard._update_bathymetry_plot(_flow_field(n_points), np.zeros(n_points), particles)
+
+    assert axis.imshow_shapes
+    assert axis.scatter_sizes == []
+    assert not axis.tricontourf_called
+    assert not axis.tricontour_called
+
+
+def test_rasterization_reuses_cached_weights_for_same_grid():
+    dashboard = object.__new__(SimulationDashboard)
+    x = np.array([0.5])
+    y = np.array([0.5])
+    mesh_geometry = {
+        'node_x': np.array([0.0, 1.0, 1.0, 0.0]),
+        'node_y': np.array([0.0, 0.0, 1.0, 1.0]),
+        'face_node_connectivity': np.array([[0, 1, 2, 3]], dtype=np.int64),
+    }
+
+    weights = dashboard._get_raster_weights(x, y, mesh_geometry)
+    image = dashboard._rasterize_field(np.array([7.0]), weights)
+    same_weights = dashboard._get_raster_weights(x, y, mesh_geometry)
+
+    assert same_weights is weights
+    assert np.nanmin(image) == 7.0
+    assert np.nanmax(image) == 7.0

--- a/tests/pathway_visualizer/test_simulation_dashboard.py
+++ b/tests/pathway_visualizer/test_simulation_dashboard.py
@@ -4,31 +4,46 @@ from sedtrails.pathway_visualizer.simulation_dashboard import SimulationDashboar
 
 
 class FakeArtist:
+    """Minimal matplotlib-like artist used for cleanup and legend tests."""
+
     def __init__(self, axis=None):
+        """Stores an optional axis reference to mimic matplotlib artist state."""
         self.axes = axis
 
     def remove(self):
+        """Marks the artist as detached from its axis."""
         self.axes = None
 
 
 class FakeImage(FakeArtist):
+    """Image-like artist stub supporting imshow update methods."""
+
     def set_data(self, image):
+        """Accepts raster image updates (no-op in tests)."""
         pass
 
     def set_extent(self, extent):
+        """Accepts extent updates (no-op in tests)."""
         pass
 
     def set_clim(self, vmin=None, vmax=None):
+        """Accepts color-limit updates (no-op in tests)."""
         pass
 
 
 class NonRemovableArtist:
+    """Artist stub that fails on remove to test robust cleanup behavior."""
+
     def remove(self):
+        """Raises to emulate third-party artists that cannot be removed."""
         raise NotImplementedError('cannot remove artist')
 
 
 class FakeAxis:
+    """Axis stub recording plotting calls to verify rendering code paths."""
+
     def __init__(self):
+        """Initializes counters and flags used by assertions."""
         self.scatter_sizes = []
         self.quiver_size = None
         self.imshow_shapes = []
@@ -76,6 +91,7 @@ class FakeAxis:
 
 
 def _dashboard_with_axis(axis_name, axis):
+    """Creates a minimally configured dashboard with one injected axis."""
     dashboard = object.__new__(SimulationDashboard)
     dashboard.axes = {axis_name: axis}
     dashboard.bathymetry_cmap = 'viridis'
@@ -85,6 +101,7 @@ def _dashboard_with_axis(axis_name, axis):
 
 
 def _flow_field(n_points):
+    """Builds a simple synthetic flow-field dictionary with n_points samples."""
     x = np.arange(n_points, dtype=float)
     y = np.zeros(n_points, dtype=float)
     return {
@@ -97,6 +114,7 @@ def _flow_field(n_points):
 
 
 def test_dashboard_should_update_uses_plot_interval():
+    """Checks should_update triggers once the elapsed interval is reached."""
     dashboard = object.__new__(SimulationDashboard)
     dashboard.last_update_time = 100.0
 
@@ -105,6 +123,7 @@ def test_dashboard_should_update_uses_plot_interval():
 
 
 def test_spatial_artist_cleanup_ignores_already_cleared_artists():
+    """Ensures artist cleanup ignores removal errors and clears the container."""
     dashboard = object.__new__(SimulationDashboard)
     dashboard._particle_artists = [NonRemovableArtist()]
 
@@ -114,6 +133,7 @@ def test_spatial_artist_cleanup_ignores_already_cleared_artists():
 
 
 def test_large_grid_flowfield_plot_uses_raster_path():
+    """Verifies large flow fields use raster + decimated quiver rendering."""
     axis = FakeAxis()
     dashboard = _dashboard_with_axis('flowfield', axis)
     n_points = SimulationDashboard.LARGE_GRID_POINT_LIMIT + 1
@@ -128,6 +148,7 @@ def test_large_grid_flowfield_plot_uses_raster_path():
 
 
 def test_small_grid_flowfield_plot_keeps_contour_path():
+    """Verifies small flow fields keep the contour-based rendering path."""
     axis = FakeAxis()
     dashboard = _dashboard_with_axis('flowfield', axis)
     n_points = SimulationDashboard.LARGE_GRID_POINT_LIMIT
@@ -140,6 +161,7 @@ def test_small_grid_flowfield_plot_keeps_contour_path():
 
 
 def test_large_grid_bathymetry_plot_uses_raster_path():
+    """Verifies large bathymetry grids switch from contours to raster rendering."""
     axis = FakeAxis()
     dashboard = _dashboard_with_axis('bathymetry', axis)
     n_points = SimulationDashboard.LARGE_GRID_POINT_LIMIT + 1
@@ -154,6 +176,7 @@ def test_large_grid_bathymetry_plot_uses_raster_path():
 
 
 def test_rasterization_reuses_cached_weights_for_same_grid():
+    """Ensures rasterization weight lookup is cached and reused for same mesh."""
     dashboard = object.__new__(SimulationDashboard)
     x = np.array([0.5])
     y = np.array([0.5])

--- a/tests/simulation_orchestrator/test_simulationmanager.py
+++ b/tests/simulation_orchestrator/test_simulationmanager.py
@@ -202,3 +202,32 @@ class TestSimulationManagerExpandTimeDimension:
             expanded['x'].isel(time=slice(0, original_size)).values,
             original_x,  # Compare against the stored original, not dataset['x']
         )
+
+
+class TestSimulationDashboardThrottle:
+    def test_large_grid_dashboard_updates_are_throttled(self):
+        manager = object.__new__(Simulation)
+        manager.dashboard = object()
+        manager._dashboard_throttle_logged = False
+        manager.logger = type('Logger', (), {'info': lambda self, *args, **kwargs: None})()
+        manager._controller = type('Controller', (), {'get': lambda self, key, default=None: default})()
+
+        sedtrails_data = type('SedtrailsData', (), {'x': np.arange(100_001)})()
+        timer = type('Timer', (), {'step_count': 0})()
+
+        assert manager._should_update_dashboard(sedtrails_data, timer)
+
+        timer.step_count = 1
+        assert not manager._should_update_dashboard(sedtrails_data, timer)
+
+        timer.step_count = 10
+        assert manager._should_update_dashboard(sedtrails_data, timer)
+
+    def test_small_grid_dashboard_updates_every_step(self):
+        manager = object.__new__(Simulation)
+        manager.dashboard = object()
+
+        sedtrails_data = type('SedtrailsData', (), {'x': np.arange(100)})()
+        timer = type('Timer', (), {'step_count': 1})()
+
+        assert manager._should_update_dashboard(sedtrails_data, timer)

--- a/tests/simulation_orchestrator/test_simulationmanager.py
+++ b/tests/simulation_orchestrator/test_simulationmanager.py
@@ -268,7 +268,10 @@ class TestSimulationManagerExpandTimeDimension:
 
 
 class TestSimulationDashboardThrottle:
+    """Tests dashboard update cadence and particle payload shape for visualization."""
+
     def test_dashboard_update_interval_uses_visualization_config(self):
+        """Configured dashboard interval should override the default update cadence."""
         class Controller:
             def get(self, key, default=None):
                 if key == 'visualization.dashboard.update_interval':
@@ -281,12 +284,14 @@ class TestSimulationDashboardThrottle:
         assert manager._dashboard_update_interval_seconds() == 30
 
     def test_dashboard_update_interval_defaults_to_one_hour(self):
+        """When unset, dashboard updates should default to a one-hour interval."""
         manager = object.__new__(Simulation)
         manager._controller = type('Controller', (), {'get': lambda self, key, default=None: default})()
 
         assert manager._dashboard_update_interval_seconds() == 3600
 
     def test_dashboard_particle_data_uses_arrays_not_single_element_lists(self):
+        """Dashboard particle payload should keep vector fields as NumPy arrays."""
         class Population:
             particles = {
                 'x': np.array([1.0, 2.0]),
@@ -304,6 +309,7 @@ class TestSimulationDashboardThrottle:
         np.testing.assert_array_equal(particle_data['mixing_depth'], np.array([np.nan, np.nan]))
 
     def test_large_grid_dashboard_updates_are_throttled(self):
+        """Large grids should throttle dashboard refreshes to periodic steps."""
         manager = object.__new__(Simulation)
         manager.dashboard = object()
         manager._dashboard_throttle_logged = False
@@ -322,6 +328,7 @@ class TestSimulationDashboardThrottle:
         assert manager._should_update_dashboard(sedtrails_data, timer)
 
     def test_small_grid_dashboard_updates_every_step(self):
+        """Small grids should keep per-step dashboard updates enabled."""
         manager = object.__new__(Simulation)
         manager.dashboard = object()
 

--- a/tests/simulation_orchestrator/test_simulationmanager.py
+++ b/tests/simulation_orchestrator/test_simulationmanager.py
@@ -9,6 +9,69 @@ import xarray as xr
 from sedtrails.simulation_orchestrator.simulation_manager import Simulation
 
 
+class TestSimulationManagerTimeConfig:
+    """Tests for simulation-time construction from configuration."""
+
+    def test_simulation_time_uses_input_model_reference_date(self):
+        """SFINCS-style date-only reference dates should align timer seconds with SedTRAILS times."""
+
+        class Controller:
+            values = {
+                'time.start': '2024-05-01 00:00:00',
+                'time.duration': '5M',
+                'time.timestep': '60S',
+                'inputs.read_interval': '30M',
+                'general.input_model.reference_date': '2024-05-01',
+            }
+
+            def get(self, key, default=None):
+                return self.values.get(key, default)
+
+        manager = object.__new__(Simulation)
+        manager._controller = Controller()
+
+        simulation_time = manager._create_simulation_time()
+
+        assert simulation_time.reference_date == '2024-05-01'
+        assert simulation_time.start == 0
+
+    @pytest.mark.parametrize('current_time', [0.0, 6011.0, 7200.0])
+    def test_loaded_chunk_is_reused_through_final_interpolation_interval(self, current_time):
+        """A loaded chunk remains valid until current time moves beyond its last timestamp."""
+
+        class SedtrailsData:
+            times = np.array([0.0, 1200.0, 2400.0, 3600.0, 4800.0, 6000.0, 7200.0])
+
+        assert not Simulation._needs_sedtrails_reload(SedtrailsData(), current_time)
+
+    @pytest.mark.parametrize('current_time', [-1.0, 7200.1])
+    def test_loaded_chunk_reloads_outside_coverage(self, current_time):
+        """Reload only when current time is outside the loaded chunk."""
+
+        class SedtrailsData:
+            times = np.array([0.0, 1200.0, 2400.0, 3600.0, 4800.0, 6000.0, 7200.0])
+
+        assert Simulation._needs_sedtrails_reload(SedtrailsData(), current_time)
+
+    def test_input_exhaustion_detects_time_after_loaded_data(self):
+        """If reload still leaves current time beyond the loaded data, input is exhausted."""
+
+        class SedtrailsData:
+            times = np.array([4800.0, 6000.0, 7200.0])
+
+        assert Simulation._is_after_loaded_sedtrails_data(SedtrailsData(), 7200.1)
+        assert not Simulation._is_after_loaded_sedtrails_data(SedtrailsData(), 7200.0)
+
+    def test_exhausted_input_suppresses_further_reload_attempts(self):
+        """After input exhaustion, later timesteps should reuse the last loaded fields."""
+
+        class SedtrailsData:
+            times = np.array([4800.0, 6000.0, 7200.0])
+
+        assert Simulation._should_attempt_sedtrails_reload(SedtrailsData(), 7200.1, input_data_exhausted=False)
+        assert not Simulation._should_attempt_sedtrails_reload(SedtrailsData(), 7200.1, input_data_exhausted=True)
+
+
 class TestSimulationManagerExpandTimeDimension:
     """Tests for the _expand_time_dimension method."""
 
@@ -205,6 +268,24 @@ class TestSimulationManagerExpandTimeDimension:
 
 
 class TestSimulationDashboardThrottle:
+    def test_dashboard_update_interval_uses_visualization_config(self):
+        class Controller:
+            def get(self, key, default=None):
+                if key == 'visualization.dashboard.update_interval':
+                    return '30S'
+                return default
+
+        manager = object.__new__(Simulation)
+        manager._controller = Controller()
+
+        assert manager._dashboard_update_interval_seconds() == 30
+
+    def test_dashboard_update_interval_defaults_to_one_hour(self):
+        manager = object.__new__(Simulation)
+        manager._controller = type('Controller', (), {'get': lambda self, key, default=None: default})()
+
+        assert manager._dashboard_update_interval_seconds() == 3600
+
     def test_large_grid_dashboard_updates_are_throttled(self):
         manager = object.__new__(Simulation)
         manager.dashboard = object()

--- a/tests/simulation_orchestrator/test_simulationmanager.py
+++ b/tests/simulation_orchestrator/test_simulationmanager.py
@@ -286,6 +286,23 @@ class TestSimulationDashboardThrottle:
 
         assert manager._dashboard_update_interval_seconds() == 3600
 
+    def test_dashboard_particle_data_uses_arrays_not_single_element_lists(self):
+        class Population:
+            particles = {
+                'x': np.array([1.0, 2.0]),
+                'y': np.array([3.0, 4.0]),
+                'burial_depth': np.array([0.1, 0.2]),
+            }
+
+        particle_data = Simulation._dashboard_particle_data(Population())
+
+        assert isinstance(particle_data['burial_depth'], np.ndarray)
+        assert isinstance(particle_data['mixing_depth'], np.ndarray)
+        assert not isinstance(particle_data['burial_depth'], list)
+        assert not isinstance(particle_data['mixing_depth'], list)
+        np.testing.assert_array_equal(particle_data['burial_depth'], np.array([0.1, 0.2]))
+        np.testing.assert_array_equal(particle_data['mixing_depth'], np.array([np.nan, np.nan]))
+
     def test_large_grid_dashboard_updates_are_throttled(self):
         manager = object.__new__(Simulation)
         manager.dashboard = object()

--- a/tests/transport_converter/plugins/test_physics_plugin.py
+++ b/tests/transport_converter/plugins/test_physics_plugin.py
@@ -1,11 +1,19 @@
-import os
 import importlib.util
 import inspect
+import os
+from pathlib import Path
+
 import pytest
+
 from sedtrails.transport_converter.plugins.physics.plugin import BasePhysicsPlugin
 
-PLUGIN_DIR = os.path.dirname(__file__).replace(
-    'tests/transport_converter/plugins', 'src/sedtrails/transport_converter/plugins/physics'
+PLUGIN_DIR = (
+    Path(__file__).resolve().parents[3]  # avoid windows recursion error
+    / 'src'
+    / 'sedtrails'
+    / 'transport_converter'
+    / 'plugins'
+    / 'physics'
 )
 
 
@@ -19,8 +27,10 @@ def get_plugin_classes():
     """
     plugin_classes = []
     for fname in os.listdir(PLUGIN_DIR):
+        if fname.startswith('test_'):
+            continue
         if fname.endswith('.py') and fname != 'plugin.py' and not fname.startswith('__'):
-            module_path = os.path.join(PLUGIN_DIR, fname)
+            module_path = PLUGIN_DIR / fname
             module_name = f'sedtrails.transport_converter.plugins.physics.{fname[:-3]}'
             spec = importlib.util.spec_from_file_location(module_name, module_path)
             module = importlib.util.module_from_spec(spec)

--- a/tests/transport_converter/test_physics_lib.py
+++ b/tests/transport_converter/test_physics_lib.py
@@ -6,7 +6,7 @@ implemented in sedtrails.transport_converter.physics_lib. The tests validate:
 
 1. **Grain Properties**: Dimensionless grain size, critical Shields parameter, settling velocity
 2. **Flow Dynamics**: Shear velocity, Shields parameter calculations
-3. **Transport Mechanisms**: Bed load and suspended load velocities  
+3. **Transport Mechanisms**: Bed load and suspended load velocities
 4. **Layer Calculations**: Transport and mixing layer thicknesses
 5. **Vector Operations**: Direction computations from transport magnitudes
 
@@ -23,48 +23,49 @@ The functions implement standard sediment transport theory including Shields ana
 Soulsby formulations, and empirical relationships for particle settling and transport.
 """
 
-import pytest
 import numpy as np
+import pytest
 from numpy.testing import assert_allclose
+
 from sedtrails.transport_converter.physics_lib import (
+    MixingLayerMethod,
+    SuspendedVelocityMethod,
+    compute_bed_load_velocity,
+    compute_directions_from_magnitude,
+    compute_grain_properties,
+    compute_mixing_layer_thickness,
     compute_shear_velocity,
     compute_shields,
-    compute_bed_load_velocity,
-    compute_transport_layer_thickness,
     compute_suspended_velocity,
-    compute_directions_from_magnitude,
-    compute_mixing_layer_thickness,
-    compute_grain_properties,
-    SuspendedVelocityMethod,
-    MixingLayerMethod,
+    compute_transport_layer_thickness,
 )
 
 
 class TestComputeGrainProperties:
     """Test the compute_grain_properties function with known examples.
-    
+
     This class validates the fundamental grain property calculations that form the basis
     of all sediment transport computations. Key properties tested:
-    
+
     - **Dimensionless grain size (D*)**: Combines particle diameter with fluid properties
       Formula: D* = d * (g*(ρs/ρw - 1)/ν²)^(1/3)
-    - **Critical Shields parameter (θcr)**: Threshold for particle motion initiation  
+    - **Critical Shields parameter (θcr)**: Threshold for particle motion initiation
     - **Settling velocity (ws)**: Terminal fall velocity in quiescent fluid
     - **Critical shear stress (τcr)**: Minimum stress needed for sediment motion
-    
+
     These properties depend on grain size, density contrast, and fluid viscosity.
     Tests verify both individual calculations and physically reasonable ranges.
     """
-    
+
     @pytest.fixture
     def grain_parameters(self):
         """Standard grain parameters for testing.
-        
+
         These parameters represent typical marine sediment conditions:
         - Grain size: 200 μm (fine to medium sand, common in coastal environments)
         - Sediment: Quartz density (most common marine sediment mineral)
         - Fluid: Cold seawater properties (representative of many coastal areas)
-        
+
         This combination yields dimensionless grain size D* ≈ 5-6, which is in the
         intermediate regime where both viscous and inertial forces are important.
         """
@@ -75,74 +76,69 @@ class TestComputeGrainProperties:
             'water_density': 1027.0,  # kg/m³ (seawater density)
             'kinematic_viscosity': 1.36e-6,  # m²/s (seawater at 10°C)
         }
-    
+
     def test_settling_velocity_known_value(self, grain_parameters):
         """Test settling velocity calculation with known input/output values.
-        
+
         This test validates the settling velocity calculation against a known reference value.
         The settling velocity represents the terminal fall speed of a particle in quiescent
         fluid, balancing gravitational and drag forces.
-        
+
         For 200 μm quartz in cold seawater, the expected settling velocity is ~0.0202 m/s,
         calculated using Soulsby (1997, p. 136) formulations that account for particle Reynolds number
         effects across viscous, intermediate, and inertial flow regimes.
-        
+
         The 1% tolerance accounts for numerical precision in iterative solutions.
         """
         result = compute_grain_properties(**grain_parameters)
-        
+
         # Expected settling velocity for these parameters should be approximately 0.0202 m/s
         # This value comes from Soulsby (1997, p. 136) empirical formulation for natural sediments
         expected_settling_velocity = 0.0202
-        
+
         assert_allclose(
             result['settling_velocity'],
             expected_settling_velocity,
             rtol=0.01,  # 1% relative tolerance for numerical precision
-            err_msg=f"Expected settling velocity ~{expected_settling_velocity}, got {result['settling_velocity']}"
+            err_msg=f'Expected settling velocity ~{expected_settling_velocity}, got {result["settling_velocity"]}',
         )
-    
+
     def test_all_properties_returned(self, grain_parameters):
         """Test that all expected properties are returned."""
         result = compute_grain_properties(**grain_parameters)
-        
-        expected_keys = {
-            'dimensionless_grain_size',
-            'critical_shields',
-            'settling_velocity', 
-            'critical_shear_stress'
-        }
-        
+
+        expected_keys = {'dimensionless_grain_size', 'critical_shields', 'settling_velocity', 'critical_shear_stress'}
+
         assert set(result.keys()) == expected_keys
-        
+
         # All values should be positive and finite
         for key, value in result.items():
-            assert np.isfinite(value), f"{key} should be finite, got {value}"
-            assert value > 0, f"{key} should be positive, got {value}"
-    
+            assert np.isfinite(value), f'{key} should be finite, got {value}'
+            assert value > 0, f'{key} should be positive, got {value}'
+
     def test_dimensionless_grain_size_formula(self, grain_parameters):
         """Test dimensionless grain size calculation.
-        
+
         The dimensionless grain size D* is a fundamental parameter in sediment transport
         that characterizes the relative importance of gravitational vs viscous forces:
-        
+
         D* = d * (g*(ρs/ρw - 1)/ν²)^(1/3)
-        
+
         Where:
         - d = grain diameter
-        - g = gravitational acceleration  
+        - g = gravitational acceleration
         - ρs, ρw = sediment and water densities
         - ν = kinematic viscosity
-        
+
         D* values indicate flow regime:
         - D* < 1: Viscous regime (Stokes law)
         - 1 < D* < 40: Intermediate regime (empirical formulas)
         - D* > 40: Inertial regime (Newton's law)
-        
+
         This test verifies the mathematical implementation matches the theoretical formula.
         """
         result = compute_grain_properties(**grain_parameters)
-        
+
         # Manual calculation: D* = ((g*(ρs/ρw - 1)/ν²)^(1/3)) * d
         # This formula combines particle and fluid properties into a single dimensionless parameter
         g = grain_parameters['gravity']
@@ -150,102 +146,102 @@ class TestComputeGrainProperties:
         rho_w = grain_parameters['water_density']
         nu = grain_parameters['kinematic_viscosity']
         d = grain_parameters['grain_diameter']
-        
+
         # The (1/3) exponent comes from dimensional analysis balancing length scales
-        expected_dstar = ((g * (rho_s/rho_w - 1) / nu**2) ** (1/3)) * d
-        
+        expected_dstar = ((g * (rho_s / rho_w - 1) / nu**2) ** (1 / 3)) * d
+
         assert_allclose(
             result['dimensionless_grain_size'],
             expected_dstar,
             rtol=1e-10,  # Very tight tolerance since this is pure arithmetic
-            err_msg="Dimensionless grain size calculation error"
+            err_msg='Dimensionless grain size calculation error',
         )
-    
+
     def test_critical_shields_range(self, grain_parameters):
         """Test that critical Shields number is in reasonable range."""
         result = compute_grain_properties(**grain_parameters)
-        
+
         # Critical Shields should be between 0.03 and 0.06 for typical sand
         assert 0.02 <= result['critical_shields'] <= 0.1, (
-            f"Critical Shields {result['critical_shields']} outside expected range [0.02, 0.1]"
+            f'Critical Shields {result["critical_shields"]} outside expected range [0.02, 0.1]'
         )
-    
+
     def test_settling_velocity_range(self, grain_parameters):
         """Test that settling velocity is in reasonable range for medium sand."""
         result = compute_grain_properties(**grain_parameters)
-        
+
         # For 250 micron sand, settling velocity should be around 0.02 m/s
         assert 0.01 <= result['settling_velocity'] <= 0.05, (
-            f"Settling velocity {result['settling_velocity']} outside expected range [0.01, 0.05] m/s"
+            f'Settling velocity {result["settling_velocity"]} outside expected range [0.01, 0.05] m/s'
         )
 
 
 class TestComputeShearVelocity:
     """Test the compute_shear_velocity function.
-    
+
     Shear velocity (u*) is a fundamental velocity scale in boundary layer flows:
     u* = sqrt(τ/ρ)
-    
+
     Where τ is bed shear stress and ρ is fluid density. Despite its name, u* is not
     actually a velocity but rather a velocity scale that characterizes the intensity
     of turbulent mixing near the bed.
-    
+
     Physical significance:
     - Controls vertical mixing in boundary layers
-    - Determines sediment transport rates  
+    - Determines sediment transport rates
     - Sets length and time scales for near-bed processes
     - Appears in logarithmic velocity profiles
-    
+
     Tests validate the simple but critical square root relationship.
     """
-    
+
     def test_single_value(self):
         """Test with a single value.
-        
+
         This test verifies the basic shear velocity formula: u* = sqrt(τ/ρ)
         Using simple round numbers (τ = 1.0 N/m², ρ = 1000 kg/m³) makes the
         calculation transparent and easy to verify manually.
-        
+
         The result (~0.0316 m/s) represents moderate turbulent conditions
         typical of coastal flows during moderate wave/current activity.
         """
         bed_shear_stress = np.array([1.0])  # N/m² - moderate shear stress
         water_density = 1000.0  # kg/m³ - fresh water density
-        
+
         result = compute_shear_velocity(bed_shear_stress, water_density)
         expected = np.sqrt(1.0 / 1000.0)  # sqrt(τ/ρ) = 0.0316 m/s
-        
+
         assert_allclose(result[0], expected)
-    
+
     def test_array_input(self):
         """Test with array input."""
         bed_shear_stress = np.array([0.5, 1.0, 2.0])
         water_density = 1025.0
-        
+
         result = compute_shear_velocity(bed_shear_stress, water_density)
         expected = np.sqrt(bed_shear_stress / water_density)
-        
+
         assert_allclose(result, expected)
-    
+
     def test_negative_shear_stress(self):
         """Test handling of negative shear stress (should use absolute value).
-        
+
         In numerical models, shear stress can sometimes be computed as negative
         due to coordinate conventions or numerical artifacts. However, shear velocity
         represents the magnitude of turbulent intensity and must always be positive.
-        
+
         The function should take the absolute value of shear stress before computing
         the square root. This ensures physical consistency while being robust to
         sign conventions in different numerical implementations.
         """
         bed_shear_stress = np.array([-1.0])  # Negative stress (coordinate convention artifact)
         water_density = 1000.0
-        
+
         result = compute_shear_velocity(bed_shear_stress, water_density)
         expected = np.sqrt(1.0 / 1000.0)  # Should be same as positive value
-        
+
         assert_allclose(result[0], expected)
-    
+
     def test_zero_shear_stress(self):
         """Test with zero shear stress."""
         result = compute_shear_velocity(np.array([0.0]), 1000.0)
@@ -254,27 +250,27 @@ class TestComputeShearVelocity:
 
 class TestComputeShields:
     """Test the compute_shields function.
-    
+
     The Shields parameter (θ) is the fundamental dimensionless parameter for
     sediment transport, representing the ratio of destabilizing (flow) to
     stabilizing (gravitational) forces acting on bed particles:
-    
+
     θ = τ / (g*(ρs - ρw)*d)
-    
+
     Where:
     - τ = bed shear stress
     - g = gravitational acceleration
-    - ρs, ρw = sediment and water densities  
+    - ρs, ρw = sediment and water densities
     - d = grain diameter
-    
+
     Physical interpretation:
     - θ < θcr: No sediment motion (stable bed)
     - θ ≈ θcr: Incipient motion (threshold conditions)
     - θ > θcr: Active transport (increasing with θ)
-    
+
     The critical Shields parameter θcr ≈ 0.03-0.06 for most natural sediments.
     """
-    
+
     @pytest.fixture
     def shields_params(self):
         """Standard parameters for Shields calculation."""
@@ -284,43 +280,43 @@ class TestComputeShields:
             'water_density': 1025.0,
             'grain_diameter': 250e-6,
         }
-    
+
     def test_formula_implementation(self, shields_params):
         """Test that the Shields formula is correctly implemented.
-        
+
         This test verifies the mathematical implementation of the Shields parameter
         formula by comparing against manual calculation. The denominator represents
         the immersed weight per unit area of a grain:
-        
+
         g*(ρs - ρw)*d = specific weight difference × grain diameter
-        
+
         This creates the proper force balance:
         - Numerator (τ): Hydrodynamic force trying to move the particle
         - Denominator: Gravitational force (reduced by buoyancy) resisting motion
-        
+
         The result is dimensionless, allowing universal comparison across different
         sediment types and flow conditions.
         """
         bed_shear_stress = np.array([1.0])  # N/m² - applied hydrodynamic stress
-        
+
         result = compute_shields(bed_shear_stress, **shields_params)
-        
+
         # Manual calculation: θ = τ / (g(ρs - ρw)d)
         # Denominator is the immersed weight per unit area of a grain layer
         expected = bed_shear_stress[0] / (
-            shields_params['gravity'] * 
-            (shields_params['sediment_density'] - shields_params['water_density']) *
-            shields_params['grain_diameter']
+            shields_params['gravity']
+            * (shields_params['sediment_density'] - shields_params['water_density'])
+            * shields_params['grain_diameter']
         )
-        
+
         assert_allclose(result[0], expected)
-    
+
     def test_array_input(self, shields_params):
         """Test with array input."""
         bed_shear_stress = np.array([0.5, 1.0, 2.0])
-        
+
         result = compute_shields(bed_shear_stress, **shields_params)
-        
+
         assert isinstance(result, np.ndarray)
         assert result.shape == bed_shear_stress.shape
         assert np.all(result >= 0)
@@ -328,170 +324,166 @@ class TestComputeShields:
 
 class TestComputeBedLoadVelocity:
     """Test the compute_bed_load_velocity function.
-    
+
     Bed load transport occurs when particles roll, slide, and hop along the bed
     while maintaining frequent contact. The bed load velocity represents the
     average speed of this near-bed particle motion.
-    
+
     Key physics:
     - Only occurs above critical Shields parameter (θ > θcr)
     - Velocity increases with excess shear stress above threshold
     - Proportional to shear velocity with empirical corrections
     - Much slower than flow velocity due to particle-bed interactions
-    
+
     The implemented formula follows Soulsby (1997):
     U_bed = 10 * u* * (1 - 0.7 * sqrt(θcr / θ))
-    
+
     Where the factor 10 and correction term are empirically determined (see Fredsoe & Deigaard, 1992, eq 7.51).
     """
-    
+
     def test_above_critical_conditions(self):
         """Test bed load velocity above critical conditions."""
         shields_number = np.array([0.1])
         critical_shields = 0.05
         mean_shear_velocity = np.array([0.01])
-        
+
         result = compute_bed_load_velocity(shields_number, critical_shields, mean_shear_velocity)
-        
+
         # Should return positive velocity
         assert result[0] > 0
         assert np.isfinite(result[0])
-    
+
     def test_below_critical_conditions(self):
         """Test bed load velocity below critical conditions."""
         shields_number = np.array([0.03])
         critical_shields = 0.05
         mean_shear_velocity = np.array([0.01])
-        
+
         result = compute_bed_load_velocity(shields_number, critical_shields, mean_shear_velocity)
-        
+
         # Should return zero velocity
         assert result[0] == 0.0
-    
+
     def test_formula_implementation(self):
         """Test the bed load velocity formula implementation.
-        
+
         This test verifies the Soulsby (1997) empirical formula for bed load velocity:
         U_bed = 10 * u* * (1 - 0.7 * sqrt(θcr / θ))
-        
+
         Formula components:
         - Factor "10": Empirical coefficient relating particle to shear velocity
         - Correction term: Accounts for threshold effects (approaches 0 as θ → θcr)
         - u*: Provides velocity scale proportional to flow intensity
-        
+
         Physical interpretation:
         - At threshold (θ = θcr): correction = 1 - 0.7 = 0.3, giving U_bed = 3*u*
         - For strong flows (θ >> θcr): correction → 1, giving U_bed → 10*u*
-        
+
         The square root dependency reflects the nonlinear response to excess stress.
         """
-        shields_number = np.array([0.1])      # Well above critical (strong transport)
-        critical_shields = 0.05               # Typical critical value for sand
-        mean_shear_velocity = np.array([0.02]) # Moderate shear velocity (m/s)
-        
+        shields_number = np.array([0.1])  # Well above critical (strong transport)
+        critical_shields = 0.05  # Typical critical value for sand
+        mean_shear_velocity = np.array([0.02])  # Moderate shear velocity (m/s)
+
         result = compute_bed_load_velocity(shields_number, critical_shields, mean_shear_velocity)
-        
+
         # Manual calculation: U_bed = 10 * u*_mean * (1 - 0.7 * sqrt(θ_cr / θ_max))
         # The correction factor accounts for threshold effects in particle motion
         expected = 10.0 * mean_shear_velocity[0] * (1 - 0.7 * np.sqrt(critical_shields / shields_number[0]))
-        
+
         assert_allclose(result[0], expected)
 
 
 class TestComputeTransportLayerThickness:
     """Test the compute_transport_layer_thickness function.
-    
+
     The transport layer thickness represents the vertical extent of the active
     sediment layer where particles are being transported. This is computed from
     mass conservation principles:
-    
+
     Mass flux = Volume flux × Bulk density
     Q_mass = Q_vol × ρs × (1 - n)
-    
+
     Where:
     - Q_mass = sediment mass flux (kg/m/s)
     - Q_vol = sediment volume flux (m²/s)
     - ρs = sediment grain density
     - n = porosity (void fraction)
-    
+
     The layer thickness is then: d = Q_vol / U = Q_mass / (U × ρs × (1-n))
-    
+
     This thickness is used in advection-diffusion models to represent the
     vertical scale of active sediment transport processes.
     """
-    
+
     def test_nonzero_velocity(self):
         """Test with non-zero velocity.
-        
+
         This test validates the mass conservation calculation for transport layer thickness.
         The calculation converts mass flux to volume flux by dividing by bulk density:
-        
+
         Steps:
         1. Convert mass flux (kg/m/s) to volume flux (m²/s) using bulk density
         2. Bulk density = ρs × (1-n) accounts for grain density and packing
         3. Layer thickness = volume flux / velocity (continuity equation)
-        
+
         Physical interpretation:
         - Higher transport rate → thicker active layer
         - Higher velocity → thinner layer (same mass spread over less thickness)
         - Higher density/lower porosity → thinner layer (more compact packing)
-        
+
         Typical values: thickness ~mm to cm for natural sediment transport.
         """
         transport_magnitude = np.array([1.0])  # kg/m/s - mass flux per unit width
-        velocity_magnitude = np.array([0.5])   # m/s - particle transport velocity
-        sediment_density = 2650.0              # kg/m³ - quartz grain density
-        porosity = 0.4                         # 40% void space (typical for sand)
-        
-        result = compute_transport_layer_thickness(
-            transport_magnitude, velocity_magnitude, sediment_density, porosity
-        )
-        
+        velocity_magnitude = np.array([0.5])  # m/s - particle transport velocity
+        sediment_density = 2650.0  # kg/m³ - quartz grain density
+        porosity = 0.4  # 40% void space (typical for sand)
+
+        result = compute_transport_layer_thickness(transport_magnitude, velocity_magnitude, sediment_density, porosity)
+
         # Manual calculation: d_layer = (Q_volume) / U_layer
         # Convert mass flux to volume flux: Q_volume = Q_mass / (ρ_s * (1 - n))
         # Bulk density ρ_bulk = ρ_s * (1-n) accounts for particle packing
         transport_flux = transport_magnitude[0] / (sediment_density * (1 - porosity))
         expected = transport_flux / velocity_magnitude[0]  # Continuity: thickness = flux/velocity
-        
+
         assert_allclose(result[0], expected)
-    
+
     def test_zero_velocity(self):
         """Test with zero velocity."""
         transport_magnitude = np.array([1.0])
         velocity_magnitude = np.array([0.0])
         sediment_density = 2650.0
         porosity = 0.4
-        
-        result = compute_transport_layer_thickness(
-            transport_magnitude, velocity_magnitude, sediment_density, porosity
-        )
-        
+
+        result = compute_transport_layer_thickness(transport_magnitude, velocity_magnitude, sediment_density, porosity)
+
         assert result[0] == 0.0
 
 
 class TestComputeSuspendedVelocity:
     """Test the compute_suspended_velocity function.
-    
+
     Suspended sediment transport occurs when particles are lifted into the water
     column by turbulent mixing and advected by the flow. Key physics:
-    
+
     **Suspension mechanism**:
     - Turbulent eddies lift particles against gravity
     - Balance between upward turbulent mixing and downward settling
     - Requires shear velocity u* > settling velocity ws for strong suspension
-    
+
     **Velocity calculation**:
     - Suspended particles move at ~flow velocity (high coupling)
     - Corrections for settling lag and concentration profiles
     - Method-dependent formulations (Soulsby 2011, etc.)
-    
+
     **Critical conditions**:
     - Below threshold: no suspension (ws dominates)
     - Above threshold: velocity ≈ flow velocity with empirical corrections
-    
+
     Tests validate method implementations and threshold behavior.
     """
-    
+
     @pytest.fixture
     def suspended_params(self):
         """Standard parameters for suspended velocity calculation."""
@@ -505,187 +497,185 @@ class TestComputeSuspendedVelocity:
             'critical_shields': 0.05,
             'method': SuspendedVelocityMethod.SOULSBY_2011,
         }
-    
+
     def test_above_critical_conditions(self, suspended_params):
         """Test suspended velocity above critical conditions."""
         result = compute_suspended_velocity(**suspended_params)
-        
+
         # Should return positive velocity
         assert result[0] > 0
         assert np.isfinite(result[0])
-    
+
     def test_below_critical_conditions(self, suspended_params):
         """Test suspended velocity below critical conditions."""
         suspended_params['shields_number'] = np.array([0.03])  # Below critical
-        
+
         result = compute_suspended_velocity(**suspended_params)
-        
+
         # Should return zero velocity
         assert result[0] == 0.0
-    
+
     def test_invalid_method(self, suspended_params):
         """Test error handling for invalid method."""
         suspended_params['method'] = 'invalid_method'
-        
-        with pytest.raises(ValueError, match="Unknown suspended velocity method"):
+
+        with pytest.raises(ValueError, match='Unknown suspended velocity method'):
             compute_suspended_velocity(**suspended_params)
 
 
 class TestComputeDirectionsFromMagnitude:
     """Test the compute_directions_from_magnitude function.
-    
+
     This function performs vector operations to compute velocity components from
     transport information. The key concept is directional scaling:
-    
+
     **Vector relationship**:
     - Transport vector: T = (Tx, Ty) with magnitude |T|
     - Unit direction: û = T/|T| = (Tx/|T|, Ty/|T|)
     - Velocity vector: V = |V| * û = |V| * (Tx/|T|, Ty/|T|)
-    
+
     **Physical interpretation**:
     - Assumes velocity direction follows transport direction
     - Scales velocity magnitude by transport direction ratios
     - Handles zero transport (no preferred direction) → zero velocity
-    
+
     **Applications**:
     - Converting scalar velocity magnitudes to vector fields
     - Maintaining consistent directional relationships in transport models
     """
-    
+
     def test_direction_calculation(self):
         """Test direction calculation from magnitude and transport components.
-        
+
         This test uses a classic 3-4-5 right triangle to verify vector scaling:
         - Transport vector: (3, 4) with magnitude 5
         - Unit direction vector: (3/5, 4/5) = (0.6, 0.8)
         - Velocity magnitude: 2.0
         - Expected velocity: 2.0 * (0.6, 0.8) = (1.2, 1.6)
-        
+
         The calculation preserves the transport direction while scaling to the
         specified velocity magnitude. This is equivalent to:
         V = |V| * (T/|T|) = |V| * unit_direction_vector
-        
+
         Verification: |V_result| = sqrt(1.2² + 1.6²) = 2.0 ✓
         """
-        velocity_magnitude = np.array([2.0])   # Desired velocity magnitude
-        transport_x = np.array([3.0])          # Transport x-component  
-        transport_y = np.array([4.0])          # Transport y-component
+        velocity_magnitude = np.array([2.0])  # Desired velocity magnitude
+        transport_x = np.array([3.0])  # Transport x-component
+        transport_y = np.array([4.0])  # Transport y-component
         transport_magnitude = np.array([5.0])  # |T| = sqrt(3² + 4²) = 5
-        
+
         velocity_x, velocity_y = compute_directions_from_magnitude(
             velocity_magnitude, transport_x, transport_y, transport_magnitude
         )
-        
+
         # Expected: V = |V| * (T/|T|) - vector scaling by unit direction
         expected_x = velocity_magnitude[0] * (transport_x[0] / transport_magnitude[0])  # 2.0 * (3/5) = 1.2
         expected_y = velocity_magnitude[0] * (transport_y[0] / transport_magnitude[0])  # 2.0 * (4/5) = 1.6
-        
+
         assert_allclose(velocity_x[0], expected_x)
         assert_allclose(velocity_y[0], expected_y)
-    
+
     def test_zero_transport_magnitude(self):
         """Test with zero transport magnitude."""
         velocity_magnitude = np.array([2.0])
         transport_x = np.array([0.0])
         transport_y = np.array([0.0])
         transport_magnitude = np.array([0.0])
-        
+
         velocity_x, velocity_y = compute_directions_from_magnitude(
             velocity_magnitude, transport_x, transport_y, transport_magnitude
         )
-        
+
         assert velocity_x[0] == 0.0
         assert velocity_y[0] == 0.0
-    
+
     def test_magnitude_consistency(self):
         """Test that computed velocity components have correct magnitude."""
         velocity_magnitude = np.array([1.0])
         transport_x = np.array([0.6])
         transport_y = np.array([0.8])
         transport_magnitude = np.array([1.0])  # Unit vector
-        
+
         velocity_x, velocity_y = compute_directions_from_magnitude(
             velocity_magnitude, transport_x, transport_y, transport_magnitude
         )
-        
-        computed_magnitude = np.sqrt(velocity_x[0]**2 + velocity_y[0]**2)
+
+        computed_magnitude = np.sqrt(velocity_x[0] ** 2 + velocity_y[0] ** 2)
         assert_allclose(computed_magnitude, velocity_magnitude[0])
 
 
 class TestComputeMixingLayerThickness:
     """Test the compute_mixing_layer_thickness function.
-    
+
     The mixing layer represents the vertical extent of active sediment-water mixing
     near the bed. This layer controls:
-    
+
     **Physical processes**:
     - Vertical diffusion of suspended sediment
     - Exchange between bed and water column
     - Concentration profile development
     - Particle residence times
-    
+
     **Bertin (2008) formulation**:
     d_mix = 0.041 * sqrt(max(τ_max - τ_cr, 0))
-    
+
     Where:
     - Coefficient 0.041 is empirically determined
     - Square root dependency reflects turbulent scaling
     - Only excess stress above critical threshold contributes
     - Units: meters (typical range: mm to cm)
-    
+
     **Applications**:
     - Boundary conditions for suspension models
     - Scaling vertical diffusion coefficients
     - Estimating near-bed concentration gradients
     """
-    
+
     def test_bertin_method(self):
         """Test Bertin (2008) method.
-        
+
         The Bertin (2008) formulation relates mixing layer thickness to excess
         shear stress above the critical threshold:
-        
+
         d_mix = 0.041 * sqrt(τ_max - τ_cr)
-        
+
         **Physical basis**:
         - Only excess stress above critical contributes to mixing
         - Square root scaling follows turbulent boundary layer theory
         - Coefficient 0.041 m/(N/m²)^0.5 from field measurements
-        
+
         **Example calculation**:
         - τ_max = 2.0 N/m² (strong flow conditions)
         - τ_cr = 1.0 N/m² (critical threshold)
         - Excess stress = 1.0 N/m²
         - Expected thickness = 0.041 * sqrt(1.0) = 0.041 m = 4.1 cm
-        
+
         This represents a substantial mixing layer typical of energetic coastal flows.
         """
         max_bed_shear_stress = np.array([2.0])  # N/m² - strong flow conditions
-        critical_shear_stress = 1.0             # N/m² - sediment motion threshold
-        
+        critical_shear_stress = 1.0  # N/m² - sediment motion threshold
+
         result = compute_mixing_layer_thickness(
-            max_bed_shear_stress, 
-            critical_shear_stress,
-            method=MixingLayerMethod.BERTIN_2008
+            max_bed_shear_stress, critical_shear_stress, method=MixingLayerMethod.BERTIN_2008
         )
-        
+
         # Manual calculation: d_mix = 0.041 * sqrt(max(τ_max - τ_cr, 0))
         # Only excess stress above threshold contributes to mixing layer development
         expected = 0.041 * np.sqrt(max_bed_shear_stress[0] - critical_shear_stress)
-        
+
         assert_allclose(result[0], expected)
-    
+
     def test_bertin_method_digitized_values(self):
         """Test Bertin (2008) method against digitized values from Figure 3.
-        
+
         This test validates the Bertin (2008) formulation using data points
         digitized from Figure 3 in the original paper. The figure shows the
         relationship between excess shear stress and mixing layer thickness
         for various field conditions.
-        
+
         **Data source**: Bertin et al. (2008), Figure 3
         **Formula**: d_mix = 0.041 * sqrt(τ_max - τ_cr)
-        
+
         The test uses representative data points that span the range of
         conditions presented in the paper, from moderate to high energy
         coastal environments.
@@ -693,131 +683,125 @@ class TestComputeMixingLayerThickness:
         # Critical shear stress (assumed constant for this test)
         # based on 200 um sand in seawater
         # (Bertin et al. (2008) use 0.18-0.22 mm sand)
-        critical_shear_stress = 0.176   # N/m² - 
-        
+        critical_shear_stress = 0.176  # N/m² -
+
         # Digitized data pairs from Bertin et al. (2008) Figure 3
         # Format: (max_bed_shear_stress [N/m²], expected_d_mix [m])
         test_data = [
             (0.27, 0.015),
-            (0.8, 0.032), 
+            (0.8, 0.032),
             (1.65, 0.05),
         ]
-        
+
         for max_stress, expected_thickness in test_data:
             max_bed_shear_stress = np.array([max_stress])
-            
+
             result = compute_mixing_layer_thickness(
-                max_bed_shear_stress,
-                critical_shear_stress,
-                method=MixingLayerMethod.BERTIN_2008
+                max_bed_shear_stress, critical_shear_stress, method=MixingLayerMethod.BERTIN_2008
             )
-            
+
             # Test against digitized values with reasonable tolerance
             # Allow for digitization uncertainty and model assumptions
             assert_allclose(
-                result[0], 
+                result[0],
                 expected_thickness,
                 rtol=0.20,  # 20% relative tolerance for digitization uncertainty
-                err_msg=f"Failed for τ_max={max_stress} N/m², expected d_mix≈{expected_thickness} m"
+                err_msg=f'Failed for τ_max={max_stress} N/m², expected d_mix≈{expected_thickness} m',
             )
-    
+
     def test_below_critical_stress(self):
         """Test with shear stress below critical value."""
         max_bed_shear_stress = np.array([0.5])
         critical_shear_stress = 1.0
-        
+
         result = compute_mixing_layer_thickness(
-            max_bed_shear_stress, 
-            critical_shear_stress,
-            method=MixingLayerMethod.BERTIN_2008
+            max_bed_shear_stress, critical_shear_stress, method=MixingLayerMethod.BERTIN_2008
         )
-        
+
         assert result[0] == 0.0
-    
+
     def test_harris_wiberg_method_not_implemented(self):
         """Test that Harris-Wiberg method raises NotImplementedError."""
         max_bed_shear_stress = np.array([2.0])
         critical_shear_stress = 1.0
-        
+
         with pytest.raises(NotImplementedError):
             compute_mixing_layer_thickness(
-                max_bed_shear_stress,
-                critical_shear_stress,
-                method=MixingLayerMethod.HARRIS_WIBERG
+                max_bed_shear_stress, critical_shear_stress, method=MixingLayerMethod.HARRIS_WIBERG
             )
-    
+
     def test_invalid_method(self):
         """Test error handling for invalid method."""
         max_bed_shear_stress = np.array([2.0])
         critical_shear_stress = 1.0
-        
-        with pytest.raises(ValueError, match="Unknown mixing layer method"):
+
+        with pytest.raises(ValueError, match='Unknown mixing layer method'):
             # Use getattr to bypass type checking for invalid method
             invalid_method = getattr(MixingLayerMethod, 'INVALID', 'invalid_method')
             compute_mixing_layer_thickness(
                 max_bed_shear_stress,
                 critical_shear_stress,
-                method=invalid_method  # type: ignore
+                method=invalid_method,  # type: ignore
             )
 
 
 class TestPhysicsLibIntegration:
     """Integration tests combining multiple functions.
-    
+
     These tests validate the complete sediment transport calculation workflow,
     ensuring that individual physics functions work together correctly:
-    
+
     **Typical calculation sequence**:
     1. Grain properties → fundamental particle characteristics
-    2. Flow conditions → shear stress and velocity fields  
+    2. Flow conditions → shear stress and velocity fields
     3. Dimensionless parameters → Shields number, transport thresholds
     4. Transport rates → bed load and suspended load calculations
     5. Layer properties → transport and mixing layer thicknesses
-    
+
     **Integration validation**:
     - Consistent units and scaling across functions
     - Physical parameter ranges maintained through workflow
     - Proper threshold behavior at critical conditions
     - Sensitivity to key parameters (grain size, flow strength)
-    
+
     These tests simulate realistic sediment transport modeling scenarios.
     """
-    
+
     def test_grain_properties_to_transport_workflow(self):
         """Test a complete workflow from grain properties to transport calculations.
-        
+
         This integration test simulates a realistic sediment transport calculation
         workflow, starting from basic particle properties and building up to
         transport velocities. This mirrors the typical sequence in numerical models:
-        
+
         **Workflow steps**:
         1. **Grain characterization**: Compute D*, θcr, ws from particle properties
         2. **Flow analysis**: Convert bed stress to dimensionless parameters
         3. **Threshold assessment**: Compare θ to θcr for transport activation
         4. **Transport calculation**: Compute particle velocities if θ > θcr
-        
+
         **Physical consistency checks**:
         - All parameters remain finite and physically reasonable
         - Proper scaling relationships maintained
         - Transport only occurs above critical conditions
-        
+
         This represents conditions for 250 μm sand in moderate coastal flows.
         """
         # Step 1: Compute fundamental grain properties for medium sand
         grain_params = {
-            'grain_diameter': 250e-6,      # 250 μm - medium sand
-            'gravity': 9.81,               # Standard gravity
-            'sediment_density': 2650.0,    # Quartz density (kg/m³)
-            'water_density': 1025.0,       # Seawater density (kg/m³) 
-            'kinematic_viscosity': 1.36e-6, # Cold seawater viscosity (m²/s)
+            'grain_diameter': 250e-6,  # 250 μm - medium sand
+            'gravity': 9.81,  # Standard gravity
+            'sediment_density': 2650.0,  # Quartz density (kg/m³)
+            'water_density': 1025.0,  # Seawater density (kg/m³)
+            'kinematic_viscosity': 1.36e-6,  # Cold seawater viscosity (m²/s)
         }
-        
+
         # Calculate particle characteristics (D*, θcr, ws, τcr)
         grain_props = compute_grain_properties(**grain_params)
-        
+
         # Step 2: Apply representative flow conditions
         bed_shear_stress = np.array([1.0])  # N/m² - moderate coastal flow
-        
+
         # Step 3: Compute dimensionless flow parameters
         # Shields parameter: θ = τ/(g*(ρs-ρw)*d)
         shields = compute_shields(
@@ -825,143 +809,143 @@ class TestPhysicsLibIntegration:
             grain_params['gravity'],
             grain_params['sediment_density'],
             grain_params['water_density'],
-            grain_params['grain_diameter']
+            grain_params['grain_diameter'],
         )
-        
+
         # Shear velocity: u* = sqrt(τ/ρw)
         shear_velocity = compute_shear_velocity(bed_shear_stress, grain_params['water_density'])
-        
+
         # Step 4: Calculate transport velocities (if above threshold)
-        bed_load_vel = compute_bed_load_velocity(
-            shields,
-            grain_props['critical_shields'],
-            shear_velocity
-        )
-        
+        bed_load_vel = compute_bed_load_velocity(shields, grain_props['critical_shields'], shear_velocity)
+
         # Validate physical consistency across the workflow
-        assert np.isfinite(shields[0]), "Shields parameter should be finite"
-        assert np.isfinite(shear_velocity[0]), "Shear velocity should be finite"
-        assert np.isfinite(bed_load_vel[0]), "Bed load velocity should be finite"
-        assert shields[0] >= 0, "Shields parameter should be non-negative"
-        assert shear_velocity[0] >= 0, "Shear velocity should be non-negative"
-        assert bed_load_vel[0] >= 0, "Bed load velocity should be non-negative"
-    
+        assert np.isfinite(shields[0]), 'Shields parameter should be finite'
+        assert np.isfinite(shear_velocity[0]), 'Shear velocity should be finite'
+        assert np.isfinite(bed_load_vel[0]), 'Bed load velocity should be finite'
+        assert shields[0] >= 0, 'Shields parameter should be non-negative'
+        assert shear_velocity[0] >= 0, 'Shear velocity should be non-negative'
+        assert bed_load_vel[0] >= 0, 'Bed load velocity should be non-negative'
+
     def test_parameter_sensitivity(self):
         """Test that functions respond sensibly to parameter changes.
-        
+
         This test validates the expected physical relationships between grain size
         and transport properties. Key physics principles being tested:
-        
+
         **Settling velocity vs grain size**:
         - Larger particles fall faster due to increased gravitational force
         - Relationship is nonlinear due to changing drag regimes
         - For sand-sized particles: ws ~ d^1.5 to d^2 (empirically)
-        
+
         **Critical shear stress vs grain size**:
         - Larger particles require more force to initiate motion
         - Relationship: τcr = θcr * g * (ρs-ρw) * d
         - Since θcr varies slowly with size, τcr ≈ proportional to d
-        
+
         **Test methodology**:
         - Use 2:1 size ratio (125 μm : 250 μm : 500 μm)
         - Covers fine to coarse sand range
         - Validates monotonic relationships expected from theory
         """
         base_params = {
-            'grain_diameter': 250e-6,      # Reference: medium sand
+            'grain_diameter': 250e-6,  # Reference: medium sand
             'gravity': 9.81,
             'sediment_density': 2650.0,
             'water_density': 1025.0,
             'kinematic_viscosity': 1.36e-6,
         }
-        
+
         # Test grain size sensitivity across realistic sand size range
         fine_params = base_params.copy()
-        fine_params['grain_diameter'] = 125e-6   # Fine sand (half size)
-        
-        coarse_params = base_params.copy() 
+        fine_params['grain_diameter'] = 125e-6  # Fine sand (half size)
+
+        coarse_params = base_params.copy()
         coarse_params['grain_diameter'] = 500e-6  # Coarse sand (double size)
-        
+
         # Calculate properties for each size class
         base_props = compute_grain_properties(**base_params)
         fine_props = compute_grain_properties(**fine_params)
         coarse_props = compute_grain_properties(**coarse_params)
-        
+
         # Validate expected physical relationships
-        
+
         # Settling velocity should increase monotonically with grain size
         # Physics: larger particles have higher terminal velocity
         assert fine_props['settling_velocity'] < base_props['settling_velocity'] < coarse_props['settling_velocity']
-        
-        # Critical shear stress should increase monotonically with grain size  
+
+        # Critical shear stress should increase monotonically with grain size
         # Physics: larger particles require more force to move
-        assert fine_props['critical_shear_stress'] < base_props['critical_shear_stress'] < coarse_props['critical_shear_stress']
+        assert (
+            fine_props['critical_shear_stress']
+            < base_props['critical_shear_stress']
+            < coarse_props['critical_shear_stress']
+        )
 
 
 # Parametrized tests for edge cases
 class TestEdgeCases:
     """Test edge cases and boundary conditions.
-    
+
     Edge case testing is critical for numerical robustness in sediment transport
     models, which must handle extreme conditions that may occur in nature:
-    
+
     **Why edge cases matter**:
     - Models encounter wide parameter ranges in real applications
     - Numerical instabilities often appear at extremes
     - Physical laws must remain valid across all scales
     - Graceful degradation prevents model crashes
-    
+
     **Testing strategy**:
     - **Zero values**: Test mathematical limits and boundary behavior
-    - **Very small values**: Ensure numerical precision is maintained  
+    - **Very small values**: Ensure numerical precision is maintained
     - **Very large values**: Verify no overflow or unrealistic results
     - **Physical limits**: Test across realistic environmental ranges
-    
+
     **Parametrized approach**:
     Uses pytest.mark.parametrize to systematically test multiple values,
     ensuring comprehensive coverage without code duplication.
     """
-    
-    @pytest.mark.parametrize("shear_stress", [0.0, 1e-10, 1e10])
+
+    @pytest.mark.parametrize('shear_stress', [0.0, 1e-10, 1e10])
     def test_shear_velocity_edge_values(self, shear_stress):
         """Test shear velocity with edge values.
-        
+
         This parametrized test covers the full range of possible shear stress values:
-        
+
         - **Zero stress (0.0)**: Calm conditions, u* should be exactly 0
         - **Tiny stress (1e-10)**: Near-zero but finite, tests numerical precision
         - **Huge stress (1e10)**: Extreme conditions (hurricane/tsunami), tests overflow
-        
+
         **Physical interpretation**:
         - 1e-10 N/m²: Virtually stagnant water
         - 1e10 N/m²: Catastrophic flow conditions (u* ≈ 100 m/s)
-        
+
         **Robustness requirements**:
         - Results must always be finite (no NaN/Inf)
         - Results must be non-negative (physical constraint)
         - Square root operation must handle full range safely
         """
         result = compute_shear_velocity(np.array([shear_stress]), 1000.0)
-        assert np.isfinite(result[0]), f"Shear velocity should be finite for stress {shear_stress}"
-        assert result[0] >= 0, f"Shear velocity should be non-negative for stress {shear_stress}"
-    
-    @pytest.mark.parametrize("grain_size", [1e-6, 1e-3, 1e-2])  # 1 micron to 1 cm
+        assert np.isfinite(result[0]), f'Shear velocity should be finite for stress {shear_stress}'
+        assert result[0] >= 0, f'Shear velocity should be non-negative for stress {shear_stress}'
+
+    @pytest.mark.parametrize('grain_size', [1e-6, 1e-3, 1e-2])  # 1 micron to 1 cm
     def test_grain_properties_size_range(self, grain_size):
         """Test grain properties across realistic size range.
-        
+
         This test spans the full range of natural sediment sizes encountered
         in marine and coastal environments:
-        
+
         **Size classes tested**:
         - **1 μm (1e-6 m)**: Clay particles, cohesive sediments
         - **1 mm (1e-3 m)**: Coarse sand to fine gravel
         - **1 cm (1e-2 m)**: Gravel, shells, coarse bed material
-        
+
         **Physics across scales**:
         - Clay: Viscous forces dominate (D* < 1), slow settling
         - Sand: Intermediate regime (1 < D* < 40), complex drag
         - Gravel: Inertial forces dominate (D* > 40), fast settling
-        
+
         **Validation criteria**:
         - All properties must remain positive and finite
         - Formulations must handle different flow regimes correctly
@@ -974,49 +958,47 @@ class TestEdgeCases:
             'water_density': 1025.0,
             'kinematic_viscosity': 1.36e-6,
         }
-        
+
         result = compute_grain_properties(**params)
-        
+
         # Validate mathematical and physical constraints across all size scales
         for property_name, value in result.items():
-            assert np.isfinite(value), f"{property_name} should be finite for grain size {grain_size*1e6:.1f} μm"
-            assert value > 0, f"{property_name} should be positive for grain size {grain_size*1e6:.1f} μm"
-    
-    @pytest.mark.parametrize("velocity_mag", [0.0, 1e-6, 1.0, 10.0])
+            assert np.isfinite(value), f'{property_name} should be finite for grain size {grain_size * 1e6:.1f} μm'
+            assert value > 0, f'{property_name} should be positive for grain size {grain_size * 1e6:.1f} μm'
+
+    @pytest.mark.parametrize('velocity_mag', [0.0, 1e-6, 1.0, 10.0])
     def test_transport_layer_thickness_velocities(self, velocity_mag):
         """Test transport layer thickness with different velocities.
-        
+
         This test examines transport layer behavior across the full range of
         possible particle velocities, from stagnant to extreme conditions:
-        
+
         **Velocity scenarios**:
         - **0.0 m/s**: Stagnant conditions, thickness should be 0 (special case)
         - **1e-6 m/s**: Nearly stagnant, very thick layer (extreme case)
         - **1.0 m/s**: Typical transport velocity in energetic flows
         - **10.0 m/s**: Extreme velocity (storm/tsunami conditions)
-        
+
         **Physical expectations**:
         - Layer thickness = volume flux / velocity (continuity)
         - Higher velocity → thinner layer (same mass, faster transport)
         - Zero velocity should be handled gracefully (avoid division by zero)
-        
+
         **Robustness testing**:
         - Function should handle full velocity range without errors
         - Results must be physically meaningful (finite, non-negative)
         """
-        transport_mag = np.array([1.0])        # Fixed mass flux (kg/m/s)
+        transport_mag = np.array([1.0])  # Fixed mass flux (kg/m/s)
         velocity_magnitude = np.array([velocity_mag])
-        
-        result = compute_transport_layer_thickness(
-            transport_mag, velocity_magnitude, 2650.0, 0.4
-        )
-        
+
+        result = compute_transport_layer_thickness(transport_mag, velocity_magnitude, 2650.0, 0.4)
+
         # Validate mathematical and physical constraints
-        assert np.isfinite(result[0]), f"Layer thickness should be finite for velocity {velocity_mag} m/s"
-        assert result[0] >= 0, f"Layer thickness should be non-negative for velocity {velocity_mag} m/s"
+        assert np.isfinite(result[0]), f'Layer thickness should be finite for velocity {velocity_mag} m/s'
+        assert result[0] >= 0, f'Layer thickness should be non-negative for velocity {velocity_mag} m/s'
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     """
     Direct test execution capability.
     
@@ -1031,4 +1013,4 @@ if __name__ == "__main__":
     - Running tests without pytest discovery overhead
     """
     # Run tests when script is executed directly with verbose output
-    pytest.main([__file__, "-v"])
+    pytest.main([__file__, '-v'])

--- a/tests/transport_converter/test_sedtrails_data.py
+++ b/tests/transport_converter/test_sedtrails_data.py
@@ -1,0 +1,65 @@
+import numpy as np
+import pytest
+
+from sedtrails.transport_converter.sedtrails_data import SedtrailsData
+from sedtrails.transport_converter.sedtrails_metadata import SedtrailsMetadata
+
+
+def _build_sedtrails_data(x, y):
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(y, dtype=float)
+    npoints = x.size
+    ntimes = 2
+
+    zeros_time_space = np.zeros((ntimes, npoints), dtype=float)
+    zero_vector = {
+        'x': zeros_time_space.copy(),
+        'y': zeros_time_space.copy(),
+        'magnitude': zeros_time_space.copy(),
+    }
+
+    metadata = SedtrailsMetadata(
+        flowfield_domain={
+            'x_min': float(np.min(x)),
+            'x_max': float(np.max(x)),
+            'y_min': float(np.min(y)),
+            'y_max': float(np.max(y)),
+        }
+    )
+
+    return SedtrailsData(
+        times=np.array([0.0, 1.0], dtype=float),
+        reference_date=np.datetime64('1970-01-01T00:00:00'),
+        x=x,
+        y=y,
+        bed_level=np.zeros(npoints, dtype=float),
+        depth_avg_flow_velocity=zero_vector,
+        fractions=1,
+        bed_load_transport=zero_vector,
+        suspended_transport=zero_vector,
+        water_depth=zeros_time_space.copy(),
+        mean_bed_shear_stress=zeros_time_space.copy(),
+        max_bed_shear_stress=zeros_time_space.copy(),
+        sediment_concentration=zeros_time_space.copy(),
+        nonlinear_wave_velocity=zero_vector,
+        metadata=metadata,
+    )
+
+
+def test_min_resolution_ignores_duplicate_coordinates():
+    data = _build_sedtrails_data(
+        x=[0.0, 1.0, 1.0, 2.0],
+        y=[0.0, 0.0, 0.0, 0.0],
+    )
+
+    assert data.metadata.min_resolution == pytest.approx(1.0)
+
+
+def test_min_resolution_none_when_no_distinct_points():
+    data = _build_sedtrails_data(
+        x=[5.0, 5.0, 5.0],
+        y=[7.0, 7.0, 7.0],
+    )
+
+    assert data.metadata.min_resolution is None
+    assert data.metadata.outer_envelope == []

--- a/tests/transport_converter/test_sedtrails_data.py
+++ b/tests/transport_converter/test_sedtrails_data.py
@@ -6,6 +6,7 @@ from sedtrails.transport_converter.sedtrails_metadata import SedtrailsMetadata
 
 
 def _build_sedtrails_data(x, y):
+    """Builds a minimal SedtrailsData instance for metadata resolution tests."""
     x = np.asarray(x, dtype=float)
     y = np.asarray(y, dtype=float)
     npoints = x.size
@@ -27,6 +28,7 @@ def _build_sedtrails_data(x, y):
         }
     )
 
+    # Keep all dynamic fields simple/zeroed so tests isolate spatial metadata behavior.
     return SedtrailsData(
         times=np.array([0.0, 1.0], dtype=float),
         reference_date=np.datetime64('1970-01-01T00:00:00'),
@@ -47,6 +49,7 @@ def _build_sedtrails_data(x, y):
 
 
 def test_min_resolution_ignores_duplicate_coordinates():
+    """Checks min resolution uses distinct points and ignores duplicates."""
     data = _build_sedtrails_data(
         x=[0.0, 1.0, 1.0, 2.0],
         y=[0.0, 0.0, 0.0, 0.0],
@@ -56,6 +59,7 @@ def test_min_resolution_ignores_duplicate_coordinates():
 
 
 def test_min_resolution_none_when_no_distinct_points():
+    """Checks degenerate coordinates produce no resolution/envelope metadata."""
     data = _build_sedtrails_data(
         x=[5.0, 5.0, 5.0],
         y=[7.0, 7.0, 7.0],


### PR DESCRIPTION
Fixes slow interpolation on very large (>300k cells) grids. 

## Main work done:

- Added major particle-position performance work:
  - Improved Numba-backed position calculator.
  - Cached triangle/simplex lookup.
  - Local triangle-neighborhood search instead of repeated brute-force global searches.
  - Faster field interpolation paths for small particle counts on large grids.

- Reduced unnecessary physics-field reads/interpolation:
  - Cached scalar/flow field retrieval.
  - Added bounded flow-field retrieval for particle updates.
  - Avoided repeated full-grid dashboard field construction when the dashboard interval is not due.

- Fixed simulation timing/reload behavior:
  - Timer now respects input-model reference dates.
  - Reload logic now reuses the final available input fields after the simulation passes the source file’s last timestamp, with a warning.
  - Added interruption/profile logging improvements.

- Fixed data/output issues:
  - Fixed the `is_mobile` NetCDF writing bug.
  - Added tests around xarray dataset writing.

- Reworked large-grid dashboard plotting:
  - Dashboard update interval now comes from config.
  - Large grids use a cached raster/image plotter instead of expensive full-grid `tricontour*`.
  - Models now store node coordinates and face-node connectivity in `SedtrailsData` for dashboard-only visualization.
  - Particle tracking remains model/plugin agnostic.

- Added regression coverage:
  - New tests for data retrieval, Numba position calculation, timer/reference dates, dashboard throttling/rasterization, SFINCS mesh geometry, and xarray output behavior.

Closes #388 