### PR TITLE
Add restart config generation from NetCDF

### DIFF
--- a/docs/references/simulation-params.md
+++ b/docs/references/simulation-params.md
@@ -69,7 +69,7 @@ Specifies paths to input data and reading parameters.
 | ------------------------- | ------- | ------------ | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | `data`                    | string  | **Required** | -             | Path to the flow field data file (e.g., D-Flow FM NetCDF output).                                                                             |
 | `read_interval`           | string  | Optional     | `30D12H25M0S` | Time chunk size for reading input data. Format: `DDdHHhMMmSSs` (e.g., `30D` for 30 days, `12H` for 12 hours).                                 |
-| `repeat_eulerian_fields`  | boolean | Optional     | `false`       | Repeat Eulerian flow fields from the first input timestamp when the simulation runtime exceeds the forcing time range. If `false`, reuse the final fields. |
+| `repeat_eulerian_fields`  | boolean | Optional     | `false`       | Repeat Eulerian flow fields only after a valid simulation start inside the forcing window. If `false`, reuse the final fields after the forcing period is exhausted. |
 | `comp_dir`                | string  | Optional     | -             | Path to directory containing complementary validation data.                                                                                   |
 
 **Example:**
@@ -497,7 +497,7 @@ Controls what results are saved and where.
 | Parameter             | Type    | Required    | Default    | Description                                                                                             |
 | --------------------- | ------- | ----------- | ---------- | ------------------------------------------------------------------------------------------------------- |
 | `directory`           | string  | Optional    | `./output` | Path to directory for storing simulation results.                                                       |
-| `save_interval`       | string  | Optional    | `1H`       | How often to save output during simulation (format: `DDdHHhMMmSSs`).                                    |
+| `save_interval`       | string  | Optional    | `1H`       | How often to store trajectory samples. CFL integration can use shorter internal steps; output stores the initial sample, scheduled samples, and final sample. |
 | `store_tracks`        | boolean | Conditional | `true`     | Store complete particle trajectories over time. Creates larger files but enables full pathway analysis. |
 | `store_end_positions` | boolean | Conditional | `false`    | Store only final particle positions. Creates smaller files but limits analysis options.                 |
 

--- a/docs/tutorials/loop-simulations.md
+++ b/docs/tutorials/loop-simulations.md
@@ -37,16 +37,19 @@ If `repeat_eulerian_fields` is `false`, SedTRAILS will keep using the final avai
 
 ## How Time Mapping Works
 
-Internally, SedTRAILS maps each particle time step to an Eulerian forcing timestamp. This is handled by the helper `_map_eulerian_field_time`, which:
-- Wraps the simulation time into the forcing window when looping is enabled.
-- Clamps the time to the final forcing timestamp when looping is disabled.
+SedTRAILS first validates that `time.start` is inside the input forcing window. Looping is not used to rescue a simulation that starts before the first forcing timestamp or after the last forcing timestamp.
+
+After that valid start:
+- In-window simulation times use the matching Eulerian forcing timestamp.
+- If `repeat_eulerian_fields` is `true`, simulation times after the forcing end are mapped back into the forcing cycle.
+- If `repeat_eulerian_fields` is `false`, SedTRAILS keeps using the final available Eulerian fields once the forcing period is exhausted.
 
 This time mapping is applied consistently across velocity and tracer fields so that particle advection remains synchronized with the Eulerian data.
 
 ## Morfac Decompression
 
 When `general.input_model.morfac` is greater than 1, the forcing time axis is decompressed before mapping. This means:
-- A morphologically accelerated input model is interpreted at its “real time” scale.
+- A morphologically accelerated input model is interpreted at its real-time scale.
 - Looping and interpolation operate on the decompressed timeline.
 
 This keeps the Eulerian time base consistent with the Lagrangian integration when morphological acceleration has been applied to the input model output.

--- a/docs/user/simulations.md
+++ b/docs/user/simulations.md
@@ -119,3 +119,125 @@ sedtrails run -c ./config-example.yaml
 The simulation will start running, and a dashboard will open to show the progress. Close the dashboard window to get back to the terminal and see the simulation results.
 :::
 
+## Restarting a Simulation
+
+If a simulation is interrupted or needs to continue from a specific point, you can generate a restart configuration that uses the last valid particle positions from a previous run as seed points for a new simulation.
+
+### When to Use Restart
+
+The restart feature is useful when:
+- A long simulation crashes or is stopped before completion
+- You want to continue a simulation without losing progress
+- You need to extend a finished simulation with additional runtime
+- You want to restart from intermediate results to test different transport parameters
+
+### Prerequisites
+
+To restart a simulation, you need:
+1. A NetCDF output file from a previous SedTRAILS run (e.g., `sedtrails_results.nc`)
+2. The original simulation configuration file used to generate that output
+3. Both files must be accessible from your working directory
+
+### Generating a Restart Configuration
+
+The restart process automatically:
+- Extracts the **last valid particle position** for each particle in the NetCDF output
+- Filters particles to include only those that were alive and in-domain at their last position
+- **Computes remaining runtime** based on the original simulation duration and elapsed time (see "Edge Case - Full Completion" in [Notes and Tips](#notes-and-tips))
+- Generates per-population seed point CSV files
+- Creates a new YAML configuration file ready to run
+
+#### Command Syntax
+
+```bash
+sedtrails config restart -f <results_file> -c <base_config> -o <output_config> [--seed-dir <seed_directory>]
+```
+
+**Parameters:**
+- `-f, --file`: Path to the NetCDF results file from the previous run (default: `sedtrails_results.nc`)
+- `-c, --config`: Path to the original YAML configuration file (default: `sedtrails.yml`)
+- `-o, --output`: Path where the new restart YAML will be written (default: `sedtrails-restart.yaml`)
+- `--seed-dir`: (Optional) Custom directory for generated seed point CSV files. If not specified, defaults to `<output_config_directory>/<output_config_stem>_seeds/`
+
+#### Example: Basic Restart
+
+If your previous run output is in `./results/sedtrails_results.nc` and the config was `./examples/sedtrails-example.yaml`:
+
+```bash
+sedtrails config restart -f ./results/sedtrails_results.nc \
+                        -c ./examples/sedtrails-example.yaml \
+                        -o ./examples/restart.yaml
+```
+
+This command will:
+1. Read the last valid position of each particle from `sedtrails_results.nc`
+2. Calculate the elapsed time and remaining duration from the original run
+3. Generate seed point files in `./examples/restart_seeds/` (one CSV per population)
+4. Create `./examples/restart.yaml` with:
+   - Updated `time.start` set to when the restart will begin
+   - Adjusted `time.duration` set to the remaining time from the original run
+   - Each population's seeding strategy replaced with `file_points` referencing the generated CSV files
+
+#### Example Output
+
+The generated restart YAML will look similar to this:
+
+```yaml
+general:
+  input_model:
+    format: fm_netcdf
+    reference_date: '1970-01-01'
+    morfac: 1
+inputs:
+  data: ./sample-data/inlet_example.nc
+time:
+  start: '2016-09-27 03:22:48'          # Updated to last valid timestamp
+  timestep: 60S
+  duration: 4D15H57M12S                 # Adjusted to remaining time from original 10D run
+particles:
+  populations:
+  - name: population_1
+    particle_type: sand
+    seeding:
+      strategy:
+        file_points:
+          path: ./examples/restart_seeds/population_1.restart_points.csv
+          x_col: x
+          y_col: y
+          has_header: true
+```
+
+The seed point CSV files contain particle coordinates from the last valid timestep:
+
+```csv
+x,y
+40293.54196405,17547.72446346
+39626.62407569,17560.15080805
+40360.98655363,17704.94651676
+```
+
+### Running the Restart
+
+Once the restart configuration is generated, run it like any other simulation:
+
+```bash
+sedtrails run -c ./examples/restart.yaml
+```
+
+The new simulation will:
+- Start from the particle positions saved in the seed point files
+- Use the adjusted `time.duration` to simulate only the remaining time
+- Output results to the same or a different output directory (configured in the restart YAML)
+
+### Notes and Tips
+
+- **Particle Retention**: Only particles that were alive and within the domain at their last position are included in the restart. Particles that escaped the domain or were trapped will not be restarted.
+
+- **Reference Date Handling**: If your original configuration used `general.input_model.reference_date`, the restart timing is automatically computed correctly using that reference date.
+
+- **Relative Paths**: Generated seed file paths in the restart YAML are relative to the current working directory (using `./` prefix). Make sure to run the restart from the same directory where the YAML was generated, or update the paths accordingly.
+
+- **Duration Precision**: The remaining duration is calculated to second precision and formatted in SedTRAILS duration syntax (e.g., `4D15H57M12S` = 4 days, 15 hours, 57 minutes, 12 seconds).
+
+- **Edge Case - Full Completion**: If the output file shows that the original simulation ran to completion (all particles reached the end time), the restart will report "No remaining duration left" and decline to create a restart file.
+

--- a/docs/user/simulations.md
+++ b/docs/user/simulations.md
@@ -233,7 +233,9 @@ The new simulation will:
 
 - **Particle Retention**: Only particles that were alive and within the domain at their last position are included in the restart. Particles that escaped the domain or were trapped will not be restarted.
 
-- **Reference Date Handling**: If your original configuration used `general.input_model.reference_date`, the restart timing is automatically computed correctly using that reference date.
+- **Reference Date Handling**: If your original configuration used `general.input_model.reference_date`, the restart YAML preserves that reference date and computes `time.start` from output times using the same time origin. Newer output files can also provide explicit `reference_date` or `time_units` metadata.
+
+- **Forcing Window Validation**: A generated restart must start inside the original input forcing window. If the output time would create a restart such as `1970-01-01 04:16:40` for forcing that starts in 2016, restart generation raises an error instead of writing an invalid YAML.
 
 - **Relative Paths**: Generated seed file paths in the restart YAML are relative to the current working directory (using `./` prefix). Make sure to run the restart from the same directory where the YAML was generated, or update the paths accordingly.
 

--- a/examples/sedtrails-example.yaml
+++ b/examples/sedtrails-example.yaml
@@ -4,8 +4,9 @@ general:
     reference_date: 1970-01-01  # Default reference date for the input model
     morfac: 1  # Morphological acceleration factor for time decompression
 inputs:
-  data: ./sample-data/inlet_sedtrails.nc
+  data: ./sample-data/inlet_example.nc
   read_interval: 10D  # Time chunk size for reading input data
+  repeat_eulerian_fields: true  # Whether to repeat the last available Eulerian fields when the simulation time exceeds the input data time range
 time:
   start:  2016-09-21 19:20:00
   timestep: 60S

--- a/examples/sedtrails-example.yaml
+++ b/examples/sedtrails-example.yaml
@@ -6,7 +6,7 @@ general:
 inputs:
   data: ./sample-data/inlet_example.nc
   read_interval: 10D  # Time chunk size for reading input data
-  repeat_eulerian_fields: true  # Whether to repeat the last available Eulerian fields when the simulation time exceeds the input data time range
+  repeat_eulerian_fields: true  # Repeat forcing after a valid start inside the input time range
 time:
   start:  2016-09-21 19:20:00
   timestep: 60S

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,4 +86,5 @@ markers = ["integration: mark a test as an integration test."]
 filterwarnings = [
   'ignore:.*:pyparsing.warnings.PyparsingDeprecationWarning:matplotlib\._fontconfig_pattern',
   'ignore:.*:pyparsing.warnings.PyparsingDeprecationWarning:matplotlib\._mathtext',
+  'ignore:numpy\.ndarray size changed, may indicate binary incompatibility\..*:RuntimeWarning',
 ]

--- a/src/sedtrails/__init__.py
+++ b/src/sedtrails/__init__.py
@@ -39,6 +39,7 @@ from .application_interfaces.api import (
     load_configuration,
     validate_configuration,
     create_config_template,
+    create_restart_config,
     # Visualization
     plot_trajectories,
     inspect_netcdf,
@@ -61,6 +62,7 @@ __all__ = [
     'load_configuration',
     'validate_configuration',
     'create_config_template',
+    'create_restart_config',
     # Visualization
     'plot_trajectories',
     'inspect_netcdf',

--- a/src/sedtrails/application_interfaces/api.py
+++ b/src/sedtrails/application_interfaces/api.py
@@ -208,6 +208,23 @@ def create_config_template(output_file: str = './sedtrails-template.yml') -> Non
     validator.create_config_template(output_file)
 
 
+def create_restart_config(
+    results_file: str,
+    base_config_file: str,
+    output_config_file: str = 'sedtrails-restart.yaml',
+    seed_points_dir: str | None = None,
+) -> 'RestartSummary':
+    """Create a restart-ready YAML and seeding files from NetCDF output."""
+    from sedtrails.application_interfaces.restart import create_restart_from_netcdf
+
+    return create_restart_from_netcdf(
+        netcdf_file=results_file,
+        base_config_file=base_config_file,
+        output_config_file=output_config_file,
+        seed_points_dir=seed_points_dir,
+    )
+
+
 # ============================================================================
 # Visualization Functions
 # ============================================================================
@@ -494,6 +511,7 @@ __all__ = [
     'load_configuration',
     'validate_configuration',
     'create_config_template',
+    'create_restart_config',
     # Visualization
     'plot_trajectories',
     'inspect_netcdf',

--- a/src/sedtrails/application_interfaces/api.py
+++ b/src/sedtrails/application_interfaces/api.py
@@ -14,6 +14,8 @@ programmatically rather than through the CLI.
 import logging
 from typing import Any, Dict, Optional
 
+from sedtrails.application_interfaces.restart import RestartSummary, create_restart_from_netcdf
+
 from .nc_inspector import NetCDFInspector
 
 # ============================================================================
@@ -213,9 +215,52 @@ def create_restart_config(
     base_config_file: str,
     output_config_file: str = 'sedtrails-restart.yaml',
     seed_points_dir: str | None = None,
-) -> 'RestartSummary':
-    """Create a restart-ready YAML and seeding files from NetCDF output."""
-    from sedtrails.application_interfaces.restart import create_restart_from_netcdf
+) -> RestartSummary:
+    """
+    Create a restart-ready configuration from SedTRAILS NetCDF output.
+
+    This function writes a new YAML configuration file and per-population seed
+    point files using the last valid particle positions in an existing results
+    file. The generated configuration can be used to continue a completed or
+    interrupted simulation from the retained particle locations.
+
+    Parameters
+    ----------
+    results_file : str
+        Path to the SedTRAILS NetCDF results file to restart from.
+    base_config_file : str
+        Path to the original SedTRAILS configuration YAML file.
+    output_config_file : str, optional
+        Path where the restart configuration file will be written.
+        Default is 'sedtrails-restart.yaml'.
+    seed_points_dir : str or None, optional
+        Directory where restart seed point CSV files will be written. If None,
+        a directory is created next to ``output_config_file``.
+
+    Returns
+    -------
+    RestartSummary
+        Summary of the generated restart configuration, seed files, restart
+        time, and number of retained particles.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``results_file`` or ``base_config_file`` does not exist.
+    ValueError
+        If the input files do not contain the data required to build restart
+        files, or no valid particles remain for restart seeding.
+
+    Examples
+    --------
+    >>> import sedtrails
+    >>> summary = sedtrails.create_restart_config(
+    ...     'results.nc',
+    ...     'config.yml',
+    ...     output_config_file='restart.yml',
+    ... )
+    >>> print(summary.output_config)
+    """
 
     return create_restart_from_netcdf(
         netcdf_file=results_file,

--- a/src/sedtrails/application_interfaces/api.py
+++ b/src/sedtrails/application_interfaces/api.py
@@ -11,10 +11,10 @@ This is the primary interface for Python users who want to use SedTRAILS
 programmatically rather than through the CLI.
 """
 
-from typing import Any, Dict, Optional
 import logging
-from .nc_inspector import NetCDFInspector
+from typing import Any, Dict, Optional
 
+from .nc_inspector import NetCDFInspector
 
 # ============================================================================
 # Simulation Functions
@@ -60,8 +60,8 @@ def run_simulation(
     >>> # Run with dashboard enabled regardless of config
     >>> sedtrails.run_simulation('config.yml', enable_dashboard=True)
     """
-    from sedtrails.simulation_orchestrator.simulation_manager import Simulation
     from sedtrails.exceptions.exceptions import ConfigurationError
+    from sedtrails.simulation_orchestrator.simulation_manager import Simulation
 
     # Set up logging if verbose
     if verbose:
@@ -256,7 +256,8 @@ def plot_trajectories(
     >>> # Display without saving
     >>> sedtrails.plot_trajectories('results.nc')
     """
-    from sedtrails.pathway_visualizer import plot_trajectories as _plot, read_netcdf
+    from sedtrails.pathway_visualizer import plot_trajectories as _plot
+    from sedtrails.pathway_visualizer import read_netcdf
 
     ds = read_netcdf(results_file)
     _plot(ds, save_plot=save, output_dir=output_dir)

--- a/src/sedtrails/application_interfaces/cli/main.py
+++ b/src/sedtrails/application_interfaces/cli/main.py
@@ -209,6 +209,52 @@ def seeding_gui_cmd(
         raise typer.Exit(code=1) from e
     except Exception as e:
         typer.echo(f'Unexpected error opening seeding GUI: {e}')
+
+
+@config_app.command('restart')
+def create_restart_config_cmd(
+    results_file: str = typer.Option(
+        'sedtrails_results.nc',
+        '--file',
+        '-f',
+        help='Path to the SedTRAILS netCDF results file.',
+    ),
+    base_config_file: str = typer.Option(
+        'sedtrails.yml',
+        '--config',
+        '-c',
+        help='Path to the original SedTRAILS configuration file.',
+    ),
+    output_config_file: str = typer.Option(
+        'sedtrails-restart.yaml',
+        '--output',
+        '-o',
+        help='Path to write the generated restart YAML file.',
+    ),
+    seed_points_dir: str = typer.Option(
+        None,
+        '--seed-dir',
+        help='Optional directory for generated restart seed point files.',
+    ),
+):
+    """Create a restart YAML and point files from a partial/full NetCDF output."""
+    from sedtrails.application_interfaces.api import create_restart_config
+
+    try:
+        summary = create_restart_config(
+            results_file=results_file,
+            base_config_file=base_config_file,
+            output_config_file=output_config_file,
+            seed_points_dir=seed_points_dir,
+        )
+        typer.echo(f"Restart config written to '{summary.output_config}'")
+        typer.echo(f"Restart time set to '{summary.restart_time}'")
+        typer.echo(f"Retained particles: {summary.retained_particles}")
+        typer.echo('Generated seed point files:')
+        for population_name, path in summary.seed_files.items():
+            typer.echo(f'  - {population_name}: {path}')
+    except Exception as e:
+        typer.echo(f'Error creating restart config: {e}')
         raise typer.Exit(code=1) from e
 
 

--- a/src/sedtrails/application_interfaces/restart.py
+++ b/src/sedtrails/application_interfaces/restart.py
@@ -243,6 +243,7 @@ def create_restart_from_netcdf(
                     'x_col': 'x',
                     'y_col': 'y',
                     'has_header': True,
+                    'deduplicate': False,
                 }
             }
 

--- a/src/sedtrails/application_interfaces/restart.py
+++ b/src/sedtrails/application_interfaces/restart.py
@@ -200,6 +200,30 @@ def _seconds_to_duration_string(total_seconds: int) -> str:
     return ''.join(parts) if parts else '0S'
 
 
+def _open_restart_dataset(netcdf_path: Path) -> xr.Dataset:
+    """Open a SedTRAILS result NetCDF without xarray backend plugin discovery."""
+    return xr.open_dataset(netcdf_path, engine='netcdf4')
+
+
+def _validate_restart_dataset_schema(ds: xr.Dataset, netcdf_path: Path) -> None:
+    """Validate that the input file has the particle trajectory fields needed for restart."""
+    missing = [name for name in ('x', 'y') if name not in ds]
+    if not missing:
+        return
+
+    available = ', '.join(map(str, list(ds.data_vars)[:10])) or 'none'
+    if len(ds.data_vars) > 10:
+        available = f'{available}, ...'
+    raise ValueError(
+        f"'{netcdf_path}' is not a SedTRAILS trajectory output file. "
+        "Restart generation expects the NetCDF file written by `sedtrails run` "
+        "(usually `results/sedtrails_results.nc`) passed with `--file`. "
+        f"Missing required particle variable(s): {', '.join(missing)}. "
+        f'Available data variables: {available}. '
+        'Eulerian forcing files belong in `inputs.data` of the base config, not in `--file`.'
+    )
+
+
 def create_restart_from_netcdf(
     netcdf_file: str,
     base_config_file: str,
@@ -232,10 +256,9 @@ def create_restart_from_netcdf(
     if not populations:
         raise ValueError('Base configuration has no particles.populations entries.')
 
-    ds = xr.open_dataset(netcdf_path)
+    ds = _open_restart_dataset(netcdf_path)
     try:
-        if 'x' not in ds or 'y' not in ds:
-            raise ValueError("NetCDF output must contain 'x' and 'y' variables.")
+        _validate_restart_dataset_schema(ds, netcdf_path)
 
         x_data = np.asarray(ds['x'].values, dtype=float)
         y_data = np.asarray(ds['y'].values, dtype=float)

--- a/src/sedtrails/application_interfaces/restart.py
+++ b/src/sedtrails/application_interfaces/restart.py
@@ -1,0 +1,266 @@
+"""Utilities to build restart inputs from a SedTRAILS NetCDF output file."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+import os
+from typing import Any
+
+import numpy as np
+import xarray as xr
+import yaml
+
+from sedtrails.application_interfaces.validator import SedtrailsYamlLoader
+from sedtrails.particle_tracer.timer import convert_duration_string_to_seconds
+
+
+@dataclass
+class RestartSummary:
+    """Summary of artifacts generated for a restart configuration."""
+
+    output_config: Path
+    seed_files: dict[str, Path]
+    restart_time: str
+    retained_particles: int
+
+
+def _to_datetime(value: Any) -> datetime:
+    if isinstance(value, datetime):
+        return value
+    if value is None:
+        raise ValueError('Missing time.start in base configuration.')
+    return datetime.fromisoformat(str(value))
+
+
+def _format_datetime(value: datetime) -> str:
+    return value.strftime('%Y-%m-%d %H:%M:%S')
+
+
+def _infer_restart_datetime(config: dict[str, Any], restart_seconds: float | None) -> datetime:
+    """Infer restart datetime from NetCDF time semantics and config."""
+    base_start = _to_datetime(config.get('time', {}).get('start'))
+    if restart_seconds is None:
+        return base_start
+
+    reference_date_value = config.get('general', {}).get('input_model', {}).get('reference_date')
+    if reference_date_value is not None:
+        reference_date = _to_datetime(reference_date_value)
+        return reference_date + timedelta(seconds=restart_seconds)
+
+    # Heuristic fallback: very large values usually indicate absolute epoch seconds.
+    if restart_seconds > 1.0e8:
+        return datetime.fromtimestamp(restart_seconds)
+
+    return base_start + timedelta(seconds=restart_seconds)
+
+
+def _last_valid_index_per_particle(x_data: np.ndarray, y_data: np.ndarray) -> np.ndarray:
+    valid_xy = np.isfinite(x_data) & np.isfinite(y_data)
+    has_valid = valid_xy.any(axis=1)
+    indices = np.full(x_data.shape[0], -1, dtype=int)
+    if np.any(has_valid):
+        rev_idx = np.argmax(valid_xy[:, ::-1], axis=1)
+        indices[has_valid] = x_data.shape[1] - 1 - rev_idx[has_valid]
+    return indices
+
+
+def _path_relative_to_cwd(path: Path) -> str:
+    """Return path as POSIX text relative to current working directory when possible."""
+    try:
+        relative = Path(os.path.relpath(path.resolve(), Path.cwd().resolve()))
+    except ValueError:
+        # Different drives on Windows cannot be relativized.
+        return str(path.resolve()).replace('\\', '/')
+
+    text = str(relative).replace('\\', '/')
+    if not relative.is_absolute() and not text.startswith(('.', '..')):
+        text = f'./{text}'
+    return text
+
+
+def _seconds_to_duration_string(total_seconds: int) -> str:
+    """Convert seconds to a compact SedTRAILS duration string (e.g., 1D2H30M)."""
+    if total_seconds <= 0:
+        return '0S'
+
+    remaining = int(total_seconds)
+    days, remaining = divmod(remaining, 86400)
+    hours, remaining = divmod(remaining, 3600)
+    minutes, seconds = divmod(remaining, 60)
+
+    parts = []
+    if days:
+        parts.append(f'{days}D')
+    if hours:
+        parts.append(f'{hours}H')
+    if minutes:
+        parts.append(f'{minutes}M')
+    if seconds:
+        parts.append(f'{seconds}S')
+
+    return ''.join(parts) if parts else '0S'
+
+
+def create_restart_from_netcdf(
+    netcdf_file: str,
+    base_config_file: str,
+    output_config_file: str = 'sedtrails-restart.yaml',
+    seed_points_dir: str | None = None,
+) -> RestartSummary:
+    """Create a restart YAML and per-population seed files from NetCDF output.
+
+    The generated configuration keeps existing settings from ``base_config_file`` but
+    replaces each population seeding strategy with ``file_points`` using particle
+    coordinates from the last valid timestep for each particle in ``netcdf_file``.
+    """
+
+    netcdf_path = Path(netcdf_file)
+    config_path = Path(base_config_file)
+    output_path = Path(output_config_file)
+
+    if not netcdf_path.is_file():
+        raise FileNotFoundError(f'NetCDF file not found: {netcdf_path}')
+    if not config_path.is_file():
+        raise FileNotFoundError(f'Base configuration file not found: {config_path}')
+
+    with open(config_path, 'r', encoding='utf-8') as handle:
+        config = yaml.load(handle, Loader=SedtrailsYamlLoader)
+
+    if not isinstance(config, dict):
+        raise ValueError('Base configuration must parse to a dictionary.')
+
+    populations = config.get('particles', {}).get('populations', [])
+    if not populations:
+        raise ValueError('Base configuration has no particles.populations entries.')
+
+    ds = xr.open_dataset(netcdf_path)
+    try:
+        if 'x' not in ds or 'y' not in ds:
+            raise ValueError("NetCDF output must contain 'x' and 'y' variables.")
+
+        x_data = np.asarray(ds['x'].values, dtype=float)
+        y_data = np.asarray(ds['y'].values, dtype=float)
+        if x_data.ndim != 2 or y_data.ndim != 2:
+            raise ValueError("Expected 'x' and 'y' to be 2D arrays (n_particles, n_timesteps).")
+
+        n_particles = x_data.shape[0]
+
+        if 'population_id' in ds:
+            pop_ids = np.asarray(ds['population_id'].values).astype(int)
+        else:
+            pop_ids = np.zeros(n_particles, dtype=int)
+
+        if pop_ids.shape[0] != n_particles:
+            raise ValueError("'population_id' length does not match number of particles.")
+
+        last_indices = _last_valid_index_per_particle(x_data, y_data)
+
+        alive_mask = np.ones(n_particles, dtype=bool)
+        if 'status_alive' in ds:
+            alive = np.asarray(ds['status_alive'].values)
+            for particle_idx, timestep_idx in enumerate(last_indices):
+                if timestep_idx >= 0:
+                    alive_mask[particle_idx] = bool(alive[particle_idx, timestep_idx])
+
+        in_domain_mask = np.ones(n_particles, dtype=bool)
+        if 'status_domain' in ds:
+            status_domain = np.asarray(ds['status_domain'].values)
+            for particle_idx, timestep_idx in enumerate(last_indices):
+                if timestep_idx >= 0:
+                    in_domain_mask[particle_idx] = bool(status_domain[particle_idx, timestep_idx])
+
+        keep_mask = (last_indices >= 0) & alive_mask & in_domain_mask
+        if not np.any(keep_mask):
+            raise ValueError('No valid particle positions available to seed restart.')
+
+        time_values = None
+        if 'time' in ds:
+            time_values = np.asarray(ds['time'].values, dtype=float)
+
+        restart_seconds = None
+        if time_values is not None and time_values.ndim == 2:
+            selected_times = np.array(
+                [time_values[i, last_indices[i]] for i in range(n_particles) if keep_mask[i]],
+                dtype=float,
+            )
+            finite_times = selected_times[np.isfinite(selected_times)]
+            if finite_times.size:
+                restart_seconds = float(np.max(finite_times))
+
+        restart_dt = _infer_restart_datetime(config, restart_seconds)
+        restart_time = _format_datetime(restart_dt)
+
+        original_duration = config.get('time', {}).get('duration')
+        if original_duration is None:
+            raise ValueError('Missing time.duration in base configuration.')
+        original_duration_seconds = convert_duration_string_to_seconds(str(original_duration))
+
+        original_start = _to_datetime(config.get('time', {}).get('start'))
+        elapsed_seconds = max(0, int((restart_dt - original_start).total_seconds()))
+        remaining_seconds = max(0, original_duration_seconds - elapsed_seconds)
+        if remaining_seconds <= 0:
+            raise ValueError('No remaining duration left in original run. Restart is not needed.')
+        remaining_duration = _seconds_to_duration_string(remaining_seconds)
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        if seed_points_dir is None:
+            seeds_dir = output_path.parent / f'{output_path.stem}_seeds'
+        else:
+            seeds_dir = Path(seed_points_dir)
+        seeds_dir.mkdir(parents=True, exist_ok=True)
+
+        seed_files: dict[str, Path] = {}
+
+        for pop_idx, population in enumerate(populations):
+            pop_name = str(population.get('name', f'population_{pop_idx + 1}'))
+
+            selected = [
+                (float(x_data[i, last_indices[i]]), float(y_data[i, last_indices[i]]))
+                for i in range(n_particles)
+                if keep_mask[i] and int(pop_ids[i]) == pop_idx
+            ]
+
+            if not selected:
+                continue
+
+            points_file = seeds_dir / f'{pop_name}.restart_points.csv'
+            with open(points_file, 'w', encoding='utf-8') as handle:
+                handle.write('x,y\n')
+                for x_coord, y_coord in selected:
+                    handle.write(f'{x_coord:.8f},{y_coord:.8f}\n')
+
+            population.setdefault('seeding', {})
+            population['seeding']['release_start'] = restart_time
+            population['seeding']['quantity'] = 1
+            population['seeding']['strategy'] = {
+                'file_points': {
+                    'path': _path_relative_to_cwd(points_file),
+                    'x_col': 'x',
+                    'y_col': 'y',
+                    'has_header': True,
+                }
+            }
+
+            seed_files[pop_name] = points_file
+
+        if not seed_files:
+            raise ValueError('No populations had active particles to include in restart files.')
+
+        config.setdefault('time', {})
+        config['time']['start'] = restart_time
+        config['time']['duration'] = remaining_duration
+
+        with open(output_path, 'w', encoding='utf-8') as handle:
+            yaml.safe_dump(config, handle, sort_keys=False)
+
+        retained_particles = int(np.count_nonzero(keep_mask))
+        return RestartSummary(
+            output_config=output_path,
+            seed_files=seed_files,
+            restart_time=restart_time,
+            retained_particles=retained_particles,
+        )
+    finally:
+        ds.close()

--- a/src/sedtrails/application_interfaces/restart.py
+++ b/src/sedtrails/application_interfaces/restart.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
 import os
+import re
 from typing import Any
 
 import numpy as np
@@ -14,6 +15,7 @@ import yaml
 
 from sedtrails.application_interfaces.validator import SedtrailsYamlLoader
 from sedtrails.particle_tracer.timer import convert_duration_string_to_seconds
+from sedtrails.transport_converter.format_converter import FormatConverter
 
 
 @dataclass
@@ -31,22 +33,69 @@ def _to_datetime(value: Any) -> datetime:
         return value
     if value is None:
         raise ValueError('Missing time.start in base configuration.')
-    return datetime.fromisoformat(str(value))
+    text = str(value).strip()
+    if text.endswith('Z'):
+        text = text[:-1]
+    return datetime.fromisoformat(text)
 
 
 def _format_datetime(value: datetime) -> str:
     return value.strftime('%Y-%m-%d %H:%M:%S')
 
 
-def _infer_restart_datetime(config: dict[str, Any], restart_seconds: float | None) -> datetime:
+def _config_reference_date(config: dict[str, Any], default: str | None = None) -> datetime | None:
+    reference_date_value = config.get('general', {}).get('input_model', {}).get('reference_date', default)
+    if reference_date_value is None:
+        return None
+    return _to_datetime(reference_date_value)
+
+
+def _parse_time_units_reference_date(units: Any) -> datetime | None:
+    if units is None:
+        return None
+
+    match = re.match(r'^\s*seconds\s+since\s+(.+?)\s*$', str(units), flags=re.IGNORECASE)
+    if not match:
+        return None
+
+    return _to_datetime(match.group(1))
+
+
+def _dataset_reference_date(ds: xr.Dataset, config: dict[str, Any]) -> datetime | None:
+    """Return the reference date used by output time values."""
+    for attr_name in ('reference_date', 'time_reference_date'):
+        if attr_name in ds.attrs:
+            return _to_datetime(ds.attrs[attr_name])
+
+    for attr_name in ('time_units', 'units'):
+        reference_date = _parse_time_units_reference_date(ds.attrs.get(attr_name))
+        if reference_date is not None:
+            return reference_date
+
+    if 'time' in ds:
+        for attr_name in ('time_units', 'units'):
+            reference_date = _parse_time_units_reference_date(ds['time'].attrs.get(attr_name))
+            if reference_date is not None:
+                return reference_date
+
+    return _config_reference_date(config)
+
+
+def _infer_restart_datetime(
+    config: dict[str, Any],
+    restart_seconds: float | None,
+    dataset_reference_date: datetime | None = None,
+) -> datetime:
     """Infer restart datetime from NetCDF time semantics and config."""
     base_start = _to_datetime(config.get('time', {}).get('start'))
     if restart_seconds is None:
         return base_start
 
-    reference_date_value = config.get('general', {}).get('input_model', {}).get('reference_date')
-    if reference_date_value is not None:
-        reference_date = _to_datetime(reference_date_value)
+    if dataset_reference_date is not None:
+        return dataset_reference_date + timedelta(seconds=restart_seconds)
+
+    reference_date = _config_reference_date(config)
+    if reference_date is not None:
         return reference_date + timedelta(seconds=restart_seconds)
 
     # Heuristic fallback: very large values usually indicate absolute epoch seconds.
@@ -54,6 +103,54 @@ def _infer_restart_datetime(config: dict[str, Any], restart_seconds: float | Non
         return datetime.utcfromtimestamp(restart_seconds)
 
     return base_start + timedelta(seconds=restart_seconds)
+
+
+def _restart_format_config(config: dict[str, Any], config_path: Path) -> dict[str, Any] | None:
+    input_model = config.get('general', {}).get('input_model', {})
+    inputs = config.get('inputs', {})
+    input_file = inputs.get('data')
+    input_format = input_model.get('format')
+    if not input_file or not input_format:
+        return None
+
+    input_path = Path(str(input_file))
+    if not input_path.is_absolute():
+        input_path = config_path.parent / input_path
+
+    return {
+        'input_file': str(input_path),
+        'input_format': input_format,
+        'reference_date': input_model.get('reference_date', '1970-01-01'),
+        'morfac': input_model.get('morfac', 1.0),
+    }
+
+
+def _validate_restart_time_matches_input(
+    config: dict[str, Any],
+    config_path: Path,
+    restart_dt: datetime,
+) -> None:
+    """Validate that the generated restart start is covered by the original forcing."""
+    format_config = _restart_format_config(config, config_path)
+    if format_config is None:
+        return
+
+    reference_date = _config_reference_date(config, default='1970-01-01')
+    if reference_date is None:
+        return
+
+    forcing_start, forcing_end = FormatConverter(format_config).get_time_bounds()
+    restart_seconds = (restart_dt - reference_date).total_seconds()
+    if forcing_start <= restart_seconds <= forcing_end:
+        return
+
+    restart_time = _format_datetime(restart_dt)
+    raise ValueError(
+        f'Restart time {restart_time} ({restart_seconds:.3f}s since reference_date '
+        f'{_format_datetime(reference_date)}) is outside the original input forcing window '
+        f'[{forcing_start:.3f}, {forcing_end:.3f}]s. '
+        'The generated restart would start before or after available forcing data.'
+    )
 
 
 def _last_valid_index_per_particle(x_data: np.ndarray, y_data: np.ndarray) -> np.ndarray:
@@ -189,7 +286,8 @@ def create_restart_from_netcdf(
             if finite_times.size:
                 restart_seconds = float(np.max(finite_times))
 
-        restart_dt = _infer_restart_datetime(config, restart_seconds)
+        restart_dt = _infer_restart_datetime(config, restart_seconds, _dataset_reference_date(ds, config))
+        _validate_restart_time_matches_input(config, config_path, restart_dt)
         restart_time = _format_datetime(restart_dt)
 
         original_duration = config.get('time', {}).get('duration')

--- a/src/sedtrails/application_interfaces/restart.py
+++ b/src/sedtrails/application_interfaces/restart.py
@@ -51,7 +51,7 @@ def _infer_restart_datetime(config: dict[str, Any], restart_seconds: float | Non
 
     # Heuristic fallback: very large values usually indicate absolute epoch seconds.
     if restart_seconds > 1.0e8:
-        return datetime.fromtimestamp(restart_seconds)
+        return datetime.utcfromtimestamp(restart_seconds)
 
     return base_start + timedelta(seconds=restart_seconds)
 

--- a/src/sedtrails/application_interfaces/restart.py
+++ b/src/sedtrails/application_interfaces/restart.py
@@ -222,7 +222,12 @@ def create_restart_from_netcdf(
                 if keep_mask[i] and int(pop_ids[i]) == pop_idx
             ]
 
+            population.setdefault('seeding', {})
+            population['seeding']['release_start'] = restart_time
+
             if not selected:
+                # Disable seeding for this population on restart (avoid reseeding new particles).
+                population['seeding']['quantity'] = 0
                 continue
 
             points_file = seeds_dir / f'{pop_name}.restart_points.csv'
@@ -231,8 +236,6 @@ def create_restart_from_netcdf(
                 for x_coord, y_coord in selected:
                     handle.write(f'{x_coord:.8f},{y_coord:.8f}\n')
 
-            population.setdefault('seeding', {})
-            population['seeding']['release_start'] = restart_time
             population['seeding']['quantity'] = 1
             population['seeding']['strategy'] = {
                 'file_points': {

--- a/src/sedtrails/particle_tracer/particle_seeder.py
+++ b/src/sedtrails/particle_tracer/particle_seeder.py
@@ -38,6 +38,7 @@ class HasFieldCoordinates(Protocol):
 
 DEFAULT_REFERENCE_DATE = '1970-01-01 00:00:00'
 DEFAULT_RELEASE_START = '__SIMULATION_START__'
+MISSING = object()
 
 
 def _release_time_to_seconds(release_time: str | int | float, reference_date: str | np.datetime64) -> float:
@@ -118,8 +119,8 @@ class PopulationConfig:
         self.strategy_settings = find_value(self.population_config, f'seeding.strategy.{self.strategy}', {})
         if not self.strategy_settings:
             raise MissingConfigurationParameter(f'"{self.strategy}" settings are not defined in the configuration.')
-        _quantity = find_value(self.population_config, 'seeding.quantity', {})
-        if not _quantity:
+        _quantity = find_value(self.population_config, 'seeding.quantity', MISSING)
+        if _quantity is MISSING:
             raise MissingConfigurationParameter('"quantity" is not defined as seeding parameter.')
         self.quantity = _quantity
         _release_start = find_value(self.population_config, 'seeding.release_start', None)
@@ -461,6 +462,9 @@ class ParticleFactory:
             raise ValueError(f'Unknown seeding strategy: {strategy_name}')
         StrategyClass = STRATEGY_MAP[strategy_name.lower()]
 
+        if int(config.quantity) <= 0:
+            return []
+
         # computes seeding positions using the strategy in config
         burial_depth = getattr(config, 'burial_depth', None)
         positions = StrategyClass.seed(config)
@@ -625,6 +629,9 @@ class ParticlePopulation:
         Currently, it does not perform any operations.
         """
 
+        if len(self.particles['x']) == 0:
+            return
+
         # Initialize vertical position ('z') based on bed level and burial depth
         self.particles['z'] = (
             self.particles['bed_level'] - self.particles['burial_depth']
@@ -642,6 +649,17 @@ class ParticlePopulation:
         updates status of particles in the population.
         """
         n_particles = len(self.particles['x'])
+        if n_particles == 0:
+            for status_name in (
+                'status_alive',
+                'status_buried',
+                'status_domain',
+                'status_released',
+                'status_transported',
+                'status_mobile',
+            ):
+                self.particles[status_name] = np.zeros(0, dtype=bool)
+            return
 
         # Compute whether particles are transported (or trapped) based on transport probability
         # Note: If "reduced_velocity" is chosen, "transport_probability" always equals one.
@@ -693,6 +711,9 @@ class ParticlePopulation:
             The current time step in the simulation in seconds.
 
         """
+
+        if len(self.particles['x']) == 0:
+            return
 
         ix = self.particles['status_mobile']  # Get indices of mobile particles
         particle_indices = np.flatnonzero(ix)

--- a/src/sedtrails/pathway_visualizer/trajectories.py
+++ b/src/sedtrails/pathway_visualizer/trajectories.py
@@ -8,6 +8,36 @@ import matplotlib.pyplot as plt
 import xarray as xr
 
 
+def _decode_netcdf_name(raw_value) -> str:
+    """Decode a NetCDF string value stored as bytes, fixed-width bytes, or char arrays."""
+    if raw_value is None:
+        return ''
+
+    if isinstance(raw_value, str):
+        return raw_value.strip()
+
+    if isinstance(raw_value, (bytes, np.bytes_)):
+        return raw_value.decode('utf-8', errors='ignore').strip('\x00').strip()
+
+    arr = np.asarray(raw_value)
+
+    # Char-array representation (e.g., dtype='|S1' with trailing nulls)
+    if arr.ndim > 0 and arr.size > 0 and arr.dtype.kind in ('S', 'U'):
+        flattened = arr.ravel().tolist()
+        chars = []
+        for item in flattened:
+            if isinstance(item, (bytes, np.bytes_)):
+                text = item.decode('utf-8', errors='ignore')
+            else:
+                text = str(item)
+            text = text.replace('\x00', '')
+            if text:
+                chars.append(text)
+        return ''.join(chars).strip()
+
+    return str(raw_value).strip()
+
+
 def read_netcdf(results_file_path: Path) -> xr.Dataset:
     """Read a SedTRAILS NetCDF file and return the xarray Dataset.
 
@@ -51,10 +81,21 @@ def plot_trajectories(ds, save_plot=False, output_dir=None):
     # Get population names
     population_names = []
     if 'population_name' in ds:
-        for i in range(n_populations):
-            name_bytes = ds['population_name'][i, :].values
-            name = ''.join([char.decode('utf-8') for char in name_bytes if char != b'\x00']).strip()
-            population_names.append(name)
+        population_var = ds['population_name']
+        n_available_names = int(population_var.sizes.get('n_populations', population_var.shape[0]))
+        n_to_decode = min(n_populations, n_available_names)
+
+        for i in range(n_to_decode):
+            # Handle both 1D fixed-width strings and 2D character arrays
+            if population_var.ndim == 1:
+                raw_name = population_var[i].values
+            else:
+                raw_name = population_var[i, :].values
+            decoded = _decode_netcdf_name(raw_name)
+            population_names.append(decoded or f'Population {i}')
+
+        if len(population_names) < n_populations:
+            population_names.extend([f'Population {i}' for i in range(len(population_names), n_populations)])
     else:
         population_names = [f'Population {i}' for i in range(n_populations)]
 
@@ -136,7 +177,7 @@ def plot_trajectories(ds, save_plot=False, output_dir=None):
     ax2.set_ylabel('Distance from Initial Position [m]')
 
     # Find the minimum time across all particles to use as reference
-    min_time = np.nanmin(time_data)
+    min_time = np.nanmin(time_data) if np.any(np.isfinite(time_data)) else 0.0
 
     for i in range(n_particles):
         # Calculate distance from initial position for each timestep

--- a/src/sedtrails/pathway_visualizer/trajectories.py
+++ b/src/sedtrails/pathway_visualizer/trajectories.py
@@ -109,7 +109,7 @@ def plot_trajectories(ds, save_plot=False, output_dir=None):
 
     # Plot each particle trajectory
     try:
-        cmap = plt.cm.get_cmap('viridis')
+        cmap = plt.get_cmap('viridis')
         colors = cmap(np.linspace(0, 1, n_particles))
     except (AttributeError, ValueError):
         # Fallback to a basic color cycle
@@ -118,7 +118,7 @@ def plot_trajectories(ds, save_plot=False, output_dir=None):
 
     # Define colors for populations
     try:
-        pop_cmap = plt.cm.get_cmap('Set1')
+        pop_cmap = plt.get_cmap('Set1')
         pop_colors = pop_cmap(np.linspace(0, 1, n_populations))
     except (AttributeError, ValueError):
         # Fallback to basic colors
@@ -132,7 +132,7 @@ def plot_trajectories(ds, save_plot=False, output_dir=None):
 
     # Plot each particle trajectory
     try:
-        cmap = plt.cm.get_cmap('viridis')
+        cmap = plt.get_cmap('viridis')
         colors = cmap(np.linspace(0, 1, n_particles))
     except (AttributeError, ValueError):
         # Fallback to a basic color cycle

--- a/src/sedtrails/simulation_orchestrator/simulation_manager.py
+++ b/src/sedtrails/simulation_orchestrator/simulation_manager.py
@@ -299,6 +299,123 @@ class Simulation:
 
         return start + ((current_time_seconds - start) % cycle_duration)
 
+    @staticmethod
+    def _validate_simulation_start_matches_input(
+        simulation_time: Time,
+        input_time_bounds: tuple[float, float] | None,
+    ) -> None:
+        """Validate that the configured simulation start is covered by forcing data."""
+        if input_time_bounds is None:
+            return
+
+        forcing_start, forcing_end = input_time_bounds
+        simulation_start = float(simulation_time.start)
+        if forcing_start <= simulation_start <= forcing_end:
+            return
+
+        configured_start = getattr(simulation_time, '_start', str(simulation_start))
+        raise ConfigurationError(
+            'time.start must be within the input forcing window. '
+            f'time.start={configured_start!r} is {simulation_start:.3f}s since reference_date '
+            f'{simulation_time.reference_date!r}, but forcing covers '
+            f'[{forcing_start:.3f}, {forcing_end:.3f}]s. '
+            'repeat_eulerian_fields only repeats forcing after a valid simulation start.'
+        )
+
+    @classmethod
+    def _validate_simulation_time_matches_input(cls, simulation_time: Time, sedtrails_data) -> None:
+        """Backward-compatible validation helper for loaded SedTRAILS data."""
+        times = np.asarray(sedtrails_data.times, dtype=float)
+        if times.size == 0:
+            raise ConfigurationError('Input forcing contains no timestamps.')
+        cls._validate_simulation_start_matches_input(simulation_time, (float(times[0]), float(times[-1])))
+
+    def _output_save_interval_seconds(self) -> int:
+        """Return the configured trajectory output cadence in seconds."""
+        save_interval_seconds = Duration(self._controller.get('outputs.save_interval', '1H')).seconds
+        if save_interval_seconds <= 0:
+            raise ConfigurationError('outputs.save_interval must be a positive duration')
+        return save_interval_seconds
+
+    @staticmethod
+    def _estimate_output_timesteps(simulation_time: Time, save_interval_seconds: int | float) -> int:
+        """Count output slots for initial, scheduled, and final trajectory samples."""
+        if save_interval_seconds <= 0:
+            raise ConfigurationError('outputs.save_interval must be a positive duration')
+
+        duration_seconds = float(simulation_time.duration.seconds)
+        if duration_seconds <= 0:
+            return 1
+
+        interval_count = int(np.floor(duration_seconds / float(save_interval_seconds)))
+        count = 1 + interval_count
+        if interval_count * float(save_interval_seconds) < duration_seconds - 1.0e-9:
+            count += 1
+        return max(1, count)
+
+    @staticmethod
+    def _next_scheduled_output_time(
+        simulation_time: Time,
+        save_interval_seconds: int | float,
+        output_index: int,
+    ) -> float:
+        """Return the next scheduled output time, capped at the simulation end."""
+        return float(min(simulation_time.start + output_index * float(save_interval_seconds), simulation_time.end))
+
+    @staticmethod
+    def _limit_timestep_to_output_schedule(
+        current_time: int | float,
+        current_timestep: int | float,
+        next_output_time: int | float,
+    ) -> float:
+        """Shorten a CFL step only when it would cross the next output boundary."""
+        remaining_to_output = float(next_output_time) - float(current_time)
+        if 0.0 < remaining_to_output < float(current_timestep):
+            return remaining_to_output
+        return float(current_timestep)
+
+    @staticmethod
+    def _is_output_sample_due(
+        sample_time: int | float,
+        next_output_time: int | float,
+        end_time: int | float,
+    ) -> bool:
+        """Return whether a trajectory sample should be stored at this time."""
+        tolerance = 1.0e-9
+        return sample_time + tolerance >= next_output_time or sample_time + tolerance >= end_time
+
+    @staticmethod
+    def _initialize_population_output_status(populations, current_time: int | float) -> None:
+        """Populate required status arrays before the initial trajectory sample is written."""
+        for population in populations:
+            particles = population.particles
+            n_particles = len(particles['x'])
+            particles.setdefault('status_alive', np.ones(n_particles, dtype=bool))
+            particles.setdefault('status_buried', np.zeros(n_particles, dtype=bool))
+            particles.setdefault('status_transported', np.zeros(n_particles, dtype=bool))
+
+            if 'status_domain' not in particles:
+                simplices = getattr(population, '_particle_simplices', None)
+                if simplices is None:
+                    particles['status_domain'] = np.ones(n_particles, dtype=bool)
+                else:
+                    particles['status_domain'] = np.asarray(simplices) >= 0
+
+            if 'status_released' not in particles:
+                release_time = particles.get('release_time')
+                if release_time is None:
+                    particles['status_released'] = np.ones(n_particles, dtype=bool)
+                else:
+                    particles['status_released'] = float(current_time) >= np.asarray(release_time, dtype=float)
+
+            particles['status_mobile'] = (
+                np.asarray(particles['status_domain'], dtype=bool)
+                & np.asarray(particles['status_alive'], dtype=bool)
+                & ~np.asarray(particles['status_buried'], dtype=bool)
+                & np.asarray(particles['status_released'], dtype=bool)
+                & np.asarray(particles['status_transported'], dtype=bool)
+            )
+
     def _get_format_config(self):
         """
         Returns configuration parameters required for the format converter.
@@ -475,6 +592,15 @@ class Simulation:
         simulation_time = self._create_simulation_time()
 
         timer = Timer(simulation_time=simulation_time, cfl_condition=self._controller.get('time.cfl_condition'))
+        repeat_eulerian_fields = self._controller.get('inputs.repeat_eulerian_fields', False)
+        input_time_bounds = self.format_converter.get_time_bounds()
+        self._validate_simulation_start_matches_input(simulation_time, input_time_bounds)
+        if repeat_eulerian_fields:
+            self.logger.info(
+                'Repeating Eulerian flow fields from %.3fs after forcing end %.3fs',
+                input_time_bounds[0],
+                input_time_bounds[1],
+            )
 
         # Load only x/y field coordinates needed for the population seeder.
         with self._profile_section('get_seeding_field_data'):
@@ -485,15 +611,6 @@ class Simulation:
         populations = seeder.seed(seeding_field_data)  # seed particles for all populations
         runtime_plans = build_population_runtime_plans(populations_config, populations, self._get_physics_config())
         flow_field_names = unique_flow_field_names(runtime_plans)
-        repeat_eulerian_fields = self._controller.get('inputs.repeat_eulerian_fields', False)
-        input_time_bounds = None
-        if repeat_eulerian_fields:
-            input_time_bounds = self.format_converter.get_time_bounds()
-            self.logger.info(
-                'Repeating Eulerian flow fields from %.3fs after forcing end %.3fs',
-                input_time_bounds[0],
-                input_time_bounds[1],
-            )
 
         # Set initial values
         sedtrails_data = None
@@ -504,6 +621,7 @@ class Simulation:
             desc='Computing positions',
             unit='%',
             bar_format='{l_bar}{bar}| {n:.1f}% [{elapsed}<{remaining}, {postfix}]',
+            disable=not sys.stderr.isatty(),
         )
         self._active_progress_bar = pbar
 
@@ -519,8 +637,8 @@ class Simulation:
         )
         # Create SedTrails dataset using DataManager's writer (composition)
         total_particles = sum([len(pop.particles['x']) for pop in populations])
-        estimated_timesteps = (simulation_time.duration.seconds // simulation_time.time_step.seconds) + 1
-        max_timesteps = estimated_timesteps * 2  # Initial buffer
+        save_interval_seconds = self._output_save_interval_seconds()
+        max_timesteps = self._estimate_output_timesteps(simulation_time, save_interval_seconds)
 
         xr_data = self.data_manager.writer.create_dataset(
             N_particles=total_particles,
@@ -530,14 +648,29 @@ class Simulation:
         )
 
         # Initialize metadata using DataManager's writer (composition)
-        self.data_manager.writer.add_metadata(xr_data, populations, flow_field_names)
+        simulation_metadata = {
+            'reference_date': str(simulation_time.reference_date),
+            'time_units': f'seconds since {simulation_time.reference_date}',
+            'time_start': self._controller.get('time.start'),
+            'time_end_seconds_since_reference_date': float(simulation_time.end),
+            'outputs_save_interval_seconds': float(save_interval_seconds),
+        }
+        self.data_manager.writer.add_metadata(xr_data, populations, flow_field_names, simulation_metadata)
+        self._initialize_population_output_status(populations, timer.current)
+        self.data_manager.collect_timestep_data(xr_data, populations, 0, timer.current)
+        output_timestep = 1
+        next_output_time = self._next_scheduled_output_time(
+            simulation_time,
+            save_interval_seconds,
+            output_timestep,
+        )
 
         # Main simulation loop with variable timestep
         input_data_exhausted = False
         input_exhaustion_warning_logged = False
         plan_retrievers = {}
         dashboard_flow_field = None
-        while not timer.stop:
+        while not timer.stop and timer.current < simulation_time.end:
             # Check if current time is within loaded SedTRAILS data
             current_time_seconds = timer.current
             field_time_seconds = self._map_eulerian_field_time(
@@ -596,6 +729,17 @@ class Simulation:
                     sedtrails_data.metadata.min_resolution,
                     sedtrails_data.metadata.timestep,
                 )
+                timer.current_timestep = min(timer.current_timestep, simulation_time.end - timer.current)
+                if output_timestep < max_timesteps:
+                    timer.current_timestep = self._limit_timestep_to_output_schedule(
+                        timer.current,
+                        timer.current_timestep,
+                        next_output_time,
+                    )
+                if timer.current_timestep <= 0:
+                    raise ConfigurationError(
+                        f'Computed non-positive timestep {timer.current_timestep} at simulation time {timer.current}.'
+                    )
 
             # Main loop
             dashboard_flow_field = None
@@ -639,16 +783,6 @@ class Simulation:
                     with self._profile_section('update_position'):
                         population.update_position(flow_field=flow_field, current_timestep=timer.current_timestep)
 
-            # Collect data from all populations for this timestep using DataManager
-            self.data_manager.collect_timestep_data(xr_data, populations, timer.step_count, timer.current)
-
-            # Check if we need to expand the time dimension
-            if timer.step_count >= max_timesteps - 10:  # 10-step safety margin
-                old_max = max_timesteps
-                max_timesteps = int(max_timesteps * 2.0)  # Expand by 100%
-                self.logger.info(f'Expanding time dimension from {old_max} to {max_timesteps}')
-                xr_data = self._expand_time_dimension(xr_data, max_timesteps)
-
             # Update dashboard if enabled
             if self._should_update_dashboard(sedtrails_data, timer) and dashboard_flow_field is not None:
                 plot_interval_seconds = self._dashboard_update_interval_seconds()
@@ -674,6 +808,27 @@ class Simulation:
                     )
 
             timer.advance()
+
+            if (
+                output_timestep < max_timesteps
+                and self._is_output_sample_due(timer.current, next_output_time, simulation_time.end)
+            ):
+                self.data_manager.collect_timestep_data(xr_data, populations, output_timestep, timer.current)
+                output_timestep += 1
+                if output_timestep < max_timesteps:
+                    next_output_time = self._next_scheduled_output_time(
+                        simulation_time,
+                        save_interval_seconds,
+                        output_timestep,
+                    )
+
+            # Check if we need to expand the time dimension. The save cadence estimate should be exact,
+            # but this keeps the writer robust to future scheduling changes.
+            if output_timestep >= max_timesteps and timer.current < simulation_time.end:
+                old_max = max_timesteps
+                max_timesteps = max_timesteps + max(1, max_timesteps // 2)
+                self.logger.info(f'Expanding time dimension from {old_max} to {max_timesteps}')
+                xr_data = self._expand_time_dimension(xr_data, max_timesteps)
 
             # Saving and plotting
             # TODO: enable saving and plotting again: addapt writer with structure issue 297
@@ -734,9 +889,8 @@ class Simulation:
         print('\nSimulation completed successfully!')
 
         # Write final results to NetCDF using DataManager's writer (composition)
-        actual_timesteps = timer.step_count + 1
         output_file = self.data_manager.writer.write(
-            xr_data, filename='sedtrails_results.nc', trim_to_actual_timesteps=True, actual_timesteps=actual_timesteps
+            xr_data, filename='sedtrails_results.nc', trim_to_actual_timesteps=True, actual_timesteps=output_timestep
         )
         print(f'Simulation results saved to: {output_file}')
         self._log_profile_summary(status='completed')

--- a/src/sedtrails/transport_converter/plugins/format/fm_netcdf.py
+++ b/src/sedtrails/transport_converter/plugins/format/fm_netcdf.py
@@ -245,11 +245,15 @@ class FormatPlugin(BaseFormatPlugin):
         if current_time is None or reading_interval is None:
             return None, None
 
-        # If reading_interval is 0 or very large, load entire file
-        if reading_interval <= 0 or reading_interval >= time_info['seconds_since_reference'][-1]:
+        times_array = np.asarray(time_info['seconds_since_reference'], dtype=float)
+        if times_array.size == 0:
             return None, None
 
-        times_array = time_info['seconds_since_reference']
+        forcing_span = times_array[-1] - times_array[0]
+
+        # If reading_interval is 0 or spans the forcing window, load entire file.
+        if reading_interval <= 0 or forcing_span <= 0 or reading_interval >= forcing_span:
+            return None, None
 
         # Find current time index
         current_idx = np.searchsorted(times_array, current_time)

--- a/src/sedtrails/transport_converter/plugins/format/sfincs.py
+++ b/src/sedtrails/transport_converter/plugins/format/sfincs.py
@@ -512,11 +512,15 @@ class FormatPlugin(BaseFormatPlugin):
         if current_time is None or reading_interval is None:
             return None, None
 
-        # If reading_interval is 0 or very large, load entire file
-        if reading_interval <= 0 or reading_interval >= time_info['seconds_since_reference'][-1]:
+        times_array = np.asarray(time_info['seconds_since_reference'], dtype=float)
+        if times_array.size == 0:
             return None, None
 
-        times_array = time_info['seconds_since_reference']
+        forcing_span = times_array[-1] - times_array[0]
+
+        # If reading_interval is 0 or spans the forcing window, load entire file.
+        if reading_interval <= 0 or forcing_span <= 0 or reading_interval >= forcing_span:
+            return None, None
 
         # Find current time index
         current_idx = np.searchsorted(times_array, current_time)

--- a/tests/cli/test_sedtrails_cli.py
+++ b/tests/cli/test_sedtrails_cli.py
@@ -6,6 +6,7 @@ import pytest
 import yaml
 from click.testing import CliRunner
 from typer.main import get_command
+from types import SimpleNamespace
 from unittest.mock import patch
 from sedtrails.application_interfaces.cli import app
 
@@ -137,3 +138,40 @@ class TestSedtrailsCLI:
             assert result.exit_code == 1
             assert 'Error running simulation: Simulation failed' in result.stdout
             mock_run_simulation.assert_called_once()
+
+    def test_config_restart_command_success(self, runner, cli_command):
+        """Test successful generation of restart config via CLI."""
+        with patch('sedtrails.application_interfaces.api.create_restart_config') as mock_create_restart:
+            mock_create_restart.return_value = SimpleNamespace(
+                output_config='restart.yaml',
+                restart_time='2020-01-01 00:02:00',
+                retained_particles=10,
+                seed_files={'population_1': 'seeds/population_1.restart_points.csv'},
+            )
+
+            result = runner.invoke(
+                cli_command,
+                [
+                    'config',
+                    'restart',
+                    '--file',
+                    'results.nc',
+                    '--config',
+                    'base.yaml',
+                    '--output',
+                    'restart.yaml',
+                ],
+            )
+
+            assert result.exit_code == 0
+            assert "Restart config written to 'restart.yaml'" in result.stdout
+            assert "Restart time set to '2020-01-01 00:02:00'" in result.stdout
+            assert 'Retained particles: 10' in result.stdout
+            assert 'population_1' in result.stdout
+
+            mock_create_restart.assert_called_once_with(
+                results_file='results.nc',
+                base_config_file='base.yaml',
+                output_config_file='restart.yaml',
+                seed_points_dir=None,
+            )

--- a/tests/configuration_interfaces/test_restart_config.py
+++ b/tests/configuration_interfaces/test_restart_config.py
@@ -9,6 +9,62 @@ import sedtrails.application_interfaces.restart as restart_module
 from sedtrails.application_interfaces.restart import create_restart_from_netcdf
 
 
+def test_open_restart_dataset_uses_netcdf4_engine(monkeypatch, tmp_path):
+    observed = {}
+
+    def fake_open_dataset(path, **kwargs):
+        observed['path'] = path
+        observed['kwargs'] = kwargs
+        return xr.Dataset()
+
+    monkeypatch.setattr(restart_module.xr, 'open_dataset', fake_open_dataset)
+    netcdf_file = tmp_path / 'results.nc'
+
+    ds = restart_module._open_restart_dataset(netcdf_file)
+
+    assert isinstance(ds, xr.Dataset)
+    assert observed['path'] == netcdf_file
+    assert observed['kwargs']['engine'] == 'netcdf4'
+
+
+def test_create_restart_rejects_forcing_file_with_clear_message(tmp_path):
+    base_config = {
+        'time': {'start': '2020-01-01 00:00:00', 'timestep': '60S', 'duration': '1D'},
+        'particles': {
+            'populations': [
+                {
+                    'name': 'population_1',
+                    'particle_type': 'sand',
+                    'seeding': {
+                        'release_start': '2020-01-01 00:00:00',
+                        'quantity': 1,
+                        'strategy': {'random': {'bbox': '0,0 1,1', 'nlocations': 1}},
+                    },
+                }
+            ]
+        },
+    }
+    config_file = tmp_path / 'base.yaml'
+    with open(config_file, 'w', encoding='utf-8') as handle:
+        yaml.safe_dump(base_config, handle, sort_keys=False)
+
+    forcing = xr.Dataset(
+        data_vars={
+            'bedlevel': (('time', 'mesh2d_nFaces'), np.zeros((1, 2))),
+            'sea_water_x_velocity': (('time', 'mesh2d_nFaces'), np.ones((1, 2))),
+        }
+    )
+    forcing_file = tmp_path / 'forcing.nc'
+    forcing.to_netcdf(forcing_file)
+
+    with pytest.raises(ValueError, match='not a SedTRAILS trajectory output file.*Eulerian forcing files'):
+        create_restart_from_netcdf(
+            netcdf_file=str(forcing_file),
+            base_config_file=str(config_file),
+            output_config_file=str(tmp_path / 'restart.yaml'),
+        )
+
+
 def test_create_restart_from_netcdf_generates_yaml_and_seed_files(tmp_path):
     base_config = {
         'time': {'start': '2020-01-01 00:00:00', 'timestep': '60S', 'duration': '1D'},

--- a/tests/configuration_interfaces/test_restart_config.py
+++ b/tests/configuration_interfaces/test_restart_config.py
@@ -5,6 +5,7 @@ import pytest
 import xarray as xr
 import yaml
 
+import sedtrails.application_interfaces.restart as restart_module
 from sedtrails.application_interfaces.restart import create_restart_from_netcdf
 
 
@@ -182,6 +183,181 @@ def test_create_restart_uses_reference_date_for_netcdf_time(tmp_path):
     with open(out_config, 'r', encoding='utf-8') as handle:
         restart_cfg = yaml.safe_load(handle)
     assert restart_cfg['time']['duration'] == '23H39M32S'
+    assert restart_cfg['general']['input_model']['reference_date'] == '1970-01-01'
+
+
+def test_create_restart_validates_generated_time_against_original_forcing(tmp_path, monkeypatch):
+    """A 1970 restart generated for 2016 forcing should fail before writing a bad config."""
+
+    class FakeFormatConverter:
+        def __init__(self, config):
+            self.config = config
+
+        def get_time_bounds(self):
+            return 1474485600.0, 1474489200.0
+
+    monkeypatch.setattr(restart_module, 'FormatConverter', FakeFormatConverter)
+
+    base_config = {
+        'general': {'input_model': {'format': 'fm_netcdf', 'reference_date': '1970-01-01'}},
+        'inputs': {'data': 'forcing.nc'},
+        'time': {'start': '2016-09-21 19:20:00', 'timestep': '60S', 'duration': '1D'},
+        'particles': {
+            'populations': [
+                {
+                    'name': 'population_1',
+                    'particle_type': 'sand',
+                    'seeding': {
+                        'release_start': '2016-09-21 19:20:00',
+                        'quantity': 1,
+                        'strategy': {'random': {'bbox': '0,0 1,1', 'nlocations': 1}},
+                    },
+                }
+            ]
+        },
+    }
+
+    config_file = tmp_path / 'base.yaml'
+    with open(config_file, 'w', encoding='utf-8') as handle:
+        yaml.safe_dump(base_config, handle, sort_keys=False)
+
+    ds = xr.Dataset(
+        data_vars={
+            'x': (('n_particles', 'n_timesteps'), np.array([[0.0]])),
+            'y': (('n_particles', 'n_timesteps'), np.array([[0.0]])),
+            'time': (('n_particles', 'n_timesteps'), np.array([[15400.0]])),
+            'population_id': (('n_particles',), np.array([0], dtype=int)),
+        }
+    )
+    netcdf_file = tmp_path / 'results.nc'
+    ds.to_netcdf(netcdf_file)
+
+    out_config = tmp_path / 'restart.yaml'
+    with pytest.raises(ValueError, match='outside the original input forcing window'):
+        create_restart_from_netcdf(
+            netcdf_file=str(netcdf_file),
+            base_config_file=str(config_file),
+            output_config_file=str(out_config),
+        )
+
+    assert not out_config.exists()
+
+
+def test_create_restart_with_valid_forcing_preserves_original_reference_date(tmp_path, monkeypatch):
+    """Valid restart generation should keep the base input-model reference date unchanged."""
+
+    class FakeFormatConverter:
+        def __init__(self, config):
+            self.config = config
+
+        def get_time_bounds(self):
+            return 1474485600.0, 1474489200.0
+
+    monkeypatch.setattr(restart_module, 'FormatConverter', FakeFormatConverter)
+
+    base_config = {
+        'general': {'input_model': {'format': 'fm_netcdf', 'reference_date': '1970-01-01'}},
+        'inputs': {'data': 'forcing.nc'},
+        'time': {'start': '2016-09-21 19:20:00', 'timestep': '60S', 'duration': '1D'},
+        'particles': {
+            'populations': [
+                {
+                    'name': 'population_1',
+                    'particle_type': 'sand',
+                    'seeding': {
+                        'release_start': '2016-09-21 19:20:00',
+                        'quantity': 1,
+                        'strategy': {'random': {'bbox': '0,0 1,1', 'nlocations': 1}},
+                    },
+                }
+            ]
+        },
+    }
+
+    config_file = tmp_path / 'base.yaml'
+    with open(config_file, 'w', encoding='utf-8') as handle:
+        yaml.safe_dump(base_config, handle, sort_keys=False)
+
+    ds = xr.Dataset(
+        data_vars={
+            'x': (('n_particles', 'n_timesteps'), np.array([[0.0, 1.0]])),
+            'y': (('n_particles', 'n_timesteps'), np.array([[0.0, 1.0]])),
+            'time': (('n_particles', 'n_timesteps'), np.array([[1474485600.0, 1474486828.0]])),
+            'population_id': (('n_particles',), np.array([0], dtype=int)),
+        }
+    )
+    netcdf_file = tmp_path / 'results.nc'
+    ds.to_netcdf(netcdf_file)
+
+    out_config = tmp_path / 'restart.yaml'
+    summary = create_restart_from_netcdf(
+        netcdf_file=str(netcdf_file),
+        base_config_file=str(config_file),
+        output_config_file=str(out_config),
+    )
+
+    assert summary.restart_time == '2016-09-21 19:40:28'
+
+    with open(out_config, 'r', encoding='utf-8') as handle:
+        restart_cfg = yaml.safe_load(handle)
+    assert restart_cfg['time']['start'] == '2016-09-21 19:40:28'
+    assert restart_cfg['general']['input_model']['reference_date'] == '1970-01-01'
+
+
+def test_create_restart_prefers_output_time_units_reference_date(tmp_path, monkeypatch):
+    """Future output metadata can define the time axis reference date explicitly."""
+
+    class FakeFormatConverter:
+        def __init__(self, config):
+            self.config = config
+
+        def get_time_bounds(self):
+            return 1474485600.0, 1474489200.0
+
+    monkeypatch.setattr(restart_module, 'FormatConverter', FakeFormatConverter)
+
+    base_config = {
+        'general': {'input_model': {'format': 'fm_netcdf', 'reference_date': '1970-01-01'}},
+        'inputs': {'data': 'forcing.nc'},
+        'time': {'start': '2016-09-21 19:20:00', 'timestep': '60S', 'duration': '1D'},
+        'particles': {
+            'populations': [
+                {
+                    'name': 'population_1',
+                    'particle_type': 'sand',
+                    'seeding': {
+                        'release_start': '2016-09-21 19:20:00',
+                        'quantity': 1,
+                        'strategy': {'random': {'bbox': '0,0 1,1', 'nlocations': 1}},
+                    },
+                }
+            ]
+        },
+    }
+
+    config_file = tmp_path / 'base.yaml'
+    with open(config_file, 'w', encoding='utf-8') as handle:
+        yaml.safe_dump(base_config, handle, sort_keys=False)
+
+    ds = xr.Dataset(
+        data_vars={
+            'x': (('n_particles', 'n_timesteps'), np.array([[0.0, 1.0]])),
+            'y': (('n_particles', 'n_timesteps'), np.array([[0.0, 1.0]])),
+            'time': (('n_particles', 'n_timesteps'), np.array([[0.0, 1228.0]])),
+            'population_id': (('n_particles',), np.array([0], dtype=int)),
+        },
+        attrs={'time_units': 'seconds since 2016-09-21 19:20:00'},
+    )
+    netcdf_file = tmp_path / 'results.nc'
+    ds.to_netcdf(netcdf_file)
+
+    summary = create_restart_from_netcdf(
+        netcdf_file=str(netcdf_file),
+        base_config_file=str(config_file),
+        output_config_file=str(tmp_path / 'restart.yaml'),
+    )
+
+    assert summary.restart_time == '2016-09-21 19:40:28'
 
 
 def test_create_restart_writes_seed_paths_relative_to_cwd(tmp_path, monkeypatch):

--- a/tests/configuration_interfaces/test_restart_config.py
+++ b/tests/configuration_interfaces/test_restart_config.py
@@ -1,0 +1,278 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+import xarray as xr
+import yaml
+
+from sedtrails.application_interfaces.restart import create_restart_from_netcdf
+
+
+def test_create_restart_from_netcdf_generates_yaml_and_seed_files(tmp_path):
+    base_config = {
+        'time': {'start': '2020-01-01 00:00:00', 'timestep': '60S', 'duration': '1D'},
+        'particles': {
+            'populations': [
+                {
+                    'name': 'population_1',
+                    'particle_type': 'sand',
+                    'seeding': {
+                        'release_start': '2020-01-01 00:00:00',
+                        'quantity': 1,
+                        'strategy': {'random': {'bbox': '0,0 1,1', 'nlocations': 1}},
+                    },
+                },
+                {
+                    'name': 'population_2',
+                    'particle_type': 'sand',
+                    'seeding': {
+                        'release_start': '2020-01-01 00:00:00',
+                        'quantity': 1,
+                        'strategy': {'random': {'bbox': '0,0 1,1', 'nlocations': 1}},
+                    },
+                },
+            ]
+        },
+    }
+
+    config_file = tmp_path / 'base.yaml'
+    with open(config_file, 'w', encoding='utf-8') as handle:
+        yaml.safe_dump(base_config, handle, sort_keys=False)
+
+    ds = xr.Dataset(
+        data_vars={
+            'x': (
+                ('n_particles', 'n_timesteps'),
+                np.array(
+                    [
+                        [0.0, 1.0, 2.0],
+                        [5.0, 6.0, np.nan],
+                        [10.0, 11.0, 12.0],
+                    ]
+                ),
+            ),
+            'y': (
+                ('n_particles', 'n_timesteps'),
+                np.array(
+                    [
+                        [0.0, 0.5, 1.0],
+                        [4.0, 4.5, np.nan],
+                        [7.0, 7.5, 8.0],
+                    ]
+                ),
+            ),
+            'time': (
+                ('n_particles', 'n_timesteps'),
+                np.array(
+                    [
+                        [0.0, 60.0, 120.0],
+                        [0.0, 60.0, np.nan],
+                        [0.0, 60.0, 120.0],
+                    ]
+                ),
+            ),
+            'population_id': (('n_particles',), np.array([0, 0, 1], dtype=int)),
+            'status_alive': (
+                ('n_particles', 'n_timesteps'),
+                np.array(
+                    [
+                        [1.0, 1.0, 1.0],
+                        [1.0, 0.0, 0.0],
+                        [1.0, 1.0, 1.0],
+                    ]
+                ),
+            ),
+            'status_domain': (
+                ('n_particles', 'n_timesteps'),
+                np.ones((3, 3), dtype=float),
+            ),
+        }
+    )
+
+    netcdf_file = tmp_path / 'results.nc'
+    ds.to_netcdf(netcdf_file)
+
+    out_config = tmp_path / 'restart.yaml'
+    out_seed_dir = tmp_path / 'restart_points'
+
+    summary = create_restart_from_netcdf(
+        netcdf_file=str(netcdf_file),
+        base_config_file=str(config_file),
+        output_config_file=str(out_config),
+        seed_points_dir=str(out_seed_dir),
+    )
+
+    assert summary.output_config == out_config
+    assert summary.restart_time == '2020-01-01 00:02:00'
+    assert summary.retained_particles == 2
+
+    assert (out_seed_dir / 'population_1.restart_points.csv').exists()
+    assert (out_seed_dir / 'population_2.restart_points.csv').exists()
+
+    with open(out_config, 'r', encoding='utf-8') as handle:
+        restart_cfg = yaml.safe_load(handle)
+
+    assert restart_cfg['time']['start'] == '2020-01-01 00:02:00'
+    assert restart_cfg['time']['duration'] == '23H58M'
+
+    pop1 = restart_cfg['particles']['populations'][0]
+    pop2 = restart_cfg['particles']['populations'][1]
+
+    assert pop1['seeding']['release_start'] == '2020-01-01 00:02:00'
+    assert pop1['seeding']['quantity'] == 1
+    assert 'file_points' in pop1['seeding']['strategy']
+
+    assert pop2['seeding']['release_start'] == '2020-01-01 00:02:00'
+    assert pop2['seeding']['quantity'] == 1
+    assert 'file_points' in pop2['seeding']['strategy']
+
+    pop1_file = Path(pop1['seeding']['strategy']['file_points']['path'])
+    pop2_file = Path(pop2['seeding']['strategy']['file_points']['path'])
+
+    assert pop1_file.name == 'population_1.restart_points.csv'
+    assert pop2_file.name == 'population_2.restart_points.csv'
+
+
+def test_create_restart_uses_reference_date_for_netcdf_time(tmp_path):
+    base_config = {
+        'general': {'input_model': {'reference_date': '1970-01-01'}},
+        'time': {'start': '2016-09-21 19:20:00', 'timestep': '60S', 'duration': '1D'},
+        'particles': {
+            'populations': [
+                {
+                    'name': 'population_1',
+                    'particle_type': 'sand',
+                    'seeding': {
+                        'release_start': '2016-09-21 19:30:00',
+                        'quantity': 1,
+                        'strategy': {'random': {'bbox': '0,0 1,1', 'nlocations': 1}},
+                    },
+                }
+            ]
+        },
+    }
+
+    config_file = tmp_path / 'base.yaml'
+    with open(config_file, 'w', encoding='utf-8') as handle:
+        yaml.safe_dump(base_config, handle, sort_keys=False)
+
+    ds = xr.Dataset(
+        data_vars={
+            'x': (('n_particles', 'n_timesteps'), np.array([[0.0, 1.0]])),
+            'y': (('n_particles', 'n_timesteps'), np.array([[0.0, 1.0]])),
+            # 2016-09-21 19:40:28 UTC in epoch seconds
+            'time': (('n_particles', 'n_timesteps'), np.array([[1474485628.0, 1474486828.0]])),
+            'population_id': (('n_particles',), np.array([0], dtype=int)),
+        }
+    )
+
+    netcdf_file = tmp_path / 'results.nc'
+    ds.to_netcdf(netcdf_file)
+
+    out_config = tmp_path / 'restart.yaml'
+
+    summary = create_restart_from_netcdf(
+        netcdf_file=str(netcdf_file),
+        base_config_file=str(config_file),
+        output_config_file=str(out_config),
+    )
+
+    assert summary.restart_time == '2016-09-21 19:40:28'
+
+    with open(out_config, 'r', encoding='utf-8') as handle:
+        restart_cfg = yaml.safe_load(handle)
+    assert restart_cfg['time']['duration'] == '23H39M32S'
+
+
+def test_create_restart_writes_seed_paths_relative_to_cwd(tmp_path, monkeypatch):
+    examples_dir = tmp_path / 'examples'
+    examples_dir.mkdir(parents=True)
+
+    base_config = {
+        'time': {'start': '2020-01-01 00:00:00', 'timestep': '60S', 'duration': '1D'},
+        'particles': {
+            'populations': [
+                {
+                    'name': 'populaton_1',
+                    'particle_type': 'sand',
+                    'seeding': {
+                        'release_start': '2020-01-01 00:00:00',
+                        'quantity': 1,
+                        'strategy': {'random': {'bbox': '0,0 1,1', 'nlocations': 1}},
+                    },
+                }
+            ]
+        },
+    }
+
+    config_file = examples_dir / 'base.yaml'
+    with open(config_file, 'w', encoding='utf-8') as handle:
+        yaml.safe_dump(base_config, handle, sort_keys=False)
+
+    ds = xr.Dataset(
+        data_vars={
+            'x': (('n_particles', 'n_timesteps'), np.array([[0.0, 1.0]])),
+            'y': (('n_particles', 'n_timesteps'), np.array([[0.0, 1.0]])),
+            'time': (('n_particles', 'n_timesteps'), np.array([[0.0, 60.0]])),
+            'population_id': (('n_particles',), np.array([0], dtype=int)),
+        }
+    )
+    netcdf_file = examples_dir / 'results.nc'
+    ds.to_netcdf(netcdf_file)
+
+    monkeypatch.chdir(tmp_path)
+    out_config = examples_dir / 'restart.yaml'
+
+    create_restart_from_netcdf(
+        netcdf_file=str(netcdf_file),
+        base_config_file=str(config_file),
+        output_config_file=str(out_config),
+    )
+
+    with open(out_config, 'r', encoding='utf-8') as handle:
+        restart_cfg = yaml.safe_load(handle)
+
+    seed_path = restart_cfg['particles']['populations'][0]['seeding']['strategy']['file_points']['path']
+    assert seed_path == './examples/restart_seeds/populaton_1.restart_points.csv'
+
+
+def test_create_restart_raises_if_no_remaining_duration(tmp_path):
+    base_config = {
+        'time': {'start': '2020-01-01 00:00:00', 'timestep': '60S', 'duration': '1D'},
+        'particles': {
+            'populations': [
+                {
+                    'name': 'population_1',
+                    'particle_type': 'sand',
+                    'seeding': {
+                        'release_start': '2020-01-01 00:00:00',
+                        'quantity': 1,
+                        'strategy': {'random': {'bbox': '0,0 1,1', 'nlocations': 1}},
+                    },
+                }
+            ]
+        },
+    }
+
+    config_file = tmp_path / 'base.yaml'
+    with open(config_file, 'w', encoding='utf-8') as handle:
+        yaml.safe_dump(base_config, handle, sort_keys=False)
+
+    ds = xr.Dataset(
+        data_vars={
+            'x': (('n_particles', 'n_timesteps'), np.array([[0.0, 1.0]])),
+            'y': (('n_particles', 'n_timesteps'), np.array([[0.0, 1.0]])),
+            # Last available time is exactly at end of original duration.
+            'time': (('n_particles', 'n_timesteps'), np.array([[0.0, 86400.0]])),
+            'population_id': (('n_particles',), np.array([0], dtype=int)),
+        }
+    )
+    netcdf_file = tmp_path / 'results.nc'
+    ds.to_netcdf(netcdf_file)
+
+    with pytest.raises(ValueError, match='No remaining duration'):
+        create_restart_from_netcdf(
+            netcdf_file=str(netcdf_file),
+            base_config_file=str(config_file),
+            output_config_file=str(tmp_path / 'restart.yaml'),
+        )

--- a/tests/particle_tracer/test_particle_seeder.py
+++ b/tests/particle_tracer/test_particle_seeder.py
@@ -1021,6 +1021,26 @@ class TestParticleFactory:
         with pytest.raises(ValueError, match='Unknown particle type'):
             ParticleFactory.create_particles(config)
 
+    def test_zero_quantity_creates_no_particles_without_strategy_seeding(self):
+        """Zero quantity disables seeding for restart populations."""
+        config = PopulationConfig(
+            {
+                'name': 'Disabled Restart Population',
+                'particle_type': 'sand',
+                'seeding': {
+                    'strategy': {'random': {'nlocations': 1}},
+                    'quantity': 0,
+                    'release_start': '2025-06-18 13:00:00',
+                    'burial_depth': {
+                        'constant': 0.0,
+                    },
+                },
+            }
+        )
+
+        assert config.quantity == 0
+        assert ParticleFactory.create_particles(config) == []
+
     def test_create_particles_release_time_set(self):
         """Test that release time is set correctly."""
         config = PopulationConfig(
@@ -1142,6 +1162,41 @@ class TestParticlePopulation:
         assert population is not None
         assert len(population.particles['x']) == 10  # 2 nlocations * 5 quantity
         assert len(population.particles['y']) == 10  # 2 nlocations * 5 quantity
+
+    def test_zero_particle_population_updates_are_noops(self):
+        """Disabled restart populations should not require particle fields."""
+        config = PopulationConfig(
+            {
+                'name': 'Disabled Restart Population',
+                'particle_type': 'sand',
+                'transport_probability': 'stochastic_transport',
+                'seeding': {
+                    'strategy': {'random': {'nlocations': 1}},
+                    'quantity': 0,
+                    'release_start': '0',
+                    'burial_depth': {
+                        'constant': 0.0,
+                    },
+                },
+            }
+        )
+        population = ParticlePopulation(
+            field_x=np.array([0.0, 1.0, 1.0, 0.0]),
+            field_y=np.array([0.0, 0.0, 1.0, 1.0]),
+            population_config=config,
+        )
+
+        population.update_burial_depth()
+        population.update_status()
+        population.update_position(
+            flow_field={'u': np.ones(4), 'v': np.zeros(4)},
+            current_timestep=1.0,
+        )
+
+        assert len(population.particles['x']) == 0
+        assert len(population.particles['y']) == 0
+        assert population.particles['status_mobile'].dtype == bool
+        assert len(population.particles['status_mobile']) == 0
 
     def test_update_information_accepts_scalar_transport_probability(self, point_config_simple):
         """Scalar fields should update particles without allocating full grid fields."""

--- a/tests/pathway_visualizer/test_trajectories.py
+++ b/tests/pathway_visualizer/test_trajectories.py
@@ -1,12 +1,11 @@
 import matplotlib
+
+matplotlib.use('Agg')
+
 import numpy as np
 import xarray as xr
 
 from sedtrails.pathway_visualizer.trajectories import plot_trajectories
-
-
-matplotlib.use('Agg')
-
 
 def test_plot_trajectories_accepts_fixed_width_population_names(monkeypatch):
     n_particles = 2

--- a/tests/pathway_visualizer/test_trajectories.py
+++ b/tests/pathway_visualizer/test_trajectories.py
@@ -1,0 +1,34 @@
+import matplotlib
+import numpy as np
+import xarray as xr
+
+from sedtrails.pathway_visualizer.trajectories import plot_trajectories
+
+
+matplotlib.use('Agg')
+
+
+def test_plot_trajectories_accepts_fixed_width_population_names(monkeypatch):
+    n_particles = 2
+    n_timesteps = 3
+
+    ds = xr.Dataset(
+        data_vars={
+            'x': (('n_particles', 'n_timesteps'), np.array([[0.0, 1.0, 2.0], [0.0, 1.5, 3.0]])),
+            'y': (('n_particles', 'n_timesteps'), np.array([[0.0, 0.5, 1.0], [0.0, 0.25, 0.5]])),
+            'time': (('n_particles', 'n_timesteps'), np.array([[0.0, 60.0, 120.0], [0.0, 60.0, 120.0]])),
+            'population_id': (('n_particles',), np.array([0, 1], dtype=int)),
+            # 1D fixed-width byte strings as produced by current writer path
+            'population_name': (('n_populations',), np.array([b'pop_A', b'pop_B'], dtype='S24')),
+        },
+        coords={
+            'n_particles': np.arange(n_particles),
+            'n_timesteps': np.arange(n_timesteps),
+            'n_populations': np.arange(2),
+        },
+    )
+
+    monkeypatch.setattr('matplotlib.pyplot.show', lambda: None)
+
+    # This previously raised: "too many indices"
+    plot_trajectories(ds)

--- a/tests/simulation_orchestrator/test_simulationmanager.py
+++ b/tests/simulation_orchestrator/test_simulationmanager.py
@@ -6,6 +6,8 @@ import numpy as np
 import pytest
 import xarray as xr
 
+from sedtrails.exceptions.exceptions import ConfigurationError
+from sedtrails.particle_tracer.timer import Duration, Time
 from sedtrails.simulation_orchestrator.simulation_manager import Simulation
 
 
@@ -71,6 +73,30 @@ class TestSimulationManagerTimeConfig:
         assert Simulation._should_attempt_sedtrails_reload(SedtrailsData(), 7200.1, input_data_exhausted=False)
         assert not Simulation._should_attempt_sedtrails_reload(SedtrailsData(), 7200.1, input_data_exhausted=True)
 
+    def test_simulation_start_must_be_within_forcing_window(self):
+        """A run must start on forcing data; repeat mapping is only allowed after that."""
+
+        class SimulationTime:
+            start = 0.0
+            reference_date = '2000-01-01'
+            _start = '2000-01-01 00:00:00'
+
+        with pytest.raises(ConfigurationError, match='time.start must be within the input forcing window'):
+            Simulation._validate_simulation_start_matches_input(SimulationTime(), (3600.0, 7200.0))
+
+    def test_simulation_start_at_forcing_edges_is_valid(self):
+        """The first and last forcing timestamps are valid simulation starts."""
+
+        class SimulationTime:
+            reference_date = '2000-01-01'
+            _start = '2000-01-01 01:00:00'
+
+            def __init__(self, start):
+                self.start = start
+
+        Simulation._validate_simulation_start_matches_input(SimulationTime(3600.0), (3600.0, 7200.0))
+        Simulation._validate_simulation_start_matches_input(SimulationTime(7200.0), (3600.0, 7200.0))
+
     def test_eulerian_time_is_unchanged_when_repeat_disabled(self):
         """Without looping, field lookups use the simulation clock."""
 
@@ -81,6 +107,17 @@ class TestSimulationManagerTimeConfig:
         )
 
         assert mapped_time == 25.0
+
+    def test_eulerian_time_before_input_start_is_not_mapped_forward(self):
+        """Before-start lookups remain invalid so validation/reload failures stay clear."""
+
+        mapped_time = Simulation._map_eulerian_field_time(
+            current_time_seconds=50.0,
+            repeat_eulerian_fields=True,
+            input_time_bounds=(100.0, 200.0),
+        )
+
+        assert mapped_time == 50.0
 
     @pytest.mark.parametrize(
         'current_time,expected_time',
@@ -123,6 +160,127 @@ class TestSimulationManagerTimeConfig:
         )
 
         assert mapped_time == 130.0
+
+    def test_output_save_interval_uses_outputs_config(self):
+        """Trajectory output cadence should be read from outputs.save_interval."""
+
+        class Controller:
+            def get(self, key, default=None):
+                if key == 'outputs.save_interval':
+                    return '30M'
+                return default
+
+        manager = object.__new__(Simulation)
+        manager._controller = Controller()
+
+        assert manager._output_save_interval_seconds() == 1800
+
+    def test_output_save_interval_defaults_to_one_hour(self):
+        """When unset, saved trajectory samples should default to one-hour spacing."""
+        manager = object.__new__(Simulation)
+        manager._controller = type('Controller', (), {'get': lambda self, key, default=None: default})()
+
+        assert manager._output_save_interval_seconds() == 3600
+
+    def test_output_save_interval_rejects_zero_duration(self):
+        """A zero save interval would make output scheduling ambiguous."""
+        manager = object.__new__(Simulation)
+        manager._controller = type('Controller', (), {'get': lambda self, key, default=None: '0S'})()
+
+        with pytest.raises(ConfigurationError, match='outputs.save_interval'):
+            manager._output_save_interval_seconds()
+
+    @pytest.mark.parametrize(
+        'duration,save_interval,expected_count',
+        [
+            ('3H', 3600, 4),
+            ('30M', 3600, 2),
+            ('2H30M', 3600, 4),
+        ],
+    )
+    def test_estimate_output_timesteps_counts_initial_scheduled_and_final(
+        self, duration, save_interval, expected_count
+    ):
+        """Output allocation follows save cadence, not CFL integration cadence."""
+        simulation_time = Time(
+            _start='2000-01-01 00:00:00',
+            duration=Duration(duration),
+            reference_date='2000-01-01',
+        )
+
+        assert Simulation._estimate_output_timesteps(simulation_time, save_interval) == expected_count
+
+    def test_next_scheduled_output_time_caps_at_simulation_end(self):
+        """The final output target should be the simulation end, not a time after it."""
+
+        class SimulationTime:
+            start = 0.0
+            end = 9000.0
+
+        assert Simulation._next_scheduled_output_time(SimulationTime(), 3600, 1) == 3600.0
+        assert Simulation._next_scheduled_output_time(SimulationTime(), 3600, 3) == 9000.0
+
+    def test_limit_timestep_to_output_schedule_hits_save_boundary(self):
+        """A CFL step that crosses an output boundary should land exactly on it."""
+        limited = Simulation._limit_timestep_to_output_schedule(
+            current_time=3598.0,
+            current_timestep=10.0,
+            next_output_time=3600.0,
+        )
+
+        assert limited == 2.0
+
+    def test_limit_timestep_to_output_schedule_keeps_short_cfl_step(self):
+        """CFL steps shorter than the remaining save interval should not be changed."""
+        limited = Simulation._limit_timestep_to_output_schedule(
+            current_time=10.0,
+            current_timestep=2.0,
+            next_output_time=3600.0,
+        )
+
+        assert limited == 2.0
+
+    @pytest.mark.parametrize(
+        'sample_time,next_output_time,end_time,expected',
+        [
+            (3599.0, 3600.0, 7200.0, False),
+            (3600.0, 3600.0, 7200.0, True),
+            (7200.0, 10800.0, 7200.0, True),
+        ],
+    )
+    def test_output_sample_due_on_interval_or_final_time(self, sample_time, next_output_time, end_time, expected):
+        """Samples should be saved only on configured boundaries or at final time."""
+        assert Simulation._is_output_sample_due(sample_time, next_output_time, end_time) is expected
+
+    def test_initialize_population_output_status_supplies_required_fields(self):
+        """The initial sample should have status fields before the first physics update."""
+
+        class Population:
+            particles = {
+                'x': np.array([1.0, 2.0]),
+                'y': np.array([3.0, 4.0]),
+                'release_time': np.array([0.0, 10.0]),
+                'burial_depth': np.array([0.0, 0.0]),
+            }
+            _particle_simplices = np.array([5, -1])
+
+        population = Population()
+
+        Simulation._initialize_population_output_status([population], current_time=5.0)
+
+        expected_keys = {
+            'status_alive',
+            'status_buried',
+            'status_domain',
+            'status_transported',
+            'status_released',
+            'status_mobile',
+        }
+        assert expected_keys.issubset(population.particles)
+        np.testing.assert_array_equal(population.particles['status_domain'], np.array([True, False]))
+        np.testing.assert_array_equal(population.particles['status_released'], np.array([True, False]))
+        np.testing.assert_array_equal(population.particles['status_transported'], np.array([False, False]))
+        np.testing.assert_array_equal(population.particles['status_mobile'], np.array([False, False]))
 
 
 class TestSimulationManagerExpandTimeDimension:

--- a/tests/transport_converter/plugins/test_format_time_slicing.py
+++ b/tests/transport_converter/plugins/test_format_time_slicing.py
@@ -1,0 +1,51 @@
+import numpy as np
+import pytest
+
+from sedtrails.transport_converter.plugins.format.fm_netcdf import FormatPlugin as FmNetcdfFormatPlugin
+from sedtrails.transport_converter.plugins.format.sfincs import FormatPlugin as SfincsFormatPlugin
+
+
+@pytest.mark.parametrize('plugin_factory', [FmNetcdfFormatPlugin, SfincsFormatPlugin])
+def test_epoch_based_forcing_axis_uses_span_for_read_interval(tmp_path, plugin_factory):
+    """A read interval longer than the forcing span should load the full file."""
+    input_file = tmp_path / 'dummy.nc'
+    input_file.touch()
+    plugin = plugin_factory(str(input_file))
+    time_info = {
+        'seconds_since_reference': np.array(
+            [
+                1474485600.0,
+                1474486200.0,
+                1474486800.0,
+            ]
+        )
+    }
+
+    assert plugin._calculate_time_slice(
+        current_time=1474485600.0,
+        reading_interval=3600.0,
+        time_info=time_info,
+    ) == (None, None)
+
+
+@pytest.mark.parametrize('plugin_factory', [FmNetcdfFormatPlugin, SfincsFormatPlugin])
+def test_short_read_interval_still_chunks_epoch_based_forcing_axis(tmp_path, plugin_factory):
+    """Read intervals shorter than the forcing span should still request a chunk."""
+    input_file = tmp_path / 'dummy.nc'
+    input_file.touch()
+    plugin = plugin_factory(str(input_file))
+    time_info = {
+        'seconds_since_reference': np.array(
+            [
+                1474485600.0,
+                1474486200.0,
+                1474486800.0,
+            ]
+        )
+    }
+
+    assert plugin._calculate_time_slice(
+        current_time=1474485600.0,
+        reading_interval=600.0,
+        time_info=time_info,
+    ) == (0, 3)


### PR DESCRIPTION
Implement restart configuration generation so a new SedTRAILS run can continue from the last valid particle positions in a NetCDF output. Adds a new module (sedtrails.application_interfaces.restart) with create_restart_from_netcdf and RestartSummary, exposes create_restart_config in the API and package exports, and wires a CLI command (sedtrails config restart) to generate per-population seed CSVs and an updated restart YAML with adjusted start/duration. Documentation updated with usage examples and notes; example config corrected (data path, repeat_eulerian_fields, fixed population name). Also fixes trajectory plotting to robustly decode NetCDF population_name strings and handle empty time arrays safely. Unit tests for the restart flow and trajectory name decoding added, and CLI test extended to cover the restart command.