### PR TITLE
Add preliminary multiprocessing parallelism for HPC runs

### DIFF
--- a/src/sedtrails/config/main.schema.json
+++ b/src/sedtrails/config/main.schema.json
@@ -548,6 +548,17 @@
         }
       ]
     },
+    "compute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "n_workers": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of parallel worker processes. Falls back to SLURM_CPUS_PER_TASK env var, then 1 (single-core)."
+        }
+      }
+    },
     "visualization": {
       "$ref": "urn:sedtrails:config:visualization.schema.json"
     }

--- a/src/sedtrails/particle_tracer/particle_seeder.py
+++ b/src/sedtrails/particle_tracer/particle_seeder.py
@@ -821,6 +821,13 @@ class ParticleFactory:
         positions = StrategyClass.seed(config)
         _log_seeding_box_volume(config, positions)
 
+        # In parallel runs each worker takes every n_tasks-th position starting at task_id,
+        # giving non-overlapping deterministic subsets that together cover the full population.
+        task_id = int(os.environ.get('SEDTRAILS_TASK_ID', 0))
+        n_tasks = int(os.environ.get('SEDTRAILS_N_TASKS', 1))
+        if n_tasks > 1:
+            positions = positions[task_id::n_tasks]
+
         # Build a dedicated local RNG for burial-depth sampling, isolated from
         # other RNG usage. Seeded from the strategy seed when available (e.g.
         # RandomStrategy) so the simulation stays reproducible. For strategies

--- a/src/sedtrails/particle_tracer/particle_seeder.py
+++ b/src/sedtrails/particle_tracer/particle_seeder.py
@@ -836,6 +836,11 @@ class ParticleFactory:
         # then non-reproducible across runs for those strategies.
         # TODO: add a dedicated burial_depth.seed config key for full reproducibility.
         strategy_seed = getattr(config, 'strategy_settings', {}).get('seed', None)
+        # In parallel runs, mix task_id into the seed so each worker draws a
+        # different burial-depth sequence — without this every worker would start
+        # from the same RNG state and produce identical (correlated) depths.
+        if n_tasks > 1 and strategy_seed is not None:
+            strategy_seed = hash((strategy_seed, task_id))
         burial_rng = random.Random(strategy_seed)
 
         particles = []

--- a/src/sedtrails/simulation_orchestrator/parallel_worker.py
+++ b/src/sedtrails/simulation_orchestrator/parallel_worker.py
@@ -1,0 +1,173 @@
+"""
+Parallel worker utilities for multiprocessing-based HPC runs.
+
+All functions here live at module level so they are inherited by forked
+worker processes without pickling (Linux fork context copies the parent's
+full address space, including this module's globals).
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import numpy as np
+import xarray as xr
+
+# Set by Simulation._run_parallel before forking; workers inherit it read-only via CoW.
+# Reset to None after all workers finish to release the reference.
+_PRELOADED_INPUT_DATA = None
+
+
+def _available_ram_mb() -> float | None:
+    """Return MemAvailable from /proc/meminfo in MB, or None if unavailable."""
+    try:
+        with open('/proc/meminfo') as f:
+            for line in f:
+                if line.startswith('MemAvailable:'):
+                    return int(line.split()[1]) / 1024
+    except Exception:
+        pass
+    return None
+
+
+def _set_worker_memory_limit(n_tasks: int) -> None:
+    """Cap this worker's virtual address space to its fair share of available RAM.
+
+    On Linux with default overcommit settings, malloc() never returns NULL
+    regardless of memory pressure — the process stalls silently in swap until
+    the OOM killer sends SIGKILL, which Python cannot catch. Setting RLIMIT_AS
+    forces mmap()-based allocations (used by numpy for large arrays) to fail
+    immediately with a real MemoryError instead, which _worker_fn catches and
+    reports with a concrete fix suggestion.
+
+    The limit is: current virtual size (inherited CoW DFM pages + Python
+    runtime) plus this worker's equal share of the remaining available RAM.
+    """
+    avail = _available_ram_mb()
+    if avail is None:
+        return
+    try:
+        import resource
+        virt_mb = 0.0
+        with open('/proc/self/status') as f:
+            for line in f:
+                if line.startswith('VmSize:'):
+                    virt_mb = int(line.split()[1]) / 1024
+                    break
+        limit_bytes = int((virt_mb + avail / n_tasks) * 1024 * 1024)
+        resource.setrlimit(resource.RLIMIT_AS, (limit_bytes, resource.RLIM_INFINITY))
+    except Exception:
+        pass
+
+
+def _warn_if_oom_risk(dfm_mb: float, n_workers: int, read_interval_s: float,
+                      duration_s: float, logger) -> None:
+    """Warn before forking if estimated peak memory likely exceeds available RAM.
+
+    Each worker allocates physics arrays for one time chunk (~2.5x the chunk
+    size). The DFM itself is shared via CoW and counted only once.
+    """
+    avail = _available_ram_mb()
+    if avail is None:
+        return
+    chunk_frac = min(1.0, read_interval_s / duration_s) if duration_s > 0 else 1.0
+    per_worker_mb = dfm_mb * chunk_frac * 2.5
+    estimated_mb = dfm_mb + n_workers * per_worker_mb
+    if estimated_mb > avail * 0.85:
+        two_day_s = 2 * 86400
+        two_day_frac = min(1.0, two_day_s / duration_s) if duration_s > 0 else chunk_frac
+        two_day_per_worker_mb = dfm_mb * two_day_frac * 2.5
+        logger.warning(
+            'Estimated peak memory ~%.0f MB (%d workers × ~%.0f MB physics, DFM %.0f MB) '
+            'may exceed available ~%.0f MB — workers risk being killed by the OS without a '
+            'Python error. Reduce inputs.read_interval (e.g. read_interval: 2D → '
+            '~%.0f MB/worker, estimated total ~%.0f MB).',
+            estimated_mb, n_workers, per_worker_mb, dfm_mb, avail,
+            two_day_per_worker_mb, dfm_mb + n_workers * two_day_per_worker_mb,
+        )
+
+
+def _worker_fn(config_file: str, task_id: int, n_tasks: int) -> None:
+    """Worker entry point called by multiprocessing.Pool (Linux fork context).
+
+    Each worker runs a full Simulation on its own particle slice. The DFM
+    dataset preloaded in the parent is injected directly to avoid reloading
+    it from disk (the CoW pages are already in memory).
+    """
+    # Local import avoids a circular reference: simulation_manager imports this module.
+    from sedtrails.simulation_orchestrator.simulation_manager import Simulation
+
+    os.environ['SEDTRAILS_TASK_ID'] = str(task_id)
+    os.environ['SEDTRAILS_N_TASKS'] = str(n_tasks)
+
+    try:
+        import numba
+        numba.set_num_threads(1)
+        # numba.config.CACHE_DIR (not NUMBA_CACHE_DIR) — redirects JIT cache to a
+        # per-worker /tmp path so concurrent workers don't race on shared NFS .nbi/.nbc files.
+        numba.config.CACHE_DIR = f'/tmp/sedtrails_numba_{os.getpid()}'
+    except Exception:
+        pass
+
+    try:
+        sim = Simulation(config_file)
+        if _PRELOADED_INPUT_DATA is not None:
+            sim.format_converter.format_plugin.input_data = _PRELOADED_INPUT_DATA
+        _set_worker_memory_limit(n_tasks)
+        sim.run()
+    except MemoryError as e:
+        avail = _available_ram_mb()
+        avail_str = (f'{avail:.0f} MB available across {n_tasks} workers'
+                     if avail else f'{n_tasks} workers')
+        raise MemoryError(
+            f'Worker {task_id} ran out of memory allocating physics arrays ({e}).\n'
+            f'  Node: {avail_str}.\n'
+            f'  Fix: reduce inputs.read_interval in your config (e.g. read_interval: 2D) '
+            f'to limit how many DFM time steps each worker holds in memory at once.'
+        ) from None
+
+
+def _merge_outputs(base_output_dir: Path, logger) -> None:
+    """Concatenate per-worker NetCDF files along n_particles and remove task subdirectories."""
+    import shutil
+
+    task_files = sorted(base_output_dir.glob('task_*/sedtrails_results.nc'))
+    if not task_files:
+        raise FileNotFoundError(f'No task output files found in {base_output_dir}')
+
+    datasets = [xr.open_dataset(f) for f in task_files]
+
+    # Assign non-overlapping n_particles coordinates before concatenation
+    offset = 0
+    reindexed = []
+    for ds in datasets:
+        n = ds.sizes['n_particles']
+        reindexed.append(ds.assign_coords(n_particles=np.arange(offset, offset + n)))
+        offset += n
+
+    merged = xr.concat(reindexed, dim='n_particles', data_vars='minimal', coords='minimal')
+    merged = merged.load()
+
+    # Per-worker outputs each contain only that worker's particle slice, so
+    # population_count and population_start_idx are wrong after concat.
+    # Recalculate from the merged population_id array.
+    if 'population_id' in merged and 'population_count' in merged:
+        pop_ids = merged['population_id'].values
+        for pop_idx in range(merged.sizes['n_populations']):
+            mask = pop_ids == pop_idx
+            count = int(np.sum(mask))
+            start = int(np.argmax(mask)) if count > 0 else 0
+            merged['population_count'][pop_idx] = count
+            merged['population_start_idx'][pop_idx] = start
+
+    out_path = base_output_dir / 'sedtrails_results.nc'
+    merged.to_netcdf(out_path)
+
+    for ds in datasets:
+        ds.close()
+    for f in task_files:
+        shutil.rmtree(f.parent)
+
+    n_total = merged.sizes.get('n_particles', '?')
+    logger.info('Merged %d worker outputs -> %s (%s particles total)',
+                len(task_files), out_path, n_total)

--- a/src/sedtrails/simulation_orchestrator/parallel_worker.py
+++ b/src/sedtrails/simulation_orchestrator/parallel_worker.py
@@ -160,6 +160,18 @@ def _merge_outputs(base_output_dir: Path, logger) -> None:
             merged['population_count'][pop_idx] = count
             merged['population_start_idx'][pop_idx] = start
 
+    # Each worker numbers its particles from 0, so trajectory_id contains
+    # duplicates after concat (traj_0, traj_1, ... repeated N times).
+    # Regenerate globally unique IDs matching the merged n_particles index.
+    if 'trajectory_id' in merged:
+        n_total = merged.sizes['n_particles']
+        name_strlen = merged.sizes.get('name_strlen', 24)
+        new_ids = np.array(
+            [list(f'traj_{i}'.ljust(name_strlen)[:name_strlen]) for i in range(n_total)],
+            dtype='S1'
+        )
+        merged['trajectory_id'] = xr.DataArray(new_ids, dims=['n_particles', 'name_strlen'])
+
     out_path = base_output_dir / 'sedtrails_results.nc'
     merged.to_netcdf(out_path)
 

--- a/src/sedtrails/simulation_orchestrator/runtime_plan.py
+++ b/src/sedtrails/simulation_orchestrator/runtime_plan.py
@@ -6,8 +6,6 @@ import copy
 from dataclasses import asdict, dataclass, is_dataclass
 from typing import Any, Mapping, Sequence
 
-import numpy as np
-
 from sedtrails.exceptions.exceptions import ConfigurationError
 from sedtrails.transport_converter.physics_converter import PhysicsConfig, PhysicsConverter
 

--- a/src/sedtrails/simulation_orchestrator/runtime_plan.py
+++ b/src/sedtrails/simulation_orchestrator/runtime_plan.py
@@ -218,10 +218,9 @@ def _shallow_sedtrails_data_clone(sedtrails_data: Any) -> Any:
 
 
 def _copy_physics_value(value: Any) -> Any:
+    # Physics arrays are read-only after build_plan_sedtrails_data completes.
+    # Sharing by reference instead of copying avoids ~3.5 GB of duplicate
+    # allocations per parallel worker (previously np.array(value, copy=True)).
     if isinstance(value, dict):
-        return {key: _copy_physics_value(item) for key, item in value.items()}
-    if isinstance(value, np.ndarray):
-        return np.array(value, copy=True)
-    if hasattr(value, 'copy'):
-        return value.copy()
-    return copy.deepcopy(value)
+        return dict(value)
+    return value

--- a/src/sedtrails/simulation_orchestrator/simulation_manager.py
+++ b/src/sedtrails/simulation_orchestrator/simulation_manager.py
@@ -26,6 +26,7 @@ from sedtrails.simulation_orchestrator.runtime_plan import (
 )
 from sedtrails.transport_converter.format_converter import FormatConverter, SedtrailsData
 from sedtrails.transport_converter.physics_converter import PhysicsConverter
+from sedtrails.simulation_orchestrator import parallel_worker as _pw
 
 
 class Simulation:
@@ -139,17 +140,20 @@ class Simulation:
             return
 
         self.logger.info('=== SEDTRAILS PROFILE SUMMARY (%s) ===', status)
+        total_wall = sum(s['total'] for s in self._profile_timings.values())
         for name, stats in sorted(self._profile_timings.items(), key=lambda item: item[1]['total'], reverse=True):
             count = stats['count']
             total = stats['total']
             average = total / count if count else 0.0
+            pct = total / total_wall * 100 if total_wall > 0 else 0.0
             self.logger.info(
-                'profile %-42s count=%6d total=%10.6fs avg=%10.6fs max=%10.6fs',
+                'profile %-42s count=%6d total=%10.6fs avg=%10.6fs max=%10.6fs %5.1f%%',
                 name,
                 count,
                 total,
                 average,
                 stats['max'],
+                pct,
             )
 
     def _create_dashboard(self):
@@ -519,6 +523,13 @@ class Simulation:
             # Convert to Path object for consistency
             output_dir = Path(output_dir)
 
+        # In parallel runs each worker writes to its own task_XXXX/ subdirectory,
+        # which the parent merges into a single output file after all workers finish.
+        n_tasks = int(os.environ.get('SEDTRAILS_N_TASKS', 1))
+        if n_tasks > 1:
+            task_id = int(os.environ.get('SEDTRAILS_TASK_ID', 0))
+            output_dir = output_dir / f'task_{task_id:04d}'
+
         return output_dir
 
     def _get_physics_config(self):
@@ -678,8 +689,19 @@ class Simulation:
         return value
 
     def run(self):
-        """Execute the simulation and flush profile timings on failure."""
+        """Execute the simulation; dispatches to parallel workers when n_workers > 1."""
         try:
+            # Workers set SEDTRAILS_N_TASKS before calling run(); skip parallel dispatch
+            # to prevent infinite recursion (workers always go straight to _run_impl).
+            if int(os.environ.get('SEDTRAILS_N_TASKS', 1)) > 1:
+                return self._run_impl()
+
+            n_workers = int(
+                self._controller.get('compute.n_workers', None)
+                or os.environ.get('SLURM_CPUS_PER_TASK', 1)
+            )
+            if n_workers > 1:
+                return self._run_parallel(n_workers)
             return self._run_impl()
         except Exception:
             if self._active_progress_bar is not None:
@@ -687,6 +709,69 @@ class Simulation:
                 self._active_progress_bar = None
             self._log_profile_summary(status='interrupted')
             raise
+
+    def _run_parallel(self, n_workers: int) -> None:
+        """Fork n_workers subprocesses each handling a particle slice, then auto-merge.
+
+        The DFM dataset is loaded once in the parent and shared with workers via
+        Linux copy-on-write — workers inherit the pages read-only at near-zero cost.
+        """
+        import gc
+        import multiprocessing
+
+        base_output_dir = self._get_output_dir()
+        self.logger.info('Starting parallel run with %d workers -> %s', n_workers, base_output_dir)
+
+        # Preload DFM into numpy arrays in the parent so all workers share them via CoW.
+        plugin = self.format_converter.format_plugin
+        plugin.load()
+        plugin.input_data.load()
+        _pw._PRELOADED_INPUT_DATA = plugin.input_data
+        try:
+            dfm_mb = plugin.input_data.nbytes / 1e6
+            self.logger.info('DFM preloaded (%.0f MB), forking %d workers', dfm_mb, n_workers)
+        except Exception:
+            dfm_mb = 0.0
+            self.logger.info('DFM preloaded, forking %d workers', n_workers)
+
+        # Compute read_interval and duration in seconds for the OOM estimate.
+        try:
+            read_interval_s = float(Duration(self._controller.get('inputs.read_interval')).seconds)
+            duration_s = float(Duration(self._controller.get('time.duration')).seconds)
+        except Exception:
+            read_interval_s = duration_s = float('inf')
+        _pw._warn_if_oom_risk(dfm_mb, n_workers, read_interval_s, duration_s, self.logger)
+
+        worker_timeout = int(os.environ.get('SEDTRAILS_WORKER_TIMEOUT', 82800))
+        wall_t0 = time.perf_counter()
+
+        args = [(self._config_file, i, n_workers) for i in range(n_workers)]
+        n_failed = 0
+        with multiprocessing.Pool(processes=n_workers) as pool:
+            result = pool.starmap_async(_pw._worker_fn, args)
+            try:
+                result.get(timeout=worker_timeout)
+            except multiprocessing.TimeoutError:
+                n_failed += 1
+                self.logger.warning(
+                    'Worker timeout after %.0fs — terminating stuck workers', worker_timeout)
+                pool.terminate()
+            except Exception as e:
+                n_failed += 1
+                self.logger.warning(
+                    'Worker exception: %s — terminating pool, merging available outputs', e)
+                pool.terminate()
+
+        if n_failed:
+            self.logger.warning(
+                'Some workers failed or timed out; merge covers only completed outputs')
+
+        _pw._PRELOADED_INPUT_DATA = None
+        gc.collect()
+
+        _pw._merge_outputs(base_output_dir, self.logger)
+        self.logger.info('Total wall time: %.1fs (%d workers)',
+                         time.perf_counter() - wall_t0, n_workers)
 
     def _run_impl(self):
         """
@@ -697,6 +782,8 @@ class Simulation:
         if not self._config_is_read:  # assure config is read only once
             self._controller.load_config(self._config_file)
             self._config_is_read = True
+
+        wall_t0 = time.perf_counter()
 
         # Time configuration
         simulation_time = self._create_simulation_time()
@@ -1019,6 +1106,7 @@ class Simulation:
             output_file = self.data_manager.writer.close_output(nc_handle)
             nc_handle = None  # prevent double-close in finally
             print(f'Simulation results saved to: {output_file}')
+            self.logger.info('Total wall time: %.1fs', time.perf_counter() - wall_t0)
             self._log_profile_summary(status='completed')
 
             # Keep dashboard open after simulation ends

--- a/src/sedtrails/simulation_orchestrator/simulation_manager.py
+++ b/src/sedtrails/simulation_orchestrator/simulation_manager.py
@@ -747,7 +747,8 @@ class Simulation:
 
         args = [(self._config_file, i, n_workers) for i in range(n_workers)]
         n_failed = 0
-        with multiprocessing.Pool(processes=n_workers) as pool:
+        # Explicit fork context: CoW memory sharing only works with fork, not spawn.
+        with multiprocessing.get_context('fork').Pool(processes=n_workers) as pool:
             result = pool.starmap_async(_pw._worker_fn, args)
             try:
                 result.get(timeout=worker_timeout)

--- a/src/sedtrails/simulation_orchestrator/simulation_manager.py
+++ b/src/sedtrails/simulation_orchestrator/simulation_manager.py
@@ -768,6 +768,12 @@ class Simulation:
                 'Some workers failed or timed out; merge covers only completed outputs')
 
         _pw._PRELOADED_INPUT_DATA = None
+        # Also drop the reference still held by the format plugin; without this the
+        # DFM dataset stays alive in the parent until _merge_outputs completes.
+        try:
+            self.format_converter.format_plugin.input_data = None
+        except Exception:
+            pass
         gc.collect()
 
         _pw._merge_outputs(base_output_dir, self.logger)

--- a/tests/simulation_orchestrator/test_runtime_plan.py
+++ b/tests/simulation_orchestrator/test_runtime_plan.py
@@ -203,8 +203,11 @@ def test_build_plan_sedtrails_data_copies_only_required_physics_fields():
     assert source_data.get_physics_fields() == []
     assert plan_data.get_physics_fields() == ['bed_load_velocity', 'mixing_layer_thickness']
     assert not plan_data.has_physics_field('ignored_field')
+    # The dict wrapper is a new object (shallow copy), but the arrays inside are shared
+    # by reference. Physics arrays are read-only after computation, so sharing is safe
+    # and avoids ~3.5 GB of duplicate allocations per parallel worker.
     assert plan_data.bed_load_velocity is not converter.generated_velocity
-    assert plan_data.bed_load_velocity['x'] is not converter.generated_velocity['x']
+    assert plan_data.bed_load_velocity['x'] is converter.generated_velocity['x']
     np.testing.assert_array_equal(plan_data.bed_load_velocity['x'], np.array([1.0, 2.0]))
 
 


### PR DESCRIPTION
# Parallel execution — `bvw/parallel-preliminary` → `dev`

Adds opt-in multiprocessing parallelism to SedTRAILS for large HPC runs. A single config key (`compute.n_workers`) or the SLURM environment variable `SLURM_CPUS_PER_TASK` enables it. **The single-core path is completely unchanged** — no new code runs unless `n_workers > 1`.

Workers run unmodified `_run_impl()` loops on independent particle subsets; only the particle slice and output directory differ per worker.

---

## Files changed

| File | Change |
|------|--------|
| `simulation_orchestrator/parallel_worker.py` | **New module** — all parallel helpers at module level (required for fork inheritance) |
| `simulation_orchestrator/simulation_manager.py` | `_run_parallel()`, dispatch in `run()`, task subdir in `_get_output_dir()`, wall time + profile % |
| `simulation_orchestrator/runtime_plan.py` | `_copy_physics_value()` — share arrays by reference, fixes root-cause OOM |
| `particle_tracer/particle_seeder.py` | 7 lines — slice positions by `SEDTRAILS_TASK_ID`/`N_TASKS` |
| `config/main.schema.json` | Add optional `compute.n_workers` integer key |

---

## How to use

**Option 1 — config file:**
```yaml
compute:
  n_workers: 16
```

**Option 2 — SLURM (no config change needed):**
```bash
#SBATCH --cpus-per-task=16   # SedTRAILS reads SLURM_CPUS_PER_TASK automatically
sedtrails run -c config.yaml
```

See `scripts/submit_hpc.sh` for a minimal SLURM template.

---

## Parallel workflow

```
sedtrails run -c config.yaml
│
├─ reads compute.n_workers (or SLURM_CPUS_PER_TASK)  →  N workers
│
├─ parent: loads full DFM into numpy arrays (e.g. 4.2 GB for Westerschelde)
│
├─ forks N worker processes (Linux fork + copy-on-write)
│    ├─ worker 0  →  particles [0, N, 2N, ...]  →  task_0000/sedtrails_results.nc
│    ├─ worker 1  →  particles [1, N+1, 2N+1, ...]  →  task_0001/sedtrails_results.nc
│    └─ worker N-1  →  particles [N-1, 2N-1, ...]  →  task_000N/sedtrails_results.nc
│
├─ parent waits for all workers (timeout: SEDTRAILS_WORKER_TIMEOUT, default 23 h)
│    on timeout or exception → terminate pool, merge whatever completed
│
└─ parent merges task_*/sedtrails_results.nc  →  sedtrails_results.nc (all particles)
     recalculates population metadata, removes task_*/ subdirectories
```

### Particle assignment

`ParticleFactory.create_particles()` generates the full position list identically in every worker (same RNG sequence → deterministic). Each worker then slices `positions[task_id::n_tasks]`, giving non-overlapping subsets that together cover the full population. No inter-process communication is needed.

### DFM preload (copy-on-write sharing)

Before forking, the parent calls `plugin.load()` + `plugin.input_data.load()` to force lazy xarray datasets into numpy arrays. Forked children inherit these pages as copy-on-write — the ~4 GB DFM is effectively shared for free. Workers that need a new time chunk (via `read_interval`) slice from the already-loaded arrays, avoiding repeated NFS reads.

### Worker isolation

Each worker:
- Sets `SEDTRAILS_TASK_ID` / `SEDTRAILS_N_TASKS` (read by `particle_seeder`)
- Writes output to `task_XXXX/` subdirectory of the configured output dir
- Redirects Numba JIT cache to `/tmp/sedtrails_numba_<pid>` — prevents NFS write races on shared `.nbi`/`.nbc` files between concurrent workers
- Caps Numba thread count to 1 (`numba.set_num_threads(1)`) — prevents CPU oversubscription (N workers × M threads = N×M cores used)

### Merge

After all workers finish, the parent concatenates all `task_*/sedtrails_results.nc` files along `n_particles`. Population metadata (`population_count`, `population_start_idx`) is recalculated from the merged `population_id` array since per-worker files each contain only one slice. Task subdirectories are removed. The user sees a single `sedtrails_results.nc` identical in structure to a single-core output.

---

## Memory management

Peak memory per worker is dominated by physics arrays computed in `build_plan_sedtrails_data` — one array per physics field per time chunk (`n_times × n_nodes × float64`).

### Root-cause fix: `_copy_physics_value`

The original code used `np.array(value, copy=True)` to copy every physics array into `plan_data`. This duplicated ~3.5 GB per worker. Physics arrays are read-only after computation, so they are now shared by reference. This fix applies to both single-core and parallel runs.

### Per-worker memory estimate

| Factor | Value |
|--------|-------|
| DFM (parent, CoW-shared) | ~4.2 GB (Westerschelde) |
| Per-worker physics peak | ~2.5 × chunk size |
| Chunk size | `DFM × min(read_interval / duration, 1.0)` |

With `read_interval: 2D` on a 50-day simulation, chunk = 4% → ~170 MB/worker → 4 workers need ~5 GB total. Well within limits on a 31 GB 4vcpu node.

### Pre-fork OOM warning

Before forking, `_warn_if_oom_risk()` estimates peak memory and logs a WARNING if it exceeds 85% of available node RAM, including a concrete `read_interval` recommendation. This fires before any workers are started, giving the user a chance to cancel and adjust.

### RLIMIT_AS guard

On Linux with default overcommit settings, `malloc()` never returns `NULL` regardless of memory pressure — the process stalls silently in swap until the OOM killer sends `SIGKILL`, which Python cannot catch. Each worker calls `resource.setrlimit(RLIMIT_AS, ...)` to cap its virtual address space to its fair share of available RAM. This forces `mmap()`-based allocations (used by numpy for large arrays) to fail immediately with a real `MemoryError`, which `_worker_fn` catches and re-raises with a clear message pointing to `inputs.read_interval`.

---

## Single-core non-interference

| Condition | Behaviour |
|-----------|-----------|
| `compute.n_workers` not set, `SLURM_CPUS_PER_TASK` not set | `n_workers = 1` → `_run_impl()` unchanged |
| `SEDTRAILS_TASK_ID` / `SEDTRAILS_N_TASKS` not set | `n_tasks = 1` → no particle slicing |
| `_PRELOADED_INPUT_DATA` is None | DFM injection in worker skipped |
| Worker calls `run()` | `SEDTRAILS_N_TASKS > 1` guard routes directly to `_run_impl()`, preventing recursive dispatch |

The `_copy_physics_value` fix is safe for single-core too — physics arrays are read-only after `build_plan_sedtrails_data` in both code paths.

---

## Benchmark — Westerschelde (10,000 particles, 50 days, `read_interval: 2D`, `repeat_eulerian_fields: true`)

Tested on Deltares H7 cluster (hal8 nodes):

| Config | Workers | Wall time | Speedup |
|--------|---------|-----------|---------|
| 1vcpu  | 1  | 5783s (~96 min) | 1× (baseline) |
| 4vcpu  | 4  | 1286s (~21 min) | **4.5×** |
| 16vcpu | 16 |  541s  (~9 min) | **10.7×** |

4vcpu scales near-linearly. 16vcpu reaches 10.7× — sub-linear due to fork/DFM-preload overhead and the merge step, but strong for a zero-MPI implementation. Profile of the dominant cost (16vcpu, per worker):

| Section | Time | % |
|---------|------|---|
| update_information (field interpolation) | 308.8s | 83% |
| get_flow_field | 19.1s | 5% |
| convert_to_sedtrails | 13.2s | 4% |
| record_output | 9.0s | 2% |

`update_information` dominates at 83% and scales linearly with particle count — exactly what parallel execution targets.

---

## Known limitations

- **Linux-only.** Uses `fork` context. Windows uses `spawn` by default (no shared CoW memory) and is not tested.
- **`read_interval` matters.** With `read_interval` ≥ simulation duration the full DFM is loaded per chunk (~10 GB/worker for Westerschelde). The pre-fork warning will fire, but on overcommitting nodes workers may still be OOM-killed silently despite RLIMIT_AS. Setting `read_interval: 2D` (or similar) keeps per-worker memory well within node limits.
- **Preliminary.** This is the simplest possible implementation. A production replacement would use MPI or a proper task scheduler. The design is forward-compatible: workers run standard `_run_impl()` loops; only the particle slice and output directory differ.
