### PR TITLE
ST-390 physics converter multifrac

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ channels:
 dependencies:
   - python=3.13
   - numpy<2.2,>=1.24
+  - scipy
   - numba
   - pandas
   - matplotlib
@@ -23,4 +24,3 @@ dependencies:
   - referencing>=0.36.2
   - pip:
     - sphinx-autodoc2>=0.5.0
-  

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,94 @@
+# Multi-Population Tracer Runtime Plan
+
+## Summary
+
+- Implement mixed population tracer methods by making physics runtime state population-scoped instead of global.
+- Support exactly one tracer method per population in this implementation; different populations may use different methods.
+- Avoid plugin field collisions by copying each population/method plan's required physics fields into a plan-local `SedtrailsData` clone immediately after conversion.
+- Archive this plan in `plan.md` before feature code changes, then execute in committed blocks on the active branch.
+
+## Key Changes
+
+- Add an internal runtime planning helper, preferably `src/sedtrails/simulation_orchestrator/runtime_plan.py`, with frozen dataclasses for:
+  - `TracerRuntimePlan`: method name, method config, flow field names, transport probability method, required physics fields, converter.
+  - `PopulationRuntimePlan`: population index/config/object plus its one tracer plan.
+- Refactor `Simulation` so it no longer stores one global `PhysicsConverter`, global `tracer_methods`, or first-population `flow_field_names`.
+- Build runtime plans after seeding, preserving population order and deriving each `PhysicsConfig` from global constants plus that population's characteristics and method config.
+- Fix `PhysicsConfig.from_dict()` so method-specific nested config is selected from the resolved `PhysicsConfig.tracer_method`, not from `getattr(config, ...)` on a possible dict.
+- Update the simulation loop:
+  - On each new input chunk, run each population plan's converter.
+  - Copy only required physics fields into a plan-local shallow `SedtrailsData` clone.
+  - Use one `FieldDataRetriever` per population plan.
+  - Compute CFL from every population plan's configured flow fields.
+  - Update each population using its own method, flow fields, mixing depth, and probability fields.
+- Preserve current movement behavior: if a method lists multiple flow fields, the population is updated once per listed flow field per timestep.
+- Preserve current method behavior:
+  - `vanwesten`: use `mixing_layer_thickness`, derived probability fields, and `update_burial_depth()`.
+  - `soulsby`: use configured `grain_velocity`, unit transport probability, and skip van Westen burial-depth update.
+- Update population schema validation to set `tracer_methods.maxProperties = 1` and require `flow_field_name` for supported method configs.
+
+## Execution Blocks And Commits
+
+- Block 0, baseline pending fixes:
+  - Commit existing SciPy dependency and Windows plugin discovery fixes.
+  - Commit message: `fix: declare scipy and harden physics plugin discovery`.
+  - Verify: `mamba run -n sedtrails python -m pytest -q tests/transport_converter/plugins/test_physics_plugin.py`.
+- Block 1, archive plan:
+  - Create `plan.md` containing this implementation plan.
+  - Commit message: `docs: archive multi-population tracer plan`.
+  - Verify: `git diff --check`.
+- Block 2, runtime planning model:
+  - Add runtime plan dataclasses and builder tests.
+  - Add validation for unknown methods, missing flow fields, and multiple methods per population.
+  - Commit message: `refactor: add population tracer runtime plan`.
+  - Verify:
+    - `mamba run -n sedtrails python -m ruff check src/sedtrails/simulation_orchestrator tests/simulation_orchestrator`
+    - `mamba run -n sedtrails python -m pytest -q tests/simulation_orchestrator`.
+- Block 3, converter/config isolation:
+  - Fix `PhysicsConfig.from_dict()`.
+  - Ensure each runtime plan owns its own `PhysicsConverter`.
+  - Add unit tests proving Soulsby and van Westen nested configs are flattened correctly and do not leak between converter instances.
+  - Commit message: `fix: isolate physics converter config per tracer method`.
+  - Verify:
+    - `mamba run -n sedtrails python -m ruff check src/sedtrails/transport_converter tests/transport_converter`
+    - `mamba run -n sedtrails python -m pytest -q tests/transport_converter`.
+- Block 4, simulation loop refactor:
+  - Replace first/last-population loop state with `PopulationRuntimePlan`.
+  - Add plan-local physics field clone/cache helper.
+  - Route CFL, scalar retrieval, flow retrieval, status updates, and dashboard data through the correct population plan retriever.
+  - Commit message: `fix: run tracer physics per population`.
+  - Verify:
+    - `mamba run -n sedtrails python -m ruff check src/sedtrails/simulation_orchestrator src/sedtrails/particle_tracer tests/simulation_orchestrator`
+    - `mamba run -n sedtrails python -m pytest -q tests/simulation_orchestrator`.
+- Block 5, regression coverage and final checks:
+  - Add regression tests for two populations using different tracer methods and for two populations using the same method with different configs.
+  - Add schema validation tests for single-method enforcement.
+  - Run full suite and final Ruff check.
+  - Commit message: `test: cover mixed population tracer methods`.
+  - Verify:
+    - `mamba run -n sedtrails python -m ruff check .`
+    - `mamba run -n sedtrails python -m pytest -q`.
+
+## Test Cases
+
+- Runtime plan builder:
+  - one `vanwesten` population creates one converter with van Westen config.
+  - one `soulsby` population creates one converter with Soulsby config.
+  - mixed `vanwesten` and `soulsby` populations preserve each population's method and flow fields.
+  - multiple methods in one population raises `ConfigurationError`.
+  - unknown method or missing `flow_field_name` raises `ConfigurationError`.
+- Converter:
+  - nested Soulsby config applies `tracer_grain_size`, `background_grain_size`, and Soulsby parameters.
+  - separate converter instances do not share plugin or grain-property cache.
+- Simulation manager:
+  - mixed populations call the correct converter with each population's `transport_probability`.
+  - CFL uses all population plan flow fields, not only the first population.
+  - update loop uses each population's method and does not reuse last population tracer methods.
+  - plan-local physics clones keep same-named fields from overwriting another population's retrieved fields.
+
+## Assumptions
+
+- Full multi-method per single population is out of scope for this implementation and will fail fast.
+- Plugin public APIs stay unchanged; collision avoidance is handled in the simulation orchestrator.
+- Existing YAML object shape for `tracer_methods` stays backward compatible for valid one-method-per-population configs.
+- Existing pending dependency/test fixes should be committed before new feature work.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ description = "Sediment TRAnsport vIsualization and Lagrangian Simulator."
 dependencies = [
   "jsonschema",
   "numpy<2.2,>=1.24",
+  "scipy",
   "pyyaml",
   "pandas",
   "matplotlib",

--- a/src/sedtrails/config/population.schema.json
+++ b/src/sedtrails/config/population.schema.json
@@ -100,6 +100,7 @@
             "properties": {
                 "flow_field_name": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                         "type": "string"
                     },
@@ -111,6 +112,9 @@
                     "description": "beta parameter for van Westen method"
                 }
             },
+            "required": [
+                "flow_field_name"
+            ],
             "description": "van Westen method for particle tracking"
         },
         "soulsby_method": {
@@ -119,6 +123,7 @@
             "properties": {
                 "flow_field_name": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                         "type": "string"
                     },
@@ -160,6 +165,9 @@
                     "description": "Initial state of Freedom Factor (0 = trapped, 1 = free) [-]"
                 }
             },
+            "required": [
+                "flow_field_name"
+            ],
             "description": "Soulsby method for particle tracking"
         }
     },
@@ -200,6 +208,7 @@
                 }
             },
             "minProperties": 1,
+            "maxProperties": 1,
             "default": {
                 "soulsby": {
                     "f": 0.1,

--- a/src/sedtrails/simulation_orchestrator/runtime_plan.py
+++ b/src/sedtrails/simulation_orchestrator/runtime_plan.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import copy
 from dataclasses import asdict, dataclass, is_dataclass
 from typing import Any, Mapping, Sequence
+
+import numpy as np
 
 from sedtrails.exceptions.exceptions import ConfigurationError
 from sedtrails.transport_converter.physics_converter import PhysicsConfig, PhysicsConverter
@@ -62,6 +65,22 @@ def unique_flow_field_names(runtime_plans: Sequence[PopulationRuntimePlan]) -> l
         for runtime_plan in runtime_plans
         for flow_field_name in runtime_plan.tracer.flow_field_names
     )
+
+
+def build_plan_sedtrails_data(sedtrails_data: Any, tracer_plan: TracerRuntimePlan) -> Any:
+    """Run plan physics and return a clone containing only plan-required physics fields."""
+
+    working_data = _shallow_sedtrails_data_clone(sedtrails_data)
+    tracer_plan.converter.convert_physics(
+        sedtrails_data=working_data,
+        transport_probability_method=tracer_plan.transport_probability_method,
+    )
+
+    plan_data = _shallow_sedtrails_data_clone(sedtrails_data)
+    for field_name in tracer_plan.required_physics_fields:
+        if working_data.has_physics_field(field_name):
+            plan_data.add_physics_field(field_name, _copy_physics_value(getattr(working_data, field_name)))
+    return plan_data
 
 
 def _build_population_runtime_plan(
@@ -190,3 +209,19 @@ def _unique_preserving_order(values: Sequence[str] | Any) -> list[str]:
             unique_values.append(value)
             seen.add(value)
     return unique_values
+
+
+def _shallow_sedtrails_data_clone(sedtrails_data: Any) -> Any:
+    cloned_data = copy.copy(sedtrails_data)
+    cloned_data._physics_fields = {}
+    return cloned_data
+
+
+def _copy_physics_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _copy_physics_value(item) for key, item in value.items()}
+    if isinstance(value, np.ndarray):
+        return np.array(value, copy=True)
+    if hasattr(value, 'copy'):
+        return value.copy()
+    return copy.deepcopy(value)

--- a/src/sedtrails/simulation_orchestrator/runtime_plan.py
+++ b/src/sedtrails/simulation_orchestrator/runtime_plan.py
@@ -1,0 +1,192 @@
+"""Runtime planning for population-specific tracer physics."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, is_dataclass
+from typing import Any, Mapping, Sequence
+
+from sedtrails.exceptions.exceptions import ConfigurationError
+from sedtrails.transport_converter.physics_converter import PhysicsConfig, PhysicsConverter
+
+
+SUPPORTED_TRACER_METHODS = frozenset({'soulsby', 'vanwesten'})
+DEFAULT_TRANSPORT_PROBABILITY_METHOD = 'no_probability'
+
+
+@dataclass(frozen=True)
+class TracerRuntimePlan:
+    """Runtime state for one population tracer method."""
+
+    method_name: str
+    method_config: Mapping[str, Any]
+    flow_field_names: tuple[str, ...]
+    transport_probability_method: str
+    required_physics_fields: tuple[str, ...]
+    converter: PhysicsConverter
+
+
+@dataclass(frozen=True)
+class PopulationRuntimePlan:
+    """Runtime state for one particle population."""
+
+    population_index: int
+    population_config: Mapping[str, Any]
+    population: Any
+    tracer: TracerRuntimePlan
+
+
+def build_population_runtime_plans(
+    population_configs: Sequence[Mapping[str, Any]],
+    populations: Sequence[Any],
+    base_physics_config: PhysicsConfig | Mapping[str, Any],
+) -> tuple[PopulationRuntimePlan, ...]:
+    """Build population-scoped tracer runtime plans."""
+
+    if len(population_configs) != len(populations):
+        raise ConfigurationError(
+            f'Population config count ({len(population_configs)}) does not match seeded population count '
+            f'({len(populations)}).'
+        )
+
+    return tuple(
+        _build_population_runtime_plan(index, population_config, population, base_physics_config)
+        for index, (population_config, population) in enumerate(zip(population_configs, populations, strict=True))
+    )
+
+
+def unique_flow_field_names(runtime_plans: Sequence[PopulationRuntimePlan]) -> list[str]:
+    """Return configured flow field names across plans, preserving first-seen order."""
+
+    return _unique_preserving_order(
+        flow_field_name
+        for runtime_plan in runtime_plans
+        for flow_field_name in runtime_plan.tracer.flow_field_names
+    )
+
+
+def _build_population_runtime_plan(
+    population_index: int,
+    population_config: Mapping[str, Any],
+    population: Any,
+    base_physics_config: PhysicsConfig | Mapping[str, Any],
+) -> PopulationRuntimePlan:
+    tracer_methods = population_config.get('tracer_methods')
+    if not isinstance(tracer_methods, Mapping) or not tracer_methods:
+        raise ConfigurationError(f'Population {population_index} must define exactly one tracer method.')
+
+    if len(tracer_methods) != 1:
+        raise ConfigurationError(
+            f'Population {population_index} defines multiple tracer methods '
+            f'({", ".join(tracer_methods.keys())}); only one method per population is supported.'
+        )
+
+    method_name, method_config = next(iter(tracer_methods.items()))
+    if method_name not in SUPPORTED_TRACER_METHODS:
+        raise ConfigurationError(
+            f'Population {population_index} uses unsupported tracer method {method_name!r}. '
+            f'Supported methods: {", ".join(sorted(SUPPORTED_TRACER_METHODS))}.'
+        )
+
+    if not isinstance(method_config, Mapping):
+        raise ConfigurationError(f'Population {population_index} tracer method {method_name!r} must be a mapping.')
+
+    flow_field_names = _get_flow_field_names(population_index, method_name, method_config)
+    transport_probability_method = population_config.get(
+        'transport_probability', DEFAULT_TRANSPORT_PROBABILITY_METHOD
+    )
+    physics_config = build_physics_config(base_physics_config, population_config, method_name, method_config)
+    tracer_config = {method_name: dict(method_config)}
+    converter = PhysicsConverter(physics_config, tracer_config)
+
+    return PopulationRuntimePlan(
+        population_index=population_index,
+        population_config=population_config,
+        population=population,
+        tracer=TracerRuntimePlan(
+            method_name=method_name,
+            method_config=method_config,
+            flow_field_names=flow_field_names,
+            transport_probability_method=transport_probability_method,
+            required_physics_fields=required_physics_fields(method_name, flow_field_names),
+            converter=converter,
+        ),
+    )
+
+
+def build_physics_config(
+    base_physics_config: PhysicsConfig | Mapping[str, Any],
+    population_config: Mapping[str, Any],
+    method_name: str,
+    method_config: Mapping[str, Any],
+) -> PhysicsConfig:
+    """Build method-specific physics config for one population."""
+
+    base_config = _physics_config_to_dict(base_physics_config)
+    base_config['tracer_method'] = method_name
+
+    characteristics = population_config.get('characteristics', {})
+    if isinstance(characteristics, Mapping):
+        if 'density' in characteristics:
+            base_config['particle_density'] = characteristics['density']
+        if 'grain_size' in characteristics:
+            base_config['grain_diameter'] = characteristics['grain_size']
+        elif 'size' in characteristics:
+            base_config['grain_diameter'] = characteristics['size']
+
+    return PhysicsConfig.from_dict(config=base_config, tracer_config={method_name: dict(method_config)})
+
+
+def required_physics_fields(method_name: str, flow_field_names: Sequence[str]) -> tuple[str, ...]:
+    """Return physics fields that must be preserved for a method plan."""
+
+    if method_name == 'vanwesten':
+        return tuple(
+            _unique_preserving_order(
+                (
+                    *flow_field_names,
+                    'mixing_layer_thickness',
+                    *(flow_field_name.replace('velocity', 'probability') for flow_field_name in flow_field_names),
+                )
+            )
+        )
+
+    if method_name == 'soulsby':
+        return tuple(_unique_preserving_order((*flow_field_names, 'mixing_layer_thickness', 'soulsby_a', 'soulsby_b')))
+
+    raise ConfigurationError(f'Unsupported tracer method {method_name!r}.')
+
+
+def _get_flow_field_names(
+    population_index: int, method_name: str, method_config: Mapping[str, Any]
+) -> tuple[str, ...]:
+    flow_field_names = method_config.get('flow_field_name')
+    if not isinstance(flow_field_names, Sequence) or isinstance(flow_field_names, str) or not flow_field_names:
+        raise ConfigurationError(
+            f'Population {population_index} tracer method {method_name!r} must define a non-empty '
+            '`flow_field_name` list.'
+        )
+
+    if not all(isinstance(flow_field_name, str) and flow_field_name for flow_field_name in flow_field_names):
+        raise ConfigurationError(
+            f'Population {population_index} tracer method {method_name!r} has invalid flow field names.'
+        )
+
+    return tuple(flow_field_names)
+
+
+def _physics_config_to_dict(config: PhysicsConfig | Mapping[str, Any]) -> dict[str, Any]:
+    if isinstance(config, PhysicsConfig):
+        return asdict(config)
+    if is_dataclass(config):
+        return asdict(config)
+    return dict(config)
+
+
+def _unique_preserving_order(values: Sequence[str] | Any) -> list[str]:
+    unique_values = []
+    seen = set()
+    for value in values:
+        if value not in seen:
+            unique_values.append(value)
+            seen.add(value)
+    return unique_values

--- a/src/sedtrails/simulation_orchestrator/simulation_manager.py
+++ b/src/sedtrails/simulation_orchestrator/simulation_manager.py
@@ -17,8 +17,12 @@ from sedtrails.particle_tracer.particle import Particle
 from sedtrails.particle_tracer.timer import Duration, Time, Timer
 from sedtrails.pathway_visualizer import SimulationDashboard
 from sedtrails.simulation_orchestrator.global_logger import log_simulation_state, setup_logging
+from sedtrails.simulation_orchestrator.runtime_plan import (
+    build_plan_sedtrails_data,
+    build_population_runtime_plans,
+    unique_flow_field_names,
+)
 from sedtrails.transport_converter.format_converter import FormatConverter, SedtrailsData
-from sedtrails.transport_converter.physics_converter import PhysicsConverter
 
 
 class Simulation:
@@ -64,12 +68,8 @@ class Simulation:
             # Global exception handler will catch and log this
             raise
 
-        for population in self.populations_config:
-            tracer_config = population['tracer_methods']
         # Initialize other components
         self.format_converter = FormatConverter(self._get_format_config())
-        # Added population_config for the soulsby method
-        self.physics_converter = PhysicsConverter(self._get_physics_config(), tracer_config)
         self.data_manager = DataManager(self._get_output_dir())
         self.data_manager.set_mesh()  # TODO: was this ever answered? is it needed?
         self.particles: list[Particle] = []  # List to hold particles
@@ -163,13 +163,7 @@ class Simulation:
         """
         from sedtrails.transport_converter.physics_converter import PhysicsConfig
 
-        # TODO implement configuration controller for multiple populations in a robust way
-        # TODO make sure the tracer_methods in config file match exactly with the plugin file name
-        tracer_method = self._controller.get('particles.populations')[0].get('tracer_methods', 'vanwesten')
-        if isinstance(tracer_method, dict):
-            tracer_method = list(tracer_method.keys())[0]
         config = PhysicsConfig(
-            tracer_method=tracer_method,
             gravity=self._controller.get('physics.constants.g', 9.81),
             von_karman_constant=self._controller.get('physics.constants.von_karman', 0.40),
             kinematic_viscosity=self._controller.get('physics.constants.kinematic_viscosity', 1.36e-6),
@@ -295,6 +289,8 @@ class Simulation:
         populations_config = self._controller.get('particles.populations', [])
         seeder = ParticleSeeder(populations_config)  # intialize seeder with population config
         populations = seeder.seed(sedtrails_data)  # seed particles for all populations using current sedtrails data
+        runtime_plans = build_population_runtime_plans(populations_config, populations, self._get_physics_config())
+        flow_field_names = unique_flow_field_names(runtime_plans)
 
         # Set initial values
         sedtrails_data = None
@@ -318,18 +314,6 @@ class Simulation:
             },
         )
 
-        # Determine flow field names from configuration
-        flow_field_names = []
-        for population in populations_config:
-            if 'tracer_methods' in population and (
-                'vanwesten' in population['tracer_methods'] or 'soulsby' in population['tracer_methods']
-            ):
-                if 'vanwesten' in population['tracer_methods']:
-                    flow_field_names = population['tracer_methods']['vanwesten']['flow_field_name']
-                elif 'soulsby' in population['tracer_methods']:
-                    flow_field_names = population['tracer_methods']['soulsby']['flow_field_name']
-                break  # Use the first population's flow fields for now
-
         # Create SedTrails dataset using DataManager's writer (composition)
         total_particles = sum([len(pop.particles['x']) for pop in populations])
         estimated_timesteps = (simulation_time.duration.seconds // simulation_time.time_step.seconds) + 1
@@ -346,6 +330,8 @@ class Simulation:
         self.data_manager.writer.add_metadata(xr_data, populations, flow_field_names)
 
         # Main simulation loop with variable timestep
+        plan_retrievers = {}
+        dashboard_flow_field = None
         while not timer.stop:
             # Check if current time is within loaded SedTRAILS data
             current_time_seconds = timer.current
@@ -359,66 +345,62 @@ class Simulation:
                     current_time=current_time_seconds, reading_interval=simulation_time.read_input_interval.seconds
                 )
 
-                # Convert physics fields with transport probability configuration
-                for pop in self.populations_config:
-                    self.physics_converter.convert_physics(
-                        sedtrails_data=sedtrails_data,
-                        transport_probability_method=pop.get('transport_probability'),
+                plan_retrievers = {
+                    runtime_plan.population_index: FieldDataRetriever(
+                        build_plan_sedtrails_data(sedtrails_data, runtime_plan.tracer)
                     )
-
-                # Create new FieldDataRetriever with updated data
-                retriever = FieldDataRetriever(sedtrails_data)  # TODO: should the retriever only be created once?
+                    for runtime_plan in runtime_plans
+                }
 
             # TODO: integrate loop over flow fields into CFL Condition
             # Collect flow fields for CFL computation
-            tracer_methods = {}
-            # TODO: this loops over populations_config, but only the last one is used. This must be fixed
-            # to handle multiple populations with different tracer methods and flow fields
-            for population in populations_config:
-                tracer_methods = population['tracer_methods']
-
             flow_data_list = []
-            for flow_field_name in flow_field_names:
-                flow_data_list.append(retriever.get_flow_field(timer.current, flow_field_name))
+            for runtime_plan in runtime_plans:
+                retriever = plan_retrievers[runtime_plan.population_index]
+                for flow_field_name in runtime_plan.tracer.flow_field_names:
+                    flow_data_list.append(retriever.get_flow_field(timer.current, flow_field_name))
 
             # Compute CFL-based timestep across all flow fields
             timer.compute_cfl_timestep(flow_data_list, sedtrails_data)
 
             # Main loop
-            for population in populations:
-                for _method in tracer_methods:
-                    for flow_field_name in flow_field_names:
-                        # Obtain scalar field information
-                        # TODO: Consider moving van westen specific fields to the plugin itself
-                        mixing_depth = retriever.get_scalar_field(timer.current, 'mixing_layer_thickness')['magnitude']
-                        bed_level = retriever.get_scalar_field(timer.current, 'bed_level')['magnitude']
-                        if self.physics_converter.config.tracer_method == 'vanwesten':
-                            transport_prob = retriever.get_scalar_field(
-                                timer.current, flow_field_name.replace('velocity', 'probability')
-                            )['magnitude']
-                        else:  # soulsby
-                            transport_prob = np.ones_like(bed_level)
+            for runtime_plan in runtime_plans:
+                population = runtime_plan.population
+                tracer_plan = runtime_plan.tracer
+                retriever = plan_retrievers[runtime_plan.population_index]
 
-                        # Update information at particle positions
-                        population.update_information(
-                            current_time=timer.current,
-                            mixing_depth=mixing_depth,
-                            bed_level=bed_level,
-                            transport_probability=transport_prob,
-                        )
+                mixing_depth = retriever.get_scalar_field(timer.current, 'mixing_layer_thickness')['magnitude']
+                bed_level = retriever.get_scalar_field(timer.current, 'bed_level')['magnitude']
 
-                        # Update particle burial depth
-                        if self.physics_converter.config.tracer_method == 'vanwesten':
-                            population.update_burial_depth()
+                for flow_field_name in tracer_plan.flow_field_names:
+                    if tracer_plan.method_name == 'vanwesten':
+                        transport_prob = retriever.get_scalar_field(
+                            timer.current, flow_field_name.replace('velocity', 'probability')
+                        )['magnitude']
+                    else:
+                        transport_prob = np.ones_like(bed_level)
 
-                        # Determining status
-                        population.update_status()
+                    # Update information at particle positions
+                    population.update_information(
+                        current_time=timer.current,
+                        mixing_depth=mixing_depth,
+                        bed_level=bed_level,
+                        transport_probability=transport_prob,
+                    )
 
-                        # Get flow field information
-                        flow_field = retriever.get_flow_field(timer.current, flow_field_name)
+                    # Update particle burial depth
+                    if tracer_plan.method_name == 'vanwesten':
+                        population.update_burial_depth()
 
-                        # Update particle position
-                        population.update_position(flow_field=flow_field, current_timestep=timer.current_timestep)
+                    # Determining status
+                    population.update_status()
+
+                    # Get flow field information
+                    flow_field = retriever.get_flow_field(timer.current, flow_field_name)
+                    dashboard_flow_field = flow_field
+
+                    # Update particle position
+                    population.update_position(flow_field=flow_field, current_timestep=timer.current_timestep)
 
             # Collect data from all populations for this timestep using DataManager
             self.data_manager.collect_timestep_data(xr_data, populations, timer.step_count, timer.current)
@@ -431,9 +413,10 @@ class Simulation:
                 xr_data = self._expand_time_dimension(xr_data, max_timesteps)
 
             # Update dashboard if enabled
-            if self.dashboard is not None:
+            if self.dashboard is not None and dashboard_flow_field is not None:
                 # For dashboard, use first population data
                 first_population = populations[0]
+                dashboard_retriever = plan_retrievers[runtime_plans[0].population_index]
                 particle_data = {
                     'x': first_population.particles['x'],
                     'y': first_population.particles['y'],
@@ -441,7 +424,7 @@ class Simulation:
                     'mixing_depth': first_population.particles['mixing_depth'],
                 }
                 # Get bathymetry data
-                bathymetry = retriever.get_scalar_field(timer.current, 'bed_level')['magnitude']
+                bathymetry = dashboard_retriever.get_scalar_field(timer.current, 'bed_level')['magnitude']
 
                 # Particle data including burial_depth and mixing_depth
 
@@ -452,7 +435,7 @@ class Simulation:
                 # Update dashboard with timing info
 
                 self.dashboard.update(
-                    flow_field,
+                    dashboard_flow_field,
                     bathymetry,
                     particle_data,
                     timer.current,

--- a/src/sedtrails/simulation_orchestrator/simulation_manager.py
+++ b/src/sedtrails/simulation_orchestrator/simulation_manager.py
@@ -397,7 +397,11 @@ class Simulation:
 
                     # Get flow field information
                     flow_field = retriever.get_flow_field(timer.current, flow_field_name)
-                    dashboard_flow_field = flow_field
+                    if (
+                        runtime_plan.population_index == 0
+                        and flow_field_name == tracer_plan.flow_field_names[0]
+                    ):
+                        dashboard_flow_field = flow_field
 
                     # Update particle position
                     population.update_position(flow_field=flow_field, current_timestep=timer.current_timestep)

--- a/src/sedtrails/transport_converter/physics_converter.py
+++ b/src/sedtrails/transport_converter/physics_converter.py
@@ -70,7 +70,14 @@ class PhysicsConfig:
             if isinstance(tracer_config.get(method), dict):
                 method_params = tracer_config[method]
             elif any(isinstance(value, dict) for value in tracer_config.values()):
-                method_params = {}
+                available_methods = sorted(
+                    key for key, value in tracer_config.items() if isinstance(value, dict)
+                )
+                raise ValueError(
+                    f"Nested tracer_config was provided, but it does not contain settings "
+                    f"for the active tracer_method '{method}'. "
+                    f"Available method keys: {available_methods}"
+                )
             else:
                 method_params = tracer_config
 

--- a/src/sedtrails/transport_converter/physics_converter.py
+++ b/src/sedtrails/transport_converter/physics_converter.py
@@ -5,8 +5,8 @@ This module adds physics-based calculations to existing SedtrailsData objects
 using the physics library functions and allowing method selection.
 """
 
-from typing import Optional, Any, Dict
 from dataclasses import dataclass, asdict
+from typing import Any, Dict, Optional
 
 # Import physics library
 from sedtrails.transport_converter import physics_lib
@@ -23,9 +23,11 @@ GRAIN_DIAMETER = 2.5e-4  # m (250 μm)
 # Morphological acceleration factor
 MORFAC = 1.0
 
+
 @dataclass
 class PhysicsConfig:
     """Configuration parameters for physics calculations."""
+
     # Physics methods
     tracer_method: str = 'vanwesten'  # name of method for
     gravity: float = GRAVITY
@@ -38,7 +40,9 @@ class PhysicsConfig:
     morfac: float = MORFAC
 
     @classmethod
-    def from_dict(cls, config: Optional[Dict[str, Any]] = None, tracer_config: Optional[Dict[str, Any]] = None) -> "PhysicsConfig":
+    def from_dict(
+        cls, config: Optional[Dict[str, Any]] = None, tracer_config: Optional[Dict[str, Any]] = None
+    ) -> 'PhysicsConfig':
         """
         Build a PhysicsConfig by merging:
         1) defaults (class fields),
@@ -48,32 +52,36 @@ class PhysicsConfig:
         """
         # Start from defaults
         obj = cls()
+
         # Apply base config
         if config:
             if isinstance(config, cls):
-                base = asdict(config)          # deep copy dataclass fields
+                base = asdict(config)
             elif isinstance(config, dict):
                 base = config
             else:
-                base = {k: v for k, v in vars(config).items() if not k.startswith("_")}
+                base = {k: v for k, v in vars(config).items() if not k.startswith('_')}
             for k, v in base.items():
                 setattr(obj, k, v)
+
         # Apply method-specific (flatten) from tracer_config
         if tracer_config:
-            method = getattr(config, "tracer_method", "vanwesten")
-            # If tracer_config is nested like {"soulsby": {...}}, pick the active method
-            if isinstance(tracer_config.get(method, None), dict):
+            method = obj.tracer_method
+            if isinstance(tracer_config.get(method), dict):
                 method_params = tracer_config[method]
-                for k, v in method_params.items():
-                    setattr(obj, k, v)
+            elif any(isinstance(value, dict) for value in tracer_config.values()):
+                method_params = {}
             else:
-                # Otherwise assume tracer_config is already flat
-                for k, v in tracer_config.items():
-                    setattr(obj, k, v)
+                method_params = tracer_config
+
+            for k, v in method_params.items():
+                setattr(obj, k, v)
         return obj
+
     # Optional: expose a dict view when needed
     def as_dict(self) -> Dict[str, Any]:
         return dict(self.__dict__)
+
 
 class PhysicsConverter:
     """
@@ -152,9 +160,8 @@ class PhysicsConverter:
                     f'Ensure the module exists and is correctly named.'
                 ) from e
             else:
-                self._physics_plugin = plugin_module.PhysicsPlugin(self.config, self.tracer_config)  # all classes should be called the PhysicsPlugin
+                self._physics_plugin = plugin_module.PhysicsPlugin(self.config, self.tracer_config)
         return self._physics_plugin
-
 
     def convert_physics(self, sedtrails_data, transport_probability_method: str = None) -> None:
         """

--- a/src/sedtrails/transport_converter/physics_converter.py
+++ b/src/sedtrails/transport_converter/physics_converter.py
@@ -5,7 +5,7 @@ This module adds physics-based calculations to existing SedtrailsData objects
 using the physics library functions and allowing method selection.
 """
 
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass
 from typing import Any, Dict, Optional
 
 # Import physics library
@@ -181,4 +181,4 @@ class PhysicsConverter:
             plugin = self._physics_plugin
 
         # Use empty dict as default if no config provided
-        plugin.add_physics(sedtrails_data, self.grain_properties, transport_probability_method or {})
+        plugin.add_physics(sedtrails_data, self.grain_properties, transport_probability_method or 'no_probability')

--- a/tests/configuration_interfaces/test_inputconfigurator.py
+++ b/tests/configuration_interfaces/test_inputconfigurator.py
@@ -12,6 +12,7 @@ from sedtrails.exceptions import YamlValidationError, YamlOutputError
 
 @pytest.fixture
 def validator():
+    """Provide a YAMLConfigValidator instance for tests."""
     # You can use any valid schema file path, but for testing _apply_defaults, schema_content is enough
     dummy_schema = {}
     dummy_schema_file = tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.yml')
@@ -29,6 +30,7 @@ class TestYAMLConfigValidator:
     """
 
     def test_apply_defaults_object(self, validator):
+        """Apply object defaults when all optional keys are missing."""
         schema = {
             'type': 'object',
             'properties': {
@@ -41,6 +43,7 @@ class TestYAMLConfigValidator:
         assert result == {'a': 'foo', 'b': 42}
 
     def test_apply_defaults_partial_object(self, validator):
+        """Preserve provided values while filling missing object defaults."""
         schema = {
             'type': 'object',
             'properties': {
@@ -53,6 +56,7 @@ class TestYAMLConfigValidator:
         assert result == {'a': 'bar', 'b': 42}
 
     def test_apply_defaults_nested_object(self, validator):
+        """Apply defaults recursively in nested object properties."""
         schema = {
             'type': 'object',
             'properties': {'outer': {'type': 'object', 'properties': {'inner': {'type': 'string', 'default': 'baz'}}}},
@@ -62,6 +66,7 @@ class TestYAMLConfigValidator:
         assert result == {'outer': {'inner': 'baz'}}
 
     def test_apply_defaults_array(self, validator):
+        """Apply item defaults for each element in an array of objects."""
         schema = {'type': 'array', 'items': {'type': 'object', 'properties': {'x': {'type': 'integer', 'default': 1}}}}
         config = [{'x': 2}, {}]
         result = validator._apply_defaults(schema, config)

--- a/tests/configuration_interfaces/test_population_schema.py
+++ b/tests/configuration_interfaces/test_population_schema.py
@@ -8,6 +8,7 @@ from sedtrails.exceptions import YamlValidationError
 
 
 def test_population_schema_rejects_multiple_tracer_methods(tmp_path):
+    """Reject populations that configure more than one tracer method."""
     config = _base_config()
     config['particles']['populations'][0]['tracer_methods'] = {
         'vanwesten': {'flow_field_name': ['bed_load_velocity']},
@@ -19,6 +20,7 @@ def test_population_schema_rejects_multiple_tracer_methods(tmp_path):
 
 
 def test_population_schema_requires_flow_field_name(tmp_path):
+    """Require flow_field_name for the selected tracer method."""
     config = _base_config()
     config['particles']['populations'][0]['tracer_methods'] = {'vanwesten': {'beta': 0.2}}
 
@@ -27,6 +29,7 @@ def test_population_schema_requires_flow_field_name(tmp_path):
 
 
 def test_population_schema_accepts_one_method_with_flow_fields(tmp_path):
+    """Accept a valid single tracer method with flow field names."""
     config = _base_config()
 
     validated = _validate_config(tmp_path, config)
@@ -36,12 +39,14 @@ def test_population_schema_accepts_one_method_with_flow_fields(tmp_path):
 
 
 def _validate_config(tmp_path, config):
+    """Write a temporary config file and validate it with the schema validator."""
     config_file = tmp_path / 'sedtrails.yml'
     config_file.write_text(yaml.dump(config))
     return YAMLConfigValidator().validate_yaml(str(config_file))
 
 
 def _base_config():
+    """Build a minimal valid base configuration for population schema tests."""
     return {
         'particles': {
             'populations': [

--- a/tests/configuration_interfaces/test_population_schema.py
+++ b/tests/configuration_interfaces/test_population_schema.py
@@ -1,0 +1,73 @@
+"""Population schema regression tests."""
+
+import yaml
+import pytest
+
+from sedtrails.application_interfaces.validator import YAMLConfigValidator
+from sedtrails.exceptions import YamlValidationError
+
+
+def test_population_schema_rejects_multiple_tracer_methods(tmp_path):
+    config = _base_config()
+    config['particles']['populations'][0]['tracer_methods'] = {
+        'vanwesten': {'flow_field_name': ['bed_load_velocity']},
+        'soulsby': {'flow_field_name': ['grain_velocity']},
+    }
+
+    with pytest.raises(YamlValidationError, match='YAML config validation error'):
+        _validate_config(tmp_path, config)
+
+
+def test_population_schema_requires_flow_field_name(tmp_path):
+    config = _base_config()
+    config['particles']['populations'][0]['tracer_methods'] = {'vanwesten': {'beta': 0.2}}
+
+    with pytest.raises(YamlValidationError, match='YAML config validation error'):
+        _validate_config(tmp_path, config)
+
+
+def test_population_schema_accepts_one_method_with_flow_fields(tmp_path):
+    config = _base_config()
+
+    validated = _validate_config(tmp_path, config)
+
+    tracer_methods = validated['particles']['populations'][0]['tracer_methods']
+    assert tracer_methods == {'vanwesten': {'flow_field_name': ['bed_load_velocity']}}
+
+
+def _validate_config(tmp_path, config):
+    config_file = tmp_path / 'sedtrails.yml'
+    config_file.write_text(yaml.dump(config))
+    return YAMLConfigValidator().validate_yaml(str(config_file))
+
+
+def _base_config():
+    return {
+        'particles': {
+            'populations': [
+                {
+                    'name': 'sand',
+                    'particle_type': 'sand',
+                    'characteristics': {
+                        'density': 2650.0,
+                        'grain_size': 0.00025,
+                    },
+                    'tracer_methods': {
+                        'vanwesten': {
+                            'flow_field_name': ['bed_load_velocity'],
+                        },
+                    },
+                    'seeding': {
+                        'burial_depth': {'constant': 0.0},
+                        'release_start': '2016-09-21 19:30:00',
+                        'quantity': 1,
+                        'strategy': {
+                            'point': {
+                                'locations': ['0.0,0.0'],
+                            },
+                        },
+                    },
+                }
+            ]
+        }
+    }

--- a/tests/simulation_orchestrator/test_runtime_plan.py
+++ b/tests/simulation_orchestrator/test_runtime_plan.py
@@ -1,10 +1,13 @@
 """Tests for population tracer runtime planning."""
 
+import numpy as np
 import pytest
 
 from sedtrails.exceptions.exceptions import ConfigurationError
 from sedtrails.simulation_orchestrator.runtime_plan import (
     DEFAULT_TRANSPORT_PROBABILITY_METHOD,
+    TracerRuntimePlan,
+    build_plan_sedtrails_data,
     build_population_runtime_plans,
     required_physics_fields,
     unique_flow_field_names,
@@ -132,3 +135,58 @@ def test_required_physics_fields_are_method_specific_and_unique():
         'soulsby_a',
         'soulsby_b',
     )
+
+
+def test_build_plan_sedtrails_data_copies_only_required_physics_fields():
+    source_data = _FakeSedtrailsData()
+    converter = _FakePhysicsConverter()
+    tracer_plan = TracerRuntimePlan(
+        method_name='vanwesten',
+        method_config={'flow_field_name': ['bed_load_velocity']},
+        flow_field_names=('bed_load_velocity',),
+        transport_probability_method='stochastic_transport',
+        required_physics_fields=('bed_load_velocity', 'mixing_layer_thickness'),
+        converter=converter,
+    )
+
+    plan_data = build_plan_sedtrails_data(source_data, tracer_plan)
+
+    assert converter.transport_probability_method == 'stochastic_transport'
+    assert source_data.get_physics_fields() == []
+    assert plan_data.get_physics_fields() == ['bed_load_velocity', 'mixing_layer_thickness']
+    assert not plan_data.has_physics_field('ignored_field')
+    assert plan_data.bed_load_velocity is not converter.generated_velocity
+    assert plan_data.bed_load_velocity['x'] is not converter.generated_velocity['x']
+    np.testing.assert_array_equal(plan_data.bed_load_velocity['x'], np.array([1.0, 2.0]))
+
+
+class _FakeSedtrailsData:
+    def __init__(self):
+        self._physics_fields = {}
+
+    def add_physics_field(self, name, data):
+        self._physics_fields[name] = data
+        setattr(self, name, data)
+
+    def has_physics_field(self, name):
+        return name in self._physics_fields
+
+    def get_physics_fields(self):
+        return list(self._physics_fields)
+
+
+class _FakePhysicsConverter:
+    def __init__(self):
+        self.generated_velocity = None
+        self.transport_probability_method = None
+
+    def convert_physics(self, sedtrails_data, transport_probability_method):
+        self.transport_probability_method = transport_probability_method
+        self.generated_velocity = {
+            'x': np.array([1.0, 2.0]),
+            'y': np.array([3.0, 4.0]),
+            'magnitude': np.array([5.0, 6.0]),
+        }
+        sedtrails_data.add_physics_field('bed_load_velocity', self.generated_velocity)
+        sedtrails_data.add_physics_field('mixing_layer_thickness', np.array([0.1, 0.2]))
+        sedtrails_data.add_physics_field('ignored_field', np.array([9.0, 9.0]))

--- a/tests/simulation_orchestrator/test_runtime_plan.py
+++ b/tests/simulation_orchestrator/test_runtime_plan.py
@@ -20,6 +20,7 @@ def _population_config(
     characteristics=None,
     transport_probability=DEFAULT_TRANSPORT_PROBABILITY_METHOD,
 ):
+    """Build a minimal population configuration for runtime plan tests."""
     return {
         'name': 'sand',
         'particle_type': 'sand',
@@ -30,6 +31,7 @@ def _population_config(
 
 
 def test_vanwesten_population_creates_population_scoped_converter():
+    """Build a van Westen plan with population-specific converter settings."""
     population_config = _population_config(
         {'vanwesten': {'flow_field_name': ['bed_load_velocity', 'suspended_velocity'], 'beta': 0.3}},
         transport_probability='stochastic_transport',
@@ -48,6 +50,7 @@ def test_vanwesten_population_creates_population_scoped_converter():
 
 
 def test_soulsby_population_creates_population_scoped_converter():
+    """Build a Soulsby plan and map population and physics values to converter config."""
     population_config = _population_config(
         {
             'soulsby': {
@@ -73,6 +76,7 @@ def test_soulsby_population_creates_population_scoped_converter():
 
 
 def test_mixed_populations_preserve_each_population_method_and_flow_fields():
+    """Keep tracer method and flow fields isolated per population in mixed runs."""
     vanwesten_config = _population_config({'vanwesten': {'flow_field_name': ['bed_load_velocity']}})
     soulsby_config = _population_config({'soulsby': {'flow_field_name': ['grain_velocity']}})
 
@@ -91,6 +95,7 @@ def test_mixed_populations_preserve_each_population_method_and_flow_fields():
 
 
 def test_same_method_populations_keep_separate_method_configs():
+    """Ensure same-method populations do not share converter instances or config."""
     fine_sand_config = _population_config(
         {'vanwesten': {'flow_field_name': ['bed_load_velocity'], 'beta': 0.1}},
         characteristics={'density': 2650.0, 'grain_size': 0.0001},
@@ -116,6 +121,7 @@ def test_same_method_populations_keep_separate_method_configs():
 
 
 def test_multiple_methods_in_one_population_raises_configuration_error():
+    """Reject a population that declares more than one tracer method."""
     population_config = _population_config(
         {
             'vanwesten': {'flow_field_name': ['bed_load_velocity']},
@@ -128,6 +134,7 @@ def test_multiple_methods_in_one_population_raises_configuration_error():
 
 
 def test_unknown_method_raises_configuration_error():
+    """Raise a configuration error for unsupported tracer methods."""
     population_config = _population_config({'unknown': {'flow_field_name': ['some_velocity']}})
 
     with pytest.raises(ConfigurationError, match='unsupported tracer method'):
@@ -135,6 +142,7 @@ def test_unknown_method_raises_configuration_error():
 
 
 def test_missing_flow_field_name_raises_configuration_error():
+    """Raise a configuration error when flow_field_name is missing."""
     population_config = _population_config({'vanwesten': {'beta': 0.3}})
 
     with pytest.raises(ConfigurationError, match='flow_field_name'):
@@ -142,6 +150,7 @@ def test_missing_flow_field_name_raises_configuration_error():
 
 
 def test_population_count_mismatch_raises_configuration_error():
+    """Raise a configuration error when seeded and configured population counts differ."""
     population_config = _population_config({'vanwesten': {'flow_field_name': ['bed_load_velocity']}})
 
     with pytest.raises(ConfigurationError, match='does not match seeded population count'):
@@ -149,6 +158,7 @@ def test_population_count_mismatch_raises_configuration_error():
 
 
 def test_required_physics_fields_are_method_specific_and_unique():
+    """Return per-method required physics fields with duplicate flow fields removed."""
     assert required_physics_fields('vanwesten', ['bed_load_velocity', 'bed_load_velocity']) == (
         'bed_load_velocity',
         'mixing_layer_thickness',
@@ -163,6 +173,7 @@ def test_required_physics_fields_are_method_specific_and_unique():
 
 
 def test_build_plan_sedtrails_data_copies_only_required_physics_fields():
+    """Copy only required converted physics fields into plan-local sedtrails data."""
     source_data = _FakeSedtrailsData()
     converter = _FakePhysicsConverter()
     tracer_plan = TracerRuntimePlan(
@@ -186,6 +197,7 @@ def test_build_plan_sedtrails_data_copies_only_required_physics_fields():
 
 
 def test_plan_local_physics_data_keeps_same_named_fields_from_overwriting():
+    """Keep same-named converted fields isolated between separate runtime plans."""
     first_tracer_plan = TracerRuntimePlan(
         method_name='vanwesten',
         method_config={'flow_field_name': ['bed_load_velocity']},
@@ -213,26 +225,36 @@ def test_plan_local_physics_data_keeps_same_named_fields_from_overwriting():
 
 
 class _FakeSedtrailsData:
+    """Minimal sedtrails-data test double storing physics fields by name."""
+
     def __init__(self):
+        """Initialize an empty physics field store."""
         self._physics_fields = {}
 
     def add_physics_field(self, name, data):
+        """Store a named physics field and expose it as an attribute."""
         self._physics_fields[name] = data
         setattr(self, name, data)
 
     def has_physics_field(self, name):
+        """Return whether a physics field exists in this test double."""
         return name in self._physics_fields
 
     def get_physics_fields(self):
+        """List stored physics field names in insertion order."""
         return list(self._physics_fields)
 
 
 class _FakePhysicsConverter:
+    """Physics converter test double that writes deterministic vector/scalar fields."""
+
     def __init__(self):
+        """Initialize converter state captured during conversion."""
         self.generated_velocity = None
         self.transport_probability_method = None
 
     def convert_physics(self, sedtrails_data, transport_probability_method):
+        """Populate test physics fields and record transport probability mode."""
         self.transport_probability_method = transport_probability_method
         self.generated_velocity = {
             'x': np.array([1.0, 2.0]),
@@ -245,9 +267,13 @@ class _FakePhysicsConverter:
 
 
 class _NamedScalarPhysicsConverter:
+    """Converter test double that writes one named scalar field."""
+
     def __init__(self, field_name, field_value):
+        """Store the field name and value that will be injected during conversion."""
         self.field_name = field_name
         self.field_value = field_value
 
     def convert_physics(self, sedtrails_data, transport_probability_method):
+        """Add the configured scalar field to the provided sedtrails data."""
         sedtrails_data.add_physics_field(self.field_name, self.field_value)

--- a/tests/simulation_orchestrator/test_runtime_plan.py
+++ b/tests/simulation_orchestrator/test_runtime_plan.py
@@ -1,0 +1,134 @@
+"""Tests for population tracer runtime planning."""
+
+import pytest
+
+from sedtrails.exceptions.exceptions import ConfigurationError
+from sedtrails.simulation_orchestrator.runtime_plan import (
+    DEFAULT_TRANSPORT_PROBABILITY_METHOD,
+    build_population_runtime_plans,
+    required_physics_fields,
+    unique_flow_field_names,
+)
+
+
+def _population_config(
+    tracer_methods,
+    *,
+    characteristics=None,
+    transport_probability=DEFAULT_TRANSPORT_PROBABILITY_METHOD,
+):
+    return {
+        'name': 'sand',
+        'particle_type': 'sand',
+        'characteristics': characteristics or {'density': 2650.0, 'grain_size': 0.00025},
+        'tracer_methods': tracer_methods,
+        'transport_probability': transport_probability,
+    }
+
+
+def test_vanwesten_population_creates_population_scoped_converter():
+    population_config = _population_config(
+        {'vanwesten': {'flow_field_name': ['bed_load_velocity', 'suspended_velocity'], 'beta': 0.3}},
+        transport_probability='stochastic_transport',
+    )
+
+    runtime_plan = build_population_runtime_plans([population_config], [object()], {'gravity': 9.8})[0]
+
+    assert runtime_plan.population_index == 0
+    assert runtime_plan.tracer.method_name == 'vanwesten'
+    assert runtime_plan.tracer.flow_field_names == ('bed_load_velocity', 'suspended_velocity')
+    assert runtime_plan.tracer.transport_probability_method == 'stochastic_transport'
+    assert runtime_plan.tracer.converter.config.tracer_method == 'vanwesten'
+    assert runtime_plan.tracer.converter.config.gravity == 9.8
+    assert runtime_plan.tracer.converter.config.beta == 0.3
+    assert runtime_plan.tracer.converter.config.grain_diameter == 0.00025
+
+
+def test_soulsby_population_creates_population_scoped_converter():
+    population_config = _population_config(
+        {
+            'soulsby': {
+                'flow_field_name': ['grain_velocity'],
+                'tracer_grain_size': 0.0001,
+                'background_grain_size': 0.0002,
+                'soulsby_mu_d': 0.6,
+            }
+        },
+        characteristics={'density': 2600.0, 'grain_size': 0.0004},
+    )
+
+    runtime_plan = build_population_runtime_plans([population_config], [object()], {'water_density': 1025.0})[0]
+
+    assert runtime_plan.tracer.method_name == 'soulsby'
+    assert runtime_plan.tracer.flow_field_names == ('grain_velocity',)
+    assert runtime_plan.tracer.converter.config.tracer_method == 'soulsby'
+    assert runtime_plan.tracer.converter.config.water_density == 1025.0
+    assert runtime_plan.tracer.converter.config.particle_density == 2600.0
+    assert runtime_plan.tracer.converter.config.tracer_grain_size == 0.0001
+    assert runtime_plan.tracer.converter.config.background_grain_size == 0.0002
+    assert runtime_plan.tracer.converter.config.soulsby_mu_d == 0.6
+
+
+def test_mixed_populations_preserve_each_population_method_and_flow_fields():
+    vanwesten_config = _population_config({'vanwesten': {'flow_field_name': ['bed_load_velocity']}})
+    soulsby_config = _population_config({'soulsby': {'flow_field_name': ['grain_velocity']}})
+
+    runtime_plans = build_population_runtime_plans(
+        [vanwesten_config, soulsby_config],
+        [object(), object()],
+        {},
+    )
+
+    assert [runtime_plan.tracer.method_name for runtime_plan in runtime_plans] == ['vanwesten', 'soulsby']
+    assert [runtime_plan.tracer.flow_field_names for runtime_plan in runtime_plans] == [
+        ('bed_load_velocity',),
+        ('grain_velocity',),
+    ]
+    assert unique_flow_field_names(runtime_plans) == ['bed_load_velocity', 'grain_velocity']
+
+
+def test_multiple_methods_in_one_population_raises_configuration_error():
+    population_config = _population_config(
+        {
+            'vanwesten': {'flow_field_name': ['bed_load_velocity']},
+            'soulsby': {'flow_field_name': ['grain_velocity']},
+        }
+    )
+
+    with pytest.raises(ConfigurationError, match='multiple tracer methods'):
+        build_population_runtime_plans([population_config], [object()], {})
+
+
+def test_unknown_method_raises_configuration_error():
+    population_config = _population_config({'unknown': {'flow_field_name': ['some_velocity']}})
+
+    with pytest.raises(ConfigurationError, match='unsupported tracer method'):
+        build_population_runtime_plans([population_config], [object()], {})
+
+
+def test_missing_flow_field_name_raises_configuration_error():
+    population_config = _population_config({'vanwesten': {'beta': 0.3}})
+
+    with pytest.raises(ConfigurationError, match='flow_field_name'):
+        build_population_runtime_plans([population_config], [object()], {})
+
+
+def test_population_count_mismatch_raises_configuration_error():
+    population_config = _population_config({'vanwesten': {'flow_field_name': ['bed_load_velocity']}})
+
+    with pytest.raises(ConfigurationError, match='does not match seeded population count'):
+        build_population_runtime_plans([population_config], [], {})
+
+
+def test_required_physics_fields_are_method_specific_and_unique():
+    assert required_physics_fields('vanwesten', ['bed_load_velocity', 'bed_load_velocity']) == (
+        'bed_load_velocity',
+        'mixing_layer_thickness',
+        'bed_load_probability',
+    )
+    assert required_physics_fields('soulsby', ['grain_velocity']) == (
+        'grain_velocity',
+        'mixing_layer_thickness',
+        'soulsby_a',
+        'soulsby_b',
+    )

--- a/tests/simulation_orchestrator/test_runtime_plan.py
+++ b/tests/simulation_orchestrator/test_runtime_plan.py
@@ -90,6 +90,31 @@ def test_mixed_populations_preserve_each_population_method_and_flow_fields():
     assert unique_flow_field_names(runtime_plans) == ['bed_load_velocity', 'grain_velocity']
 
 
+def test_same_method_populations_keep_separate_method_configs():
+    fine_sand_config = _population_config(
+        {'vanwesten': {'flow_field_name': ['bed_load_velocity'], 'beta': 0.1}},
+        characteristics={'density': 2650.0, 'grain_size': 0.0001},
+    )
+    coarse_sand_config = _population_config(
+        {'vanwesten': {'flow_field_name': ['bed_load_velocity'], 'beta': 0.4}},
+        characteristics={'density': 2650.0, 'grain_size': 0.0005},
+    )
+
+    runtime_plans = build_population_runtime_plans(
+        [fine_sand_config, coarse_sand_config],
+        [object(), object()],
+        {},
+    )
+
+    fine_converter = runtime_plans[0].tracer.converter
+    coarse_converter = runtime_plans[1].tracer.converter
+    assert fine_converter is not coarse_converter
+    assert fine_converter.config.beta == 0.1
+    assert coarse_converter.config.beta == 0.4
+    assert fine_converter.config.grain_diameter == 0.0001
+    assert coarse_converter.config.grain_diameter == 0.0005
+
+
 def test_multiple_methods_in_one_population_raises_configuration_error():
     population_config = _population_config(
         {
@@ -160,6 +185,33 @@ def test_build_plan_sedtrails_data_copies_only_required_physics_fields():
     np.testing.assert_array_equal(plan_data.bed_load_velocity['x'], np.array([1.0, 2.0]))
 
 
+def test_plan_local_physics_data_keeps_same_named_fields_from_overwriting():
+    first_tracer_plan = TracerRuntimePlan(
+        method_name='vanwesten',
+        method_config={'flow_field_name': ['bed_load_velocity']},
+        flow_field_names=('bed_load_velocity',),
+        transport_probability_method='stochastic_transport',
+        required_physics_fields=('mixing_layer_thickness',),
+        converter=_NamedScalarPhysicsConverter('mixing_layer_thickness', np.array([0.1, 0.2])),
+    )
+    second_tracer_plan = TracerRuntimePlan(
+        method_name='soulsby',
+        method_config={'flow_field_name': ['grain_velocity']},
+        flow_field_names=('grain_velocity',),
+        transport_probability_method='no_probability',
+        required_physics_fields=('mixing_layer_thickness',),
+        converter=_NamedScalarPhysicsConverter('mixing_layer_thickness', np.array([9.0, 10.0])),
+    )
+    source_data = _FakeSedtrailsData()
+
+    first_plan_data = build_plan_sedtrails_data(source_data, first_tracer_plan)
+    second_plan_data = build_plan_sedtrails_data(source_data, second_tracer_plan)
+
+    np.testing.assert_array_equal(first_plan_data.mixing_layer_thickness, np.array([0.1, 0.2]))
+    np.testing.assert_array_equal(second_plan_data.mixing_layer_thickness, np.array([9.0, 10.0]))
+    assert source_data.get_physics_fields() == []
+
+
 class _FakeSedtrailsData:
     def __init__(self):
         self._physics_fields = {}
@@ -190,3 +242,12 @@ class _FakePhysicsConverter:
         sedtrails_data.add_physics_field('bed_load_velocity', self.generated_velocity)
         sedtrails_data.add_physics_field('mixing_layer_thickness', np.array([0.1, 0.2]))
         sedtrails_data.add_physics_field('ignored_field', np.array([9.0, 9.0]))
+
+
+class _NamedScalarPhysicsConverter:
+    def __init__(self, field_name, field_value):
+        self.field_name = field_name
+        self.field_value = field_value
+
+    def convert_physics(self, sedtrails_data, transport_probability_method):
+        sedtrails_data.add_physics_field(self.field_name, self.field_value)

--- a/tests/transport_converter/plugins/test_physics_plugin.py
+++ b/tests/transport_converter/plugins/test_physics_plugin.py
@@ -1,12 +1,11 @@
-import os
 import importlib.util
 import inspect
+from pathlib import Path
+
 import pytest
 from sedtrails.transport_converter.plugins.physics.plugin import BasePhysicsPlugin
 
-PLUGIN_DIR = os.path.dirname(__file__).replace(
-    'tests/transport_converter/plugins', 'src/sedtrails/transport_converter/plugins/physics'
-)
+PLUGIN_DIR = Path(__file__).resolve().parents[3] / 'src' / 'sedtrails' / 'transport_converter' / 'plugins' / 'physics'
 
 
 def get_plugin_classes():
@@ -18,11 +17,11 @@ def get_plugin_classes():
         list: List of plugin classes found in the directory.
     """
     plugin_classes = []
-    for fname in os.listdir(PLUGIN_DIR):
+    for plugin_path in PLUGIN_DIR.iterdir():
+        fname = plugin_path.name
         if fname.endswith('.py') and fname != 'plugin.py' and not fname.startswith('__'):
-            module_path = os.path.join(PLUGIN_DIR, fname)
             module_name = f'sedtrails.transport_converter.plugins.physics.{fname[:-3]}'
-            spec = importlib.util.spec_from_file_location(module_name, module_path)
+            spec = importlib.util.spec_from_file_location(module_name, plugin_path)
             module = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(module)
             for _, obj in inspect.getmembers(module, inspect.isclass):

--- a/tests/transport_converter/test_physics_converter.py
+++ b/tests/transport_converter/test_physics_converter.py
@@ -1,0 +1,63 @@
+"""Tests for physics converter configuration handling."""
+
+from sedtrails.transport_converter.physics_converter import PhysicsConfig, PhysicsConverter
+
+
+def test_nested_tracer_config_uses_resolved_method_from_dict_config():
+    config = PhysicsConfig.from_dict(
+        config={'tracer_method': 'soulsby', 'gravity': 9.8},
+        tracer_config={
+            'soulsby': {
+                'flow_field_name': ['grain_velocity'],
+                'tracer_grain_size': 0.0001,
+                'background_grain_size': 0.0002,
+                'soulsby_mu_d': 0.6,
+            },
+            'vanwesten': {
+                'flow_field_name': ['bed_load_velocity'],
+                'beta': 0.3,
+            },
+        },
+    )
+
+    assert config.tracer_method == 'soulsby'
+    assert config.gravity == 9.8
+    assert config.tracer_grain_size == 0.0001
+    assert config.background_grain_size == 0.0002
+    assert config.soulsby_mu_d == 0.6
+    assert not hasattr(config, 'beta')
+
+
+def test_flat_tracer_config_is_still_applied():
+    config = PhysicsConfig.from_dict(
+        config={'tracer_method': 'vanwesten'},
+        tracer_config={'flow_field_name': ['bed_load_velocity'], 'beta': 0.4},
+    )
+
+    assert config.tracer_method == 'vanwesten'
+    assert config.beta == 0.4
+    assert config.flow_field_name == ['bed_load_velocity']
+
+
+def test_converter_instances_do_not_share_config_or_caches():
+    first = PhysicsConverter(
+        {'tracer_method': 'soulsby'},
+        {'soulsby': {'flow_field_name': ['grain_velocity'], 'tracer_grain_size': 0.0001}},
+    )
+    second = PhysicsConverter(
+        {'tracer_method': 'soulsby'},
+        {'soulsby': {'flow_field_name': ['grain_velocity'], 'tracer_grain_size': 0.0005}},
+    )
+
+    assert first.config.tracer_grain_size == 0.0001
+    assert second.config.tracer_grain_size == 0.0005
+    assert first.config is not second.config
+    assert first._grain_properties is not second._grain_properties
+    assert first._physics_plugin is None
+    assert second._physics_plugin is None
+
+    first._grain_properties['sentinel'] = 1
+    first._physics_plugin = object()
+
+    assert second._grain_properties == {}
+    assert second._physics_plugin is None


### PR DESCRIPTION
## Summary

- Added population-scoped tracer runtime planning so mixed population simulations no longer derive physics from the first population or leak tracer method state from the last loop iteration.
- Refactored simulation execution to use one `PhysicsConverter` per population tracer plan, with plan-local copied physics fields to avoid same-name field collisions.
- Fixed `PhysicsConfig.from_dict()` so nested method configs are flattened using the resolved tracer method.
- Tightened population schema validation to require exactly one tracer method per population and require non-empty `flow_field_name`.
- Added regression coverage for mixed `vanwesten`/`soulsby` populations, same-method populations with different configs, plan-local physics isolation, and schema validation.
- Archived the implementation plan in `plan.md`.

Closes #390 