### PR TITLE
Speed up trajectory plotting and defaults (no actual gui involved)

### DIFF
--- a/docs/user/output.md
+++ b/docs/user/output.md
@@ -151,6 +151,18 @@ Use ``sedtrails viz trajectories`` to plot the saved ``x``, ``y``, and ``time`` 
 sedtrails viz trajectories -f C:\your-filepath-here\sedtrails_results.nc
 ```
 
+By default, the command draws only the spatial trajectory panel so it remains usable for large particle sets. Write directly to a file and plot a deterministic sample for the fastest workflow:
+
+```text
+sedtrails viz trajectories -f C:\your-filepath-here\sedtrails_results.nc --output trajectories.png --max-particles 2000 --markers end
+```
+
+Use ``--panels all`` to draw the previous four-panel summary, or request selected optional panels:
+
+```text
+sedtrails viz trajectories -f C:\your-filepath-here\sedtrails_results.nc --panels spatial,population --output trajectories.png
+```
+
 ![SedTRAILS trajectory example](../_static/img/example-trajectory-plots.png)
 
 The built-in trajectory plotter reads the saved particle coordinates directly. Its distance panel is computed from each particle's saved ``x`` and ``y`` positions relative to that particle's first valid position; it does not use ``covered_distance``.
@@ -158,8 +170,16 @@ The built-in trajectory plotter reads the saved particle coordinates directly. I
 The following options can be used to save and customize the plot:
 
 - ``--file`` or ``-f``: Path to the SedTRAILS NetCDF file to visualize. By default, it expects ``sedtrails_results.nc`` in the current directory.
+- ``--output``: Exact plot file path to write. When used, the plot is saved directly and no figure window is opened by default.
 - ``--save`` or ``-s``: Save the figure as ``particle_trajectories.png``.
 - ``--output-dir`` or ``-o``: Directory for the saved PNG when ``--save`` is used. The default is the current directory.
+- ``--max-particles``: Maximum number of particles to plot. The sample is deterministic and stratified by population where population IDs are available.
+- ``--sample-fraction``: Fraction of particles to plot. This cannot be combined with ``--max-particles``.
+- ``--sample-seed``: Seed for deterministic sampling. The default is ``0``.
+- ``--markers``: Endpoint markers to draw: ``none``, ``end``, or ``start-end``. The default preserves both start and end markers.
+- ``--marker-size``: Marker size for start/end points. The default is ``12``, which is smaller than earlier SedTRAILS versions.
+- ``--panels``: Panels to draw. The default is ``spatial``. Use ``all`` for the previous four-panel plot, or a comma-separated subset of ``spatial``, ``distance``, ``population``, and ``population-distance``.
+- ``--show`` or ``--no-show``: Override whether an interactive figure window is displayed. By default, saved plots are not shown and unsaved plots are shown.
 - ``--help`` or ``-h``: Show the command help.
 
 :::warning

--- a/docs/user/output.md
+++ b/docs/user/output.md
@@ -171,8 +171,8 @@ The following options can be used to save and customize the plot:
 
 - ``--file`` or ``-f``: Path to the SedTRAILS NetCDF file to visualize. By default, it expects ``sedtrails_results.nc`` in the current directory.
 - ``--output``: Exact plot file path to write. When used, the plot is saved directly and no figure window is opened by default.
-- ``--save`` or ``-s``: Save the figure as ``particle_trajectories.png``.
-- ``--output-dir`` or ``-o``: Directory for the saved PNG when ``--save`` is used. The default is the current directory.
+ - ``--save``/``--no-save`` or ``-s``: Save the figure as ``particle_trajectories.png`` (default). Use ``--no-save`` to display the figure instead.
+ - ``--output-dir`` or ``-o``: Directory for the saved PNG when ``--output`` is not provided. Defaults to the NetCDF file directory.
 - ``--max-particles``: Maximum number of particles to plot. The sample is deterministic and stratified by population where population IDs are available.
 - ``--sample-fraction``: Fraction of particles to plot. This cannot be combined with ``--max-particles``.
 - ``--sample-seed``: Seed for deterministic sampling. The default is ``0``.

--- a/docs/user/output.md
+++ b/docs/user/output.md
@@ -176,8 +176,8 @@ The following options can be used to save and customize the plot:
 - ``--max-particles``: Maximum number of particles to plot. The sample is deterministic and stratified by population where population IDs are available.
 - ``--sample-fraction``: Fraction of particles to plot. This cannot be combined with ``--max-particles``.
 - ``--sample-seed``: Seed for deterministic sampling. The default is ``0``.
-- ``--markers``: Endpoint markers to draw: ``none``, ``end``, or ``start-end``. The default preserves both start and end markers.
-- ``--marker-size``: Marker size for start/end points. The default is ``12``, which is smaller than earlier SedTRAILS versions.
+- ``--markers``: Endpoint markers to draw: ``none``, ``end``, or ``start-end``. The default is ``end``.
+- ``--marker-size``: Marker size for start/end points. The default is ``3``.
 - ``--panels``: Panels to draw. The default is ``spatial``. Use ``all`` for the previous four-panel plot, or a comma-separated subset of ``spatial``, ``distance``, ``population``, and ``population-distance``.
 - ``--show`` or ``--no-show``: Override whether an interactive figure window is displayed. By default, saved plots are not shown and unsaved plots are shown.
 - ``--help`` or ``-h``: Show the command help.

--- a/docs/user/visualization.md
+++ b/docs/user/visualization.md
@@ -4,6 +4,47 @@ This page is a placeholder for SedTRAILS visualization guidance beyond the live 
 
 For the real-time run dashboard, see [Monitoring Dashboard](dashboard.md). For output file inspection and trajectory plotting commands, see [Output](output.md).
 
+## Basic Visualization
+
+Use ``sedtrails viz trajectories`` to plot the saved ``x``, ``y``, and ``time`` trajectories:
+
+```text
+sedtrails viz trajectories -f C:\your-filepath-here\sedtrails_results.nc
+```
+
+By default, the command draws only the spatial trajectory panel so it remains usable for large particle sets. Write directly to a file and plot a deterministic sample for the fastest workflow:
+
+```text
+sedtrails viz trajectories -f C:\your-filepath-here\sedtrails_results.nc --output trajectories.png --max-particles 2000 --markers end
+```
+
+Use ``--panels all`` to draw the previous four-panel summary, or request selected optional panels:
+
+```text
+sedtrails viz trajectories -f C:\your-filepath-here\sedtrails_results.nc --panels spatial,population --output trajectories.png
+```
+
+![SedTRAILS trajectory example](../_static/img/example-trajectory-plots.png)
+
+The built-in trajectory plotter reads the saved particle coordinates directly. Its distance panel is computed from each particle's saved ``x`` and ``y`` positions relative to that particle's first valid position; it does not use ``covered_distance``.
+
+The following options can be used to save and customize the plot:
+
+- ``--file`` or ``-f``: Path to the SedTRAILS NetCDF file to visualize. By default, it expects ``sedtrails_results.nc`` in the current directory.
+- ``--output`` or ``-o``: Output target. If this points to an existing directory, SedTRAILS writes ``particle_trajectories.png`` inside it. Otherwise, SedTRAILS treats it as a filename. If omitted, SedTRAILS writes ``particle_trajectories.png`` next to the NetCDF file.
+- ``--max-particles``: Maximum number of particles to plot. The sample is deterministic and stratified by population where population IDs are available.
+- ``--sample-fraction``: Fraction of particles to plot. This cannot be combined with ``--max-particles``.
+- ``--sample-seed``: Seed for deterministic sampling. The default is ``0``.
+- ``--markers``: Endpoint markers to draw: ``none``, ``end``, or ``start-end``. The default is ``end``.
+- ``--marker-size``: Marker size for start/end points. The default is ``3``.
+- ``--panels``: Panels to draw. The default is ``spatial``. Use ``all`` for a four-panel plot, or a comma-separated subset of ``spatial``, ``distance``, ``population``, and ``population-distance``.
+- ``--show`` or ``--no-show``: Override whether an interactive figure window is displayed. By default, plots are not shown.
+- ``--help`` or ``-h``: Show the command help.
+
+:::warning
+More advanced visualization functions will be added in future releases, but for now we encourage users to build custom visualizations directly from the output data.
+:::
+
 ## Bathymetry colormaps
 
 SedTRAILS has reusable bathymetry colormaps for input-data checks and visualization tools. These are currently used by the seeding setup GUI and can also be reused from Python plotting scripts.

--- a/src/sedtrails/__init__.py
+++ b/src/sedtrails/__init__.py
@@ -24,7 +24,7 @@ Examples
 --------
 >>> import sedtrails
 >>> sedtrails.run_simulation('config.yml', output='results.nc')
->>> sedtrails.plot_trajectories('results.nc', save=True)
+>>> sedtrails.plot_trajectories('results.nc')
 """
 
 from .__version__ import __version__

--- a/src/sedtrails/application_interfaces/api.py
+++ b/src/sedtrails/application_interfaces/api.py
@@ -286,6 +286,14 @@ def plot_trajectories(
     results_file: str,
     save: bool = False,
     output_dir: str = '.',
+    output_file: str | None = None,
+    max_particles: int | None = None,
+    sample_fraction: float | None = None,
+    sample_seed: int = 0,
+    markers: str = 'start-end',
+    marker_size: float = 12.0,
+    panels: str = 'spatial',
+    show: bool | None = None,
 ) -> None:
     """
     Plot particle trajectories from a SedTRAILS NetCDF results file.
@@ -299,6 +307,29 @@ def plot_trajectories(
     output_dir : str, optional
         Directory where the plot will be saved if save=True.
         Default is current directory.
+    output_file : str, optional
+        Exact path where the plot should be written. This enables headless
+        file output and takes precedence over ``save``/``output_dir``.
+    max_particles : int, optional
+        Maximum number of particles to plot. Mutually exclusive with
+        ``sample_fraction``.
+    sample_fraction : float, optional
+        Fraction of particles to plot. Mutually exclusive with
+        ``max_particles``.
+    sample_seed : int, optional
+        Seed used for deterministic sampling.
+    markers : str, optional
+        Endpoint marker mode: ``none``, ``end``, or ``start-end``.
+    marker_size : float, optional
+        Marker size for start/end points. Default is 12.
+    panels : str, optional
+        Panels to draw. Default is ``spatial`` for the fast single-panel plot.
+        Use ``all`` for the previous four-panel figure, or a comma-separated
+        subset of ``spatial``, ``distance``, ``population``, and
+        ``population-distance``.
+    show : bool, optional
+        Whether to display the figure. Defaults to display-only when no output
+        path is requested.
 
     Examples
     --------
@@ -312,7 +343,22 @@ def plot_trajectories(
     from sedtrails.pathway_visualizer import read_netcdf
 
     ds = read_netcdf(results_file)
-    _plot(ds, save_plot=save, output_dir=output_dir)
+    try:
+        _plot(
+            ds,
+            save_plot=save,
+            output_dir=output_dir,
+            output_file=output_file,
+            max_particles=max_particles,
+            sample_fraction=sample_fraction,
+            sample_seed=sample_seed,
+            markers=markers,
+            marker_size=marker_size,
+            panels=panels,
+            show=show,
+        )
+    finally:
+        ds.close()
 
 
 def inspect_netcdf(results_file: str) -> 'NetCDFInspector':

--- a/src/sedtrails/application_interfaces/api.py
+++ b/src/sedtrails/application_interfaces/api.py
@@ -284,9 +284,7 @@ def create_restart_config(
 
 def plot_trajectories(
     results_file: str,
-    save: bool = False,
-    output_dir: str = '.',
-    output_file: str | None = None,
+    output: str | None = None,
     max_particles: int | None = None,
     sample_fraction: float | None = None,
     sample_seed: int = 0,
@@ -302,14 +300,11 @@ def plot_trajectories(
     ----------
     results_file : str
         Path to the SedTRAILS NetCDF results file.
-    save : bool, optional
-        Whether to save the plot as a PNG file. Default is False (display only).
-    output_dir : str, optional
-        Directory where the plot will be saved if save=True (and output_file is not set).
-        Default ``'.'`` uses the NetCDF file directory when available.
-    output_file : str, optional
-        Exact path where the plot should be written. This enables headless
-        file output and takes precedence over ``save``/``output_dir``.
+    output : str, optional
+        Output target. If ``output`` is an existing directory, the plot is
+        written as ``particle_trajectories.png`` inside it. Otherwise,
+        ``output`` is treated as a filename. If omitted, the default output
+        is ``particle_trajectories.png`` in the NetCDF file directory.
     max_particles : int, optional
         Maximum number of particles to plot. Mutually exclusive with
         ``sample_fraction``.
@@ -334,10 +329,13 @@ def plot_trajectories(
     Examples
     --------
     >>> import sedtrails
-    >>> sedtrails.plot_trajectories('results.nc', save=True)
-
-    >>> # Display without saving
     >>> sedtrails.plot_trajectories('results.nc')
+
+    >>> # Save in an existing folder using the default file name
+    >>> sedtrails.plot_trajectories('results.nc', output='plots')
+
+    >>> # Save to an explicit file
+    >>> sedtrails.plot_trajectories('results.nc', output='plots/custom_name.png')
     """
     from sedtrails.pathway_visualizer import plot_trajectories as _plot
     from sedtrails.pathway_visualizer import read_netcdf
@@ -346,9 +344,7 @@ def plot_trajectories(
     try:
         _plot(
             ds,
-            save_plot=save,
-            output_dir=output_dir,
-            output_file=output_file,
+            output=output,
             max_particles=max_particles,
             sample_fraction=sample_fraction,
             sample_seed=sample_seed,

--- a/src/sedtrails/application_interfaces/api.py
+++ b/src/sedtrails/application_interfaces/api.py
@@ -305,8 +305,8 @@ def plot_trajectories(
     save : bool, optional
         Whether to save the plot as a PNG file. Default is False (display only).
     output_dir : str, optional
-        Directory where the plot will be saved if save=True.
-        Default is current directory.
+        Directory where the plot will be saved if save=True (and output_file is not set).
+        Default ``'.'`` uses the NetCDF file directory when available.
     output_file : str, optional
         Exact path where the plot should be written. This enables headless
         file output and takes precedence over ``save``/``output_dir``.

--- a/src/sedtrails/application_interfaces/cli/main.py
+++ b/src/sedtrails/application_interfaces/cli/main.py
@@ -447,16 +447,56 @@ def plot_trajectories_cmd(
         help='Path to the SedTRAILS netCDF file to visualize. By default, it expects an "sedtrails_results.nc" file in the current directory.',
     ),
     save_fig: bool = typer.Option(
-        False,
-        '--save',
+        True,
+        '--save/--no-save',
         '-s',
-        help='Save plot as a PNG file. Creates a "particle_trajectories.png" file',
+        help='Save plot as a PNG file by default. Use --no-save to display the figure instead.',
+    ),
+    output_file: str | None = typer.Option(
+        None,
+        '--output',
+        help='Write the plot directly to this file path instead of using the default output location.',
     ),
     output_dir: str = typer.Option(
         '.',
         '--output-dir',
         '-o',
-        help='Directory to save plot if --save is used. Default is the current directory.',
+        help='Directory to save the plot when --output is not provided. Defaults to the NetCDF file directory.',
+    ),
+    max_particles: int | None = typer.Option(
+        10000,
+        '--max-particles',
+        help='Maximum number of particles to plot. Sampling is deterministic and stratified by population.',
+    ),
+    sample_fraction: float | None = typer.Option(
+        None,
+        '--sample-fraction',
+        help='Fraction of particles to plot. Mutually exclusive with --max-particles.',
+    ),
+    sample_seed: int = typer.Option(
+        0,
+        '--sample-seed',
+        help='Seed for deterministic particle sampling.',
+    ),
+    markers: str = typer.Option(
+        'end',
+        '--markers',
+        help='Endpoint markers to draw: none, end, or start-end. Default is end.',
+    ),
+    marker_size: float = typer.Option(
+        3.0,
+        '--marker-size',
+        help='Marker size for start/end points. Default is 3.',
+    ),
+    panels: str = typer.Option(
+        'spatial',
+        '--panels',
+        help='Panels to draw: spatial, distance, population, population-distance, all, or a comma-separated subset.',
+    ),
+    show: bool | None = typer.Option(
+        None,
+        '--show/--no-show',
+        help='Display the figure window. Defaults to no window when saving to a file.',
     ),
 ):
     """
@@ -468,16 +508,42 @@ def plot_trajectories_cmd(
         Path to the SedTRAILS NetCDF results file.
     save_fig : bool
         The save fig value.
+    output_file : str | None
+        Exact plot file to write.
     output_dir : str
         Directory where output files are written.
+    max_particles : int | None
+        Maximum number of particles to plot.
+    sample_fraction : float | None
+        Fraction of particles to plot.
+    sample_seed : int
+        Seed for deterministic sampling.
+    markers : str
+        Endpoint marker mode.
+    marker_size : float
+        Marker size for start/end points.
+    panels : str
+        Panels to draw.
+    show : bool | None
+        Whether to display the figure.
     """
     from sedtrails.application_interfaces.api import plot_trajectories
 
     try:
-        plot_trajectories(results_file, save=save_fig, output_dir=output_dir)
-        if save_fig:
-            typer.echo(f"Plot saved to '{output_dir}/particle_trajectories.png'")
-        else:
+        plot_trajectories(
+            results_file,
+            save=save_fig,
+            output_dir=output_dir,
+            output_file=output_file,
+            max_particles=max_particles,
+            sample_fraction=sample_fraction,
+            sample_seed=sample_seed,
+            markers=markers,
+            marker_size=marker_size,
+            panels=panels,
+            show=show,
+        )
+        if not output_file and not save_fig:
             typer.echo('Plot displayed successfully')
     except Exception as e:
         typer.echo(f'Error plotting trajectories: {e}')

--- a/src/sedtrails/application_interfaces/cli/main.py
+++ b/src/sedtrails/application_interfaces/cli/main.py
@@ -446,22 +446,16 @@ def plot_trajectories_cmd(
         '-f',
         help='Path to the SedTRAILS netCDF file to visualize. By default, it expects an "sedtrails_results.nc" file in the current directory.',
     ),
-    save_fig: bool = typer.Option(
-        True,
-        '--save/--no-save',
-        '-s',
-        help='Save plot as a PNG file by default. Use --no-save to display the figure instead.',
-    ),
-    output_file: str | None = typer.Option(
+    output: str | None = typer.Option(
         None,
         '--output',
-        help='Write the plot directly to this file path instead of using the default output location.',
-    ),
-    output_dir: str = typer.Option(
-        '.',
-        '--output-dir',
         '-o',
-        help='Directory to save the plot when --output is not provided. Defaults to the NetCDF file directory.',
+        help=(
+            'Output target. If this is an existing directory, the plot is written as '
+            '"particle_trajectories.png" inside it. Otherwise, this is treated as a '
+            'filename. If omitted, defaults to "particle_trajectories.png" in the '
+            'NetCDF file directory.'
+        ),
     ),
     max_particles: int | None = typer.Option(
         10000,
@@ -506,12 +500,8 @@ def plot_trajectories_cmd(
     ----------
     results_file : str
         Path to the SedTRAILS NetCDF results file.
-    save_fig : bool
-        The save fig value.
-    output_file : str | None
-        Exact plot file to write.
-    output_dir : str
-        Directory where output files are written.
+    output : str | None
+        Output path or directory.
     max_particles : int | None
         Maximum number of particles to plot.
     sample_fraction : float | None
@@ -532,9 +522,7 @@ def plot_trajectories_cmd(
     try:
         plot_trajectories(
             results_file,
-            save=save_fig,
-            output_dir=output_dir,
-            output_file=output_file,
+            output=output,
             max_particles=max_particles,
             sample_fraction=sample_fraction,
             sample_seed=sample_seed,
@@ -543,7 +531,7 @@ def plot_trajectories_cmd(
             panels=panels,
             show=show,
         )
-        if not output_file and not save_fig:
+        if show is True:
             typer.echo('Plot displayed successfully')
     except Exception as e:
         typer.echo(f'Error plotting trajectories: {e}')

--- a/src/sedtrails/pathway_visualizer/trajectories.py
+++ b/src/sedtrails/pathway_visualizer/trajectories.py
@@ -358,7 +358,7 @@ def _distance_line_segments(
     y_data: np.ndarray,
     time_data: np.ndarray,
     min_time: float,
-) -> tuple[list[np.ndarray], list[np.ndarray], dict[int, tuple[np.ndarray, np.ndarray]]]:
+) -> tuple[list[np.ndarray], np.ndarray, dict[int, tuple[np.ndarray, np.ndarray]]]:
     distance_segments = []
     distance_indices = []
     particle_distances = {}
@@ -402,12 +402,11 @@ def _resolve_output_file(ds: xr.Dataset, save_plot: bool, output_dir, output_fil
         return Path(output_file)
     if not save_plot:
         return None
-    if output_dir is None or output_dir == '.':
+    output_dir_path = Path(output_dir) if output_dir is not None else Path('.')
+    if output_dir is None or output_dir_path == Path('.'):
         source_file = ds.encoding.get('source', '.')
-        output_dir = Path(source_file).parent
-    else:
-        output_dir = Path(output_dir)
-    return output_dir / 'particle_trajectories.png'
+        output_dir_path = Path(source_file).parent
+    return output_dir_path / 'particle_trajectories.png'
 
 
 def _normalize_panels(panels: str | list[str] | tuple[str, ...]) -> list[str]:

--- a/src/sedtrails/pathway_visualizer/trajectories.py
+++ b/src/sedtrails/pathway_visualizer/trajectories.py
@@ -5,6 +5,7 @@ Module for visualizing particle trajectories from SedTRAILS NetCDF output files.
 from pathlib import Path
 import re
 import numpy as np
+from matplotlib.collections import LineCollection
 import matplotlib.pyplot as plt
 import xarray as xr
 
@@ -99,6 +100,143 @@ def _time_values_as_seconds(ds: xr.Dataset, time_var: xr.DataArray) -> np.ndarra
     return np.asarray(values, dtype=float)
 
 
+def _infer_particle_dim(ds: xr.Dataset) -> str | None:
+    """Infer the particle dimension used by the trajectory arrays."""
+    if 'x' not in ds:
+        return None
+
+    x_var = ds['x']
+    if x_var.ndim == 1:
+        return x_var.dims[0]
+    if x_var.ndim == 2 and 'time' in ds and ds['time'].ndim == 1 and x_var.dims[0] == ds['time'].dims[0]:
+        return x_var.dims[1]
+    if 'n_particles' in ds.sizes:
+        return 'n_particles'
+    if 'population_id' in ds and ds['population_id'].ndim == 1:
+        return ds['population_id'].dims[0]
+    return None
+
+
+def _particle_count(ds: xr.Dataset) -> int:
+    particle_dim = _infer_particle_dim(ds)
+    if particle_dim is None:
+        return 0
+    return int(ds.sizes[particle_dim])
+
+
+def _select_sample_indices(
+    n_particles: int,
+    population_ids: np.ndarray | None = None,
+    *,
+    max_particles: int | None = None,
+    sample_fraction: float | None = None,
+    sample_seed: int = 0,
+) -> np.ndarray:
+    """Return deterministic particle indices for plotting."""
+    if max_particles is not None and sample_fraction is not None:
+        raise ValueError("'max_particles' and 'sample_fraction' are mutually exclusive.")
+    if max_particles is not None and max_particles < 1:
+        raise ValueError("'max_particles' must be at least 1.")
+    if sample_fraction is not None and not (0.0 < sample_fraction <= 1.0):
+        raise ValueError("'sample_fraction' must be greater than 0 and less than or equal to 1.")
+
+    if n_particles <= 0:
+        return np.array([], dtype=int)
+    if max_particles is None and sample_fraction is None:
+        return np.arange(n_particles, dtype=int)
+
+    if max_particles is not None:
+        target = min(int(max_particles), n_particles)
+    else:
+        target = int(np.ceil(n_particles * float(sample_fraction)))
+        target = max(1, min(target, n_particles))
+
+    if target >= n_particles:
+        return np.arange(n_particles, dtype=int)
+
+    rng = np.random.default_rng(sample_seed)
+    if population_ids is None or len(population_ids) != n_particles:
+        return np.sort(rng.choice(n_particles, size=target, replace=False))
+
+    selected: list[np.ndarray] = []
+    unique_populations = np.unique(population_ids)
+    population_indices = [np.flatnonzero(population_ids == pop_id) for pop_id in unique_populations]
+    ideal_counts = np.array([len(indices) * target / n_particles for indices in population_indices], dtype=float)
+    counts = np.floor(ideal_counts).astype(int)
+
+    if target >= len(population_indices):
+        counts = np.maximum(counts, 1)
+
+    overflow = int(counts.sum() - target)
+    if overflow > 0:
+        removable_order = np.argsort(ideal_counts - counts)
+        for idx in removable_order:
+            if overflow == 0:
+                break
+            minimum = 1 if target >= len(population_indices) else 0
+            if counts[idx] > minimum:
+                counts[idx] -= 1
+                overflow -= 1
+
+    remainder = int(target - counts.sum())
+    if remainder > 0:
+        fractional_order = np.argsort(-(ideal_counts - np.floor(ideal_counts)))
+        for idx in fractional_order:
+            if remainder == 0:
+                break
+            capacity = len(population_indices[idx]) - counts[idx]
+            if capacity > 0:
+                counts[idx] += 1
+                remainder -= 1
+
+    for indices, count in zip(population_indices, counts, strict=True):
+        if count > 0:
+            selected.append(rng.choice(indices, size=min(count, len(indices)), replace=False))
+
+    if not selected:
+        return np.array([], dtype=int)
+
+    selected_indices = np.unique(np.concatenate(selected).astype(int))
+    if selected_indices.size < target:
+        remaining_pool = np.setdiff1d(np.arange(n_particles, dtype=int), selected_indices, assume_unique=True)
+        if remaining_pool.size:
+            extra = rng.choice(remaining_pool, size=min(target - selected_indices.size, remaining_pool.size), replace=False)
+            selected_indices = np.concatenate((selected_indices, extra))
+    elif selected_indices.size > target:
+        selected_indices = rng.choice(selected_indices, size=target, replace=False)
+
+    return np.sort(selected_indices)
+
+
+def _sample_dataset(
+    ds: xr.Dataset,
+    *,
+    max_particles: int | None = None,
+    sample_fraction: float | None = None,
+    sample_seed: int = 0,
+) -> tuple[xr.Dataset, int, int]:
+    """Return a dataset sampled along the particle dimension before materialization."""
+    n_total = _particle_count(ds)
+    population_ids = None
+    if 'population_id' in ds:
+        population_ids = np.asarray(ds['population_id'].values)
+
+    indices = _select_sample_indices(
+        n_total,
+        population_ids,
+        max_particles=max_particles,
+        sample_fraction=sample_fraction,
+        sample_seed=sample_seed,
+    )
+    if len(indices) == n_total:
+        return ds, n_total, n_total
+
+    particle_dim = _infer_particle_dim(ds)
+    if particle_dim is None:
+        return ds, n_total, n_total
+    return ds.isel({particle_dim: indices}), n_total, len(indices)
+
+
 def _trajectory_arrays(ds: xr.Dataset) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Return x/y/time arrays in plotting shape: (n_particles, n_timesteps)."""
     x_var = ds['x']
@@ -142,41 +280,7 @@ def _trajectory_arrays(ds: xr.Dataset) -> tuple[np.ndarray, np.ndarray, np.ndarr
     return x_data, y_data, time_data
 
 
-def plot_trajectories(ds, save_plot=False, output_dir=None):
-    """Plot particle trajectories from a SedTRAILS dataset.
-
-    Parameters
-    ----------
-    ds : xarray.Dataset
-        Dataset containing particle trajectory variables, including ``x``,
-        ``y``, and ``time``.
-    save_plot : bool, optional
-        If true, save the generated figure as ``particle_trajectories.png``.
-    output_dir : str or pathlib.Path, optional
-        Directory where the figure is saved. If omitted, the source dataset
-        directory is used when available.
-
-    Notes
-    -----
-    This function creates a four-panel matplotlib figure and displays it with
-    ``plt.show()``. It does not return the figure or axes.
-    """
-
-    # Extract trajectory data
-    x_data, y_data, time_data = _trajectory_arrays(ds)
-
-    n_particles, n_timesteps = x_data.shape
-
-    print(f'\nPlotting trajectories for {n_particles} particles over {n_timesteps} timesteps...')
-
-    # Create the plot with 2x2 subplots
-    fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(2, 2, figsize=(20, 16))
-
-    # Extract population information for color coding
-    population_ids = ds['population_id'].values if 'population_id' in ds else np.zeros(n_particles, dtype=int)
-    n_populations = int(ds.sizes['n_populations']) if 'n_populations' in ds.sizes else 1
-
-    # Get population names
+def _decode_population_names(ds: xr.Dataset, n_populations: int) -> list[str]:
     population_names = []
     if 'population_name' in ds:
         population_var = ds['population_name']
@@ -184,7 +288,6 @@ def plot_trajectories(ds, save_plot=False, output_dir=None):
         n_to_decode = min(n_populations, n_available_names)
 
         for i in range(n_to_decode):
-            # Handle both 1D fixed-width strings and 2D character arrays
             if population_var.ndim == 1:
                 raw_name = population_var[i].values
             else:
@@ -197,252 +300,457 @@ def plot_trajectories(ds, save_plot=False, output_dir=None):
     else:
         population_names = [f'Population {i}' for i in range(n_populations)]
 
-    # Define colors for populations
+    return population_names
+
+
+def _population_colors(n_populations: int):
     try:
         pop_cmap = plt.get_cmap('Set1')
-        pop_colors = pop_cmap(np.linspace(0, 1, n_populations))
+        return pop_cmap(np.linspace(0, 1, n_populations))
     except (AttributeError, ValueError):
-        # Fallback to basic colors
         base_colors = ['red', 'blue', 'green', 'orange', 'purple', 'brown', 'pink', 'gray']
-        pop_colors = [base_colors[i % len(base_colors)] for i in range(n_populations)]
+        return [base_colors[i % len(base_colors)] for i in range(n_populations)]
 
-    # Plot 1: All trajectories on spatial map (individual particle colors)
-    ax1.set_title(f'(a) Particle Trajectories - Individual Colors (n={n_particles})')
-    ax1.set_xlabel('X [m]')
-    ax1.set_ylabel('Y [m]')
 
-    # Plot each particle trajectory
+def _particle_colors(n_particles: int):
     try:
         cmap = plt.get_cmap('viridis')
-        colors = cmap(np.linspace(0, 1, n_particles))
+        return cmap(np.linspace(0, 1, n_particles))
     except (AttributeError, ValueError):
-        # Fallback to a basic color cycle
         color_cycle = plt.rcParams['axes.prop_cycle'].by_key()['color']
-        colors = [color_cycle[i % len(color_cycle)] for i in range(n_particles)]
+        return [color_cycle[i % len(color_cycle)] for i in range(n_particles)]
 
-    for i in range(n_particles):
-        # Filter out NaN values (particles may not exist for all timesteps)
+
+def _line_segments(
+    x_data: np.ndarray,
+    y_data: np.ndarray,
+) -> tuple[list[np.ndarray], np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    segments = []
+    plotted_indices = []
+    endpoint_indices = []
+    starts = []
+    ends = []
+
+    for i in range(x_data.shape[0]):
         mask = ~(np.isnan(x_data[i, :]) | np.isnan(y_data[i, :]))
         if np.any(mask):
             x_traj = x_data[i, mask]
             y_traj = y_data[i, mask]
+            points = np.column_stack((x_traj, y_traj))
+            if len(points) >= 2:
+                segments.append(points)
+                plotted_indices.append(i)
+            endpoint_indices.append(i)
+            starts.append(points[0])
+            ends.append(points[-1])
 
-            # Plot trajectory line
-            ax1.plot(
-                x_traj,
-                y_traj,
-                color=colors[i],
-                alpha=0.7,
-                linewidth=1,
-                label=f'Particle {i}' if n_particles <= 10 else None,
-            )
+    return (
+        segments,
+        np.asarray(plotted_indices, dtype=int),
+        np.asarray(endpoint_indices, dtype=int),
+        np.asarray(starts, dtype=float) if starts else np.empty((0, 2), dtype=float),
+        np.asarray(ends, dtype=float) if ends else np.empty((0, 2), dtype=float),
+    )
 
-            # Mark start and end points
-            # start point marker
-            ax1.scatter(
-                x_traj[0], y_traj[0], color=colors[i], marker='x', s=50, linewidth=1, zorder=5
-            )
-            # end point marker
-            ax1.scatter(
-                x_traj[-1], y_traj[-1], color=colors[i], marker='o', s=50, edgecolor='black', linewidth=1, zorder=5
-            )
 
-    # Add legend if few particles
-    if n_particles <= 10:
-        ax1.legend(bbox_to_anchor=(1.05, 1), loc='upper left')
+def _distance_line_segments(
+    x_data: np.ndarray,
+    y_data: np.ndarray,
+    time_data: np.ndarray,
+    min_time: float,
+) -> tuple[list[np.ndarray], list[np.ndarray], dict[int, tuple[np.ndarray, np.ndarray]]]:
+    distance_segments = []
+    distance_indices = []
+    particle_distances = {}
 
-    ax1.grid(True, alpha=0.3)
-    ax1.set_aspect('equal', adjustable='box')
-
-    # Plot 2: Time series of distances from initial position
-    ax2.set_title('(b) Distance from Initial Position vs Time')
-    ax2.set_xlabel('Time [hours]')
-    ax2.set_ylabel('Distance from Initial Position [m]')
-
-    # Find the minimum time across all particles to use as reference
-    min_time = np.nanmin(time_data) if np.any(np.isfinite(time_data)) else 0.0
-
-    for i in range(n_particles):
-        # Calculate distance from initial position for each timestep
+    for i in range(x_data.shape[0]):
         mask = ~(np.isnan(x_data[i, :]) | np.isnan(y_data[i, :]))
         if np.any(mask):
             x_traj = x_data[i, mask]
             y_traj = y_data[i, mask]
             time_traj = time_data[i, mask]
-
-            # Get initial position (first valid point)
-            x0 = x_traj[0]
-            y0 = y_traj[0]
-
-            # Convert time to hours relative to simulation start
             time_hours = (time_traj - min_time) / 3600.0
+            distances = np.sqrt((x_traj - x_traj[0]) ** 2 + (y_traj - y_traj[0]) ** 2)
+            particle_distances[i] = (time_hours, distances)
+            if len(time_hours) >= 2:
+                distance_segments.append(np.column_stack((time_hours, distances)))
+                distance_indices.append(i)
 
-            # Calculate distance from initial position
-            distances = np.sqrt((x_traj - x0) ** 2 + (y_traj - y0) ** 2)
-            ax2.plot(time_hours, distances, color=colors[i], alpha=0.7, linewidth=1)
+    return distance_segments, np.asarray(distance_indices, dtype=int), particle_distances
 
-    ax2.grid(True, alpha=0.3)
+
+def _add_endpoint_markers(ax, starts, ends, *, colors, markers: str, marker_size: float):
+    if markers == 'none':
+        return
+    if markers == 'start-end' and len(starts):
+        ax.scatter(starts[:, 0], starts[:, 1], color=colors, marker='x', s=marker_size, linewidth=1, zorder=5)
+    if markers in {'end', 'start-end'} and len(ends):
+        ax.scatter(
+            ends[:, 0],
+            ends[:, 1],
+            color=colors,
+            marker='o',
+            s=marker_size,
+            edgecolor='black',
+            linewidth=0.5,
+            zorder=5,
+        )
+
+
+def _resolve_output_file(ds: xr.Dataset, save_plot: bool, output_dir, output_file) -> Path | None:
+    if output_file is not None:
+        return Path(output_file)
+    if not save_plot:
+        return None
+    if output_dir is None or output_dir == '.':
+        source_file = ds.encoding.get('source', '.')
+        output_dir = Path(source_file).parent
+    else:
+        output_dir = Path(output_dir)
+    return output_dir / 'particle_trajectories.png'
+
+
+def _normalize_panels(panels: str | list[str] | tuple[str, ...]) -> list[str]:
+    valid_panels = ('spatial', 'distance', 'population', 'population-distance')
+
+    if isinstance(panels, str):
+        requested = [panel.strip().lower() for panel in panels.split(',') if panel.strip()]
+    else:
+        requested = [str(panel).strip().lower() for panel in panels if str(panel).strip()]
+
+    if not requested:
+        requested = ['spatial']
+    if 'all' in requested:
+        return list(valid_panels)
+
+    invalid = sorted(set(requested) - set(valid_panels))
+    if invalid:
+        raise ValueError(
+            "'panels' contains invalid values: "
+            f"{', '.join(invalid)}. Valid values are: all, {', '.join(valid_panels)}."
+        )
+
+    ordered = [panel for panel in valid_panels if panel in requested]
+    if 'spatial' not in ordered:
+        ordered.insert(0, 'spatial')
+    return ordered
+
+
+def _create_panel_axes(panels: list[str]):
+    if len(panels) == 1:
+        fig, ax = plt.subplots(1, 1, figsize=(10, 8))
+        return fig, {panels[0]: ax}
+
+    ncols = 2
+    nrows = int(np.ceil(len(panels) / ncols))
+    fig, axes = plt.subplots(nrows, ncols, figsize=(10 * ncols, 8 * nrows))
+    axes_flat = np.atleast_1d(axes).ravel()
+    axes_by_panel = dict(zip(panels, axes_flat, strict=True))
+    for ax in axes_flat[len(panels) :]:
+        ax.set_visible(False)
+    return fig, axes_by_panel
+
+
+def plot_trajectories(
+    ds,
+    save_plot=False,
+    output_dir=None,
+    output_file=None,
+    max_particles: int | None = None,
+    sample_fraction: float | None = None,
+    sample_seed: int = 0,
+    markers: str = 'start-end',
+    marker_size: float = 12.0,
+    panels: str | list[str] | tuple[str, ...] = 'spatial',
+    show: bool | None = None,
+):
+    """Plot particle trajectories from a SedTRAILS dataset.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        Dataset containing particle trajectory variables, including ``x``,
+        ``y``, and ``time``.
+    save_plot : bool, optional
+        If true, save the generated figure as ``particle_trajectories.png``.
+    output_dir : str or pathlib.Path, optional
+        Directory where the figure is saved. If omitted, the source dataset
+        directory is used when available.
+    output_file : str or pathlib.Path, optional
+        Exact file path for the saved figure. When supplied, the figure is
+        written directly to this path and is not shown unless ``show=True``.
+    max_particles : int, optional
+        Maximum number of particles to plot. Sampling is deterministic and
+        stratified by population when population IDs are available.
+    sample_fraction : float, optional
+        Fraction of particles to plot. Mutually exclusive with
+        ``max_particles``.
+    sample_seed : int, optional
+        Seed used for deterministic particle sampling.
+    markers : {'none', 'end', 'start-end'}, optional
+        Which endpoint markers to draw.
+    marker_size : float, optional
+        Marker size for start/end points.
+    panels : str or sequence of str, optional
+        Panels to draw. ``spatial`` is the fast default. Use ``all`` for the
+        previous four-panel figure, or a comma-separated subset of ``spatial``,
+        ``distance``, ``population``, and ``population-distance``.
+    show : bool or None, optional
+        Whether to display the figure. By default, figures are shown only when
+        they are not saved.
+
+    Notes
+    -----
+    This function creates a four-panel matplotlib figure. It returns the figure
+    and axes to support testing or further customization.
+    """
+    if markers not in {'none', 'end', 'start-end'}:
+        raise ValueError("'markers' must be one of: 'none', 'end', or 'start-end'.")
+    if marker_size <= 0:
+        raise ValueError("'marker_size' must be greater than 0.")
+    selected_panels = _normalize_panels(panels)
+
+    output_path = _resolve_output_file(ds, save_plot, output_dir, output_file)
+    if show is None:
+        show = output_path is None
+
+    sampled_ds, n_total_particles, n_sampled_particles = _sample_dataset(
+        ds,
+        max_particles=max_particles,
+        sample_fraction=sample_fraction,
+        sample_seed=sample_seed,
+    )
+
+    x_data, y_data, time_data = _trajectory_arrays(sampled_ds)
+
+    n_particles, n_timesteps = x_data.shape
+
+    if n_sampled_particles != n_total_particles:
+        print(
+            f'\nPlotting trajectories for {n_sampled_particles} of {n_total_particles} '
+            f'particles over {n_timesteps} timesteps...'
+        )
+    else:
+        print(f'\nPlotting trajectories for {n_particles} particles over {n_timesteps} timesteps...')
+
+    fig, axes_by_panel = _create_panel_axes(selected_panels)
+
+    # Extract population information for color coding
+    population_ids = (
+        np.asarray(sampled_ds['population_id'].values, dtype=int)
+        if 'population_id' in sampled_ds
+        else np.zeros(n_particles, dtype=int)
+    )
+    n_populations = int(sampled_ds.sizes['n_populations']) if 'n_populations' in sampled_ds.sizes else 1
+
+    # Plot 1: All trajectories on spatial map (individual particle colors)
+    ax1 = axes_by_panel['spatial']
+    ax1.set_title(f'(a) Particle Trajectories - Individual Colors (n={n_particles})')
+    ax1.set_xlabel('X [m]')
+    ax1.set_ylabel('Y [m]')
+
+    # Plot each particle trajectory
+    colors = np.asarray(_particle_colors(n_particles))
+    spatial_segments, spatial_indices, endpoint_indices, starts, ends = _line_segments(x_data, y_data)
+    if spatial_segments:
+        ax1.add_collection(LineCollection(spatial_segments, colors=colors[spatial_indices], alpha=0.7, linewidths=1))
+        ax1.autoscale()
+    endpoint_colors = colors[endpoint_indices] if len(starts) else []
+    _add_endpoint_markers(ax1, starts, ends, colors=endpoint_colors, markers=markers, marker_size=marker_size)
+
+    # Add legend if few particles
+    if n_particles <= 10:
+        for i, color in enumerate(colors):
+            ax1.plot([], [], color=color, alpha=0.7, linewidth=1, label=f'Particle {i}')
+        ax1.legend(bbox_to_anchor=(1.05, 1), loc='upper left')
+
+    ax1.grid(True, alpha=0.3)
+    ax1.set_aspect('equal', adjustable='box')
+
+    if selected_panels == ['spatial']:
+        plt.tight_layout()
+
+        if output_path is not None:
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            fig.savefig(output_path, dpi=300, bbox_inches='tight')
+            print(f'Plot saved to: {output_path}')
+
+        if show:
+            plt.show()
+        elif output_path is not None:
+            plt.close(fig)
+
+        return fig, axes_by_panel
+
+    # Plot 2: Time series of distances from initial position
+    ax2 = axes_by_panel.get('distance')
+    ax4 = axes_by_panel.get('population-distance')
+
+    if ax2 is not None:
+        ax2.set_title('(b) Distance from Initial Position vs Time')
+        ax2.set_xlabel('Time [hours]')
+        ax2.set_ylabel('Distance from Initial Position [m]')
+
+    # Find the minimum time across all particles to use as reference
+    min_time = np.nanmin(time_data) if np.any(np.isfinite(time_data)) else 0.0
+
+    particle_distances = {}
+    if ax2 is not None or ax4 is not None:
+        distance_segments, distance_indices, particle_distances = _distance_line_segments(
+            x_data, y_data, time_data, min_time
+        )
+        if ax2 is not None and distance_segments:
+            ax2.add_collection(
+                LineCollection(distance_segments, colors=colors[distance_indices], alpha=0.7, linewidths=1)
+            )
+            ax2.autoscale()
+
+    if ax2 is not None:
+        ax2.grid(True, alpha=0.3)
+
+    if 'population' in selected_panels or 'population-distance' in selected_panels:
+        population_names = _decode_population_names(sampled_ds, n_populations)
+        pop_colors = _population_colors(n_populations)
 
     # Plot 3: Trajectories colored by population
-    ax3.set_title('(c) Particle Trajectories - Colored by Population')
-    ax3.set_xlabel('X [m]')
-    ax3.set_ylabel('Y [m]')
+    ax3 = axes_by_panel.get('population')
+    if ax3 is not None:
+        ax3.set_title('(c) Particle Trajectories - Colored by Population')
+        ax3.set_xlabel('X [m]')
+        ax3.set_ylabel('Y [m]')
 
     # Plot trajectories grouped by population
-    for pop_idx in range(n_populations):
-        particles_in_pop = []
-        # Find particles belonging to this population
-        for i in range(n_particles):
-            if population_ids[i] == pop_idx:
-                particles_in_pop.append(i)
+    if ax3 is not None:
+        for pop_idx in range(n_populations):
+            particles_in_pop = np.flatnonzero(population_ids == pop_idx)
+            pop_segments = []
+            pop_starts = []
+            pop_ends = []
+            for i in particles_in_pop:
+                mask = ~(np.isnan(x_data[i, :]) | np.isnan(y_data[i, :]))
+                if np.any(mask):
+                    points = np.column_stack((x_data[i, mask], y_data[i, mask]))
+                    if len(points) >= 2:
+                        pop_segments.append(points)
+                    pop_starts.append(points[0])
+                    pop_ends.append(points[-1])
 
-        # Plot trajectories for this population
-        for i in particles_in_pop:
-            mask = ~(np.isnan(x_data[i, :]) | np.isnan(y_data[i, :]))
-            if np.any(mask):
-                x_traj = x_data[i, mask]
-                y_traj = y_data[i, mask]
-
-                # Plot trajectory line with population color
-                ax3.plot(
-                    x_traj,
-                    y_traj,
-                    color=pop_colors[pop_idx],
-                    alpha=0.7,
-                    linewidth=1,
-                    label=population_names[pop_idx] if i == particles_in_pop[0] else '',
+            if pop_segments:
+                ax3.add_collection(
+                    LineCollection(pop_segments, colors=[pop_colors[pop_idx]], alpha=0.7, linewidths=1)
+                )
+                ax3.plot([], [], color=pop_colors[pop_idx], alpha=0.7, linewidth=1, label=population_names[pop_idx])
+            if pop_starts:
+                marker_colors = [pop_colors[pop_idx]] * len(pop_starts)
+                _add_endpoint_markers(
+                    ax3,
+                    np.asarray(pop_starts, dtype=float),
+                    np.asarray(pop_ends, dtype=float),
+                    colors=marker_colors,
+                    markers=markers,
+                    marker_size=marker_size,
                 )
 
-                # Mark start and end points
-                ax3.scatter(
-                    x_traj[0],
-                    y_traj[0],
-                    color=pop_colors[pop_idx],
-                    marker='x',
-                    s=50,
-                    linewidth=1,
-                    zorder=5,
-                )
-                ax3.scatter(
-                    x_traj[-1],
-                    y_traj[-1],
-                    color=pop_colors[pop_idx],
-                    marker='o',
-                    s=50,
-                    edgecolor='black',
-                    linewidth=1,
-                    zorder=5,
-                )
-
-    ax3.legend()
-    ax3.grid(True, alpha=0.3)
-    ax3.set_aspect('equal', adjustable='box')
+        ax3.legend()
+        ax3.autoscale()
+        ax3.grid(True, alpha=0.3)
+        ax3.set_aspect('equal', adjustable='box')
 
     # Plot 4: Distance from initial position by population with statistics
-    ax4.set_title('(d) Distance from Initial Position by Population')
-    ax4.set_xlabel('Time [hours]')
-    ax4.set_ylabel('Distance from Initial Position [m]')
+    if ax4 is not None:
+        ax4.set_title('(d) Distance from Initial Position by Population')
+        ax4.set_xlabel('Time [hours]')
+        ax4.set_ylabel('Distance from Initial Position [m]')
 
     # Create containers for population statistics
     population_stats = {}
 
     # First pass: collect all data for each population
-    for pop_idx in range(n_populations):
-        population_stats[pop_idx] = {
-            'times': [],
-            'distances': [],
-            'name': population_names[pop_idx],
-            'color': pop_colors[pop_idx],
-        }
+    if ax4 is not None:
+        for pop_idx in range(n_populations):
+            population_stats[pop_idx] = {
+                'times': [],
+                'distances': [],
+                'name': population_names[pop_idx],
+                'color': pop_colors[pop_idx],
+            }
 
-        # Find particles belonging to this population
-        particles_in_pop = [i for i in range(n_particles) if population_ids[i] == pop_idx]
+            particles_in_pop = np.flatnonzero(population_ids == pop_idx)
 
-        # Plot individual particle distances for this population
-        for i in particles_in_pop:
-            mask = ~(np.isnan(x_data[i, :]) | np.isnan(y_data[i, :]))
-            if np.any(mask):
-                x_traj = x_data[i, mask]
-                y_traj = y_data[i, mask]
-                time_traj = time_data[i, mask]
-
-                # Get initial position
-                x0 = x_traj[0]
-                y0 = y_traj[0]
-
-                # Convert time to hours relative to simulation start
-                time_hours = (time_traj - min_time) / 3600.0
-
-                # Calculate distance from initial position
-                distances = np.sqrt((x_traj - x0) ** 2 + (y_traj - y0) ** 2)
-
-                # Plot individual particle line (thin, transparent)
-                ax4.plot(time_hours, distances, color=pop_colors[pop_idx], alpha=0.3, linewidth=0.8)
-
-                # Store data for statistics
-                population_stats[pop_idx]['times'].append(time_hours)
-                population_stats[pop_idx]['distances'].append(distances)
+            # Plot individual particle distances for this population
+            pop_distance_segments = []
+            for i in particles_in_pop:
+                if i in particle_distances:
+                    time_hours, distances = particle_distances[i]
+                    if len(time_hours) >= 2:
+                        pop_distance_segments.append(np.column_stack((time_hours, distances)))
+                    population_stats[pop_idx]['times'].append(time_hours)
+                    population_stats[pop_idx]['distances'].append(distances)
+            if pop_distance_segments:
+                ax4.add_collection(
+                    LineCollection(pop_distance_segments, colors=[pop_colors[pop_idx]], alpha=0.3, linewidths=0.8)
+                )
 
     # Second pass: compute and plot population statistics
-    for pop_idx in range(n_populations):
-        if population_stats[pop_idx]['times']:
-            # Create a common time grid for interpolation
-            all_times = np.concatenate(population_stats[pop_idx]['times'])
-            min_t, max_t = np.min(all_times), np.max(all_times)
-            common_time = np.linspace(min_t, max_t, 100)
+    if ax4 is not None:
+        for pop_idx in range(n_populations):
+            if population_stats[pop_idx]['times']:
+                # Create a common time grid for interpolation
+                all_times = np.concatenate(population_stats[pop_idx]['times'])
+                min_t, max_t = np.min(all_times), np.max(all_times)
+                common_time = np.linspace(min_t, max_t, 100)
 
-            # Interpolate all particle distances onto common time grid
-            interpolated_distances = []
-            for time_arr, dist_arr in zip(
-                population_stats[pop_idx]['times'], population_stats[pop_idx]['distances'], strict=True
-            ):
-                if len(time_arr) > 1:  # Need at least 2 points for interpolation
-                    interp_dist = np.interp(common_time, time_arr, dist_arr)
-                    interpolated_distances.append(interp_dist)
+                # Interpolate all particle distances onto common time grid
+                interpolated_distances = []
+                for time_arr, dist_arr in zip(
+                    population_stats[pop_idx]['times'], population_stats[pop_idx]['distances'], strict=True
+                ):
+                    if len(time_arr) > 1:  # Need at least 2 points for interpolation
+                        interp_dist = np.interp(common_time, time_arr, dist_arr)
+                        interpolated_distances.append(interp_dist)
 
-            if interpolated_distances:
-                # Convert to array for easy statistics
-                distances_array = np.array(interpolated_distances)
+                if interpolated_distances:
+                    # Convert to array for easy statistics
+                    distances_array = np.array(interpolated_distances)
 
-                # Compute mean and standard deviation
-                mean_distances = np.mean(distances_array, axis=0)
-                std_distances = np.std(distances_array, axis=0)
+                    # Compute mean and standard deviation
+                    mean_distances = np.mean(distances_array, axis=0)
+                    std_distances = np.std(distances_array, axis=0)
 
-                # Plot mean line (thick)
-                ax4.plot(
-                    common_time,
-                    mean_distances,
-                    color=pop_colors[pop_idx],
-                    linewidth=3,
-                    label=f'{population_names[pop_idx]} (mean)',
-                )
+                    # Plot mean line (thick)
+                    ax4.plot(
+                        common_time,
+                        mean_distances,
+                        color=pop_colors[pop_idx],
+                        linewidth=3,
+                        label=f'{population_names[pop_idx]} (mean)',
+                    )
 
-                # Plot standard deviation bands
-                ax4.fill_between(
-                    common_time,
-                    mean_distances - std_distances,
-                    mean_distances + std_distances,
-                    color=pop_colors[pop_idx],
-                    alpha=0.2,
-                    label=f'{population_names[pop_idx]} (+/-1 std)',
-                )
+                    # Plot standard deviation bands
+                    ax4.fill_between(
+                        common_time,
+                        mean_distances - std_distances,
+                        mean_distances + std_distances,
+                        color=pop_colors[pop_idx],
+                        alpha=0.2,
+                        label=f'{population_names[pop_idx]} (+/-1 std)',
+                    )
 
-    ax4.legend()
-    ax4.grid(True, alpha=0.3)
+        ax4.legend()
+        ax4.autoscale()
+        ax4.grid(True, alpha=0.3)
 
     plt.tight_layout()
 
     # Save plot if requested
-    if save_plot:
-        if output_dir is None or output_dir == '.':
-            # Extract the source file path from the dataset encoding
-            source_file = ds.encoding.get('source', '.')
-            output_dir = Path(source_file).parent
-        else:
-            output_dir = Path(output_dir)
+    if output_path is not None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        fig.savefig(output_path, dpi=300, bbox_inches='tight')
+        print(f'Plot saved to: {output_path}')
 
-        output_file = output_dir / 'particle_trajectories.png'
-        plt.savefig(output_file, dpi=300, bbox_inches='tight')
-        print(f'Plot saved to: {output_file}')
+    if show:
+        plt.show()
+    elif output_path is not None:
+        plt.close(fig)
 
-    plt.show()
+    return fig, axes_by_panel

--- a/src/sedtrails/pathway_visualizer/trajectories.py
+++ b/src/sedtrails/pathway_visualizer/trajectories.py
@@ -407,16 +407,18 @@ def _add_endpoint_markers(ax, starts, ends, *, colors, markers: str, marker_size
         )
 
 
-def _resolve_output_file(ds: xr.Dataset, save_plot: bool, output_dir, output_file) -> Path | None:
-    if output_file is not None:
-        return Path(output_file)
-    if not save_plot:
-        return None
-    output_dir_path = Path(output_dir) if output_dir is not None else Path('.')
-    if output_dir is None or output_dir_path == Path('.'):
-        source_file = ds.encoding.get('source', '.')
-        output_dir_path = Path(source_file).parent
-    return output_dir_path / 'particle_trajectories.png'
+def _resolve_output_file(ds: xr.Dataset, output) -> Path:
+    default_name = 'particle_trajectories.png'
+
+    if output is not None:
+        output_path = Path(output)
+        if output_path.is_dir():
+            return output_path / default_name
+        return output_path
+
+    source_file = ds.encoding.get('source', '.')
+    source_dir = Path(source_file).parent
+    return source_dir / default_name
 
 
 def _normalize_panels(panels: str | list[str] | tuple[str, ...]) -> list[str]:
@@ -461,9 +463,7 @@ def _create_panel_axes(panels: list[str]):
 
 def plot_trajectories(
     ds,
-    save_plot=False,
-    output_dir=None,
-    output_file=None,
+    output=None,
     max_particles: int | None = None,
     sample_fraction: float | None = None,
     sample_seed: int = 0,
@@ -479,14 +479,12 @@ def plot_trajectories(
     ds : xarray.Dataset
         Dataset containing particle trajectory variables, including ``x``,
         ``y``, and ``time``.
-    save_plot : bool, optional
-        If true, save the generated figure as ``particle_trajectories.png``.
-    output_dir : str or pathlib.Path, optional
-        Directory where the figure is saved. If omitted, the source dataset
-        directory is used when available.
-    output_file : str or pathlib.Path, optional
-        Exact file path for the saved figure. When supplied, the figure is
-        written directly to this path and is not shown unless ``show=True``.
+    output : str or pathlib.Path, optional
+        Output target for the figure. If this is an existing directory, the
+        plot is saved as ``particle_trajectories.png`` inside that directory.
+        Otherwise, it is treated as an exact output filename. When omitted,
+        the default output is ``particle_trajectories.png`` in the source
+        dataset directory when available.
     max_particles : int, optional
         Maximum number of particles to plot. Sampling is deterministic and
         stratified by population when population IDs are available.
@@ -504,8 +502,7 @@ def plot_trajectories(
         previous four-panel figure, or a comma-separated subset of ``spatial``,
         ``distance``, ``population``, and ``population-distance``.
     show : bool or None, optional
-        Whether to display the figure. By default, figures are shown only when
-        they are not saved.
+        Whether to display the figure. By default, figures are not shown.
 
     Notes
     -----
@@ -518,9 +515,9 @@ def plot_trajectories(
         raise ValueError("'marker_size' must be greater than 0.")
     selected_panels = _normalize_panels(panels)
 
-    output_path = _resolve_output_file(ds, save_plot, output_dir, output_file)
+    output_path = _resolve_output_file(ds, output)
     if show is None:
-        show = output_path is None
+        show = False
 
     sampled_ds, n_total_particles, n_sampled_particles = _sample_dataset(
         ds,

--- a/src/sedtrails/pathway_visualizer/trajectories.py
+++ b/src/sedtrails/pathway_visualizer/trajectories.py
@@ -2,12 +2,13 @@
 Module for visualizing particle trajectories from SedTRAILS NetCDF output files.
 """
 
-from pathlib import Path
 import re
-import numpy as np
-from matplotlib.collections import LineCollection
+from pathlib import Path
+
 import matplotlib.pyplot as plt
+import numpy as np
 import xarray as xr
+from matplotlib.collections import LineCollection
 
 
 def _decode_netcdf_name(raw_value) -> str:
@@ -22,6 +23,13 @@ def _decode_netcdf_name(raw_value) -> str:
         return raw_value.decode('utf-8', errors='ignore').strip('\x00').strip()
 
     arr = np.asarray(raw_value)
+
+    # Scalar numpy bytes/str (0-dim array or item)
+    if arr.ndim == 0:
+        item = arr.item()
+        if isinstance(item, (bytes, np.bytes_)):
+            return item.decode('utf-8', errors='ignore').strip('\x00').strip()
+        return str(item).strip()
 
     # Char-array representation (e.g., dtype='|S1' with trailing nulls)
     if arr.ndim > 0 and arr.size > 0 and arr.dtype.kind in ('S', 'U'):
@@ -200,7 +208,9 @@ def _select_sample_indices(
     if selected_indices.size < target:
         remaining_pool = np.setdiff1d(np.arange(n_particles, dtype=int), selected_indices, assume_unique=True)
         if remaining_pool.size:
-            extra = rng.choice(remaining_pool, size=min(target - selected_indices.size, remaining_pool.size), replace=False)
+            extra = rng.choice(
+                remaining_pool, size=min(target - selected_indices.size, remaining_pool.size), replace=False
+            )
             selected_indices = np.concatenate((selected_indices, extra))
     elif selected_indices.size > target:
         selected_indices = rng.choice(selected_indices, size=target, replace=False)
@@ -258,8 +268,8 @@ def _trajectory_arrays(ds: xr.Dataset) -> tuple[np.ndarray, np.ndarray, np.ndarr
         y_data = np.asarray(y_var.values, dtype=float).T
     else:
         raise ValueError(
-            "Expected SedTRAILS time-major trajectory arrays shaped as "
-            "(n_timesteps, n_particles), or 1D checkpoint arrays."
+            'Expected SedTRAILS time-major trajectory arrays shaped as '
+            '(n_timesteps, n_particles), or 1D checkpoint arrays.'
         )
 
     n_particles, n_timesteps = x_data.shape
@@ -425,8 +435,7 @@ def _normalize_panels(panels: str | list[str] | tuple[str, ...]) -> list[str]:
     invalid = sorted(set(requested) - set(valid_panels))
     if invalid:
         raise ValueError(
-            "'panels' contains invalid values: "
-            f"{', '.join(invalid)}. Valid values are: all, {', '.join(valid_panels)}."
+            f"'panels' contains invalid values: {', '.join(invalid)}. Valid values are: all, {', '.join(valid_panels)}."
         )
 
     ordered = [panel for panel in valid_panels if panel in requested]
@@ -607,9 +616,9 @@ def plot_trajectories(
     if ax2 is not None:
         ax2.grid(True, alpha=0.3)
 
-    if 'population' in selected_panels or 'population-distance' in selected_panels:
-        population_names = _decode_population_names(sampled_ds, n_populations)
-        pop_colors = _population_colors(n_populations)
+    # if 'population' in selected_panels or 'population-distance' in selected_panels:
+    population_names = _decode_population_names(sampled_ds, n_populations)
+    pop_colors = _population_colors(n_populations)
 
     # Plot 3: Trajectories colored by population
     ax3 = axes_by_panel.get('population')
@@ -635,9 +644,7 @@ def plot_trajectories(
                     pop_ends.append(points[-1])
 
             if pop_segments:
-                ax3.add_collection(
-                    LineCollection(pop_segments, colors=[pop_colors[pop_idx]], alpha=0.7, linewidths=1)
-                )
+                ax3.add_collection(LineCollection(pop_segments, colors=[pop_colors[pop_idx]], alpha=0.7, linewidths=1))
                 ax3.plot([], [], color=pop_colors[pop_idx], alpha=0.7, linewidth=1, label=population_names[pop_idx])
             if pop_starts:
                 marker_colors = [pop_colors[pop_idx]] * len(pop_starts)

--- a/tests/cli/test_sedtrails_cli.py
+++ b/tests/cli/test_sedtrails_cli.py
@@ -140,7 +140,7 @@ class TestSedtrailsCLI:
             report_domain_exits=False,
         )
 
-    def test_viz_trajectories_defaults_to_saving_and_new_plot_settings(
+    def test_viz_trajectories_defaults_to_output_path_and_new_plot_settings(
         self, runner, cli_command, tmp_path, monkeypatch
     ):
         """Test default trajectories visualization settings."""
@@ -152,9 +152,7 @@ class TestSedtrailsCLI:
         assert result.exit_code == 0
         mock_plot_trajectories.assert_called_once_with(
             'sedtrails_results.nc',
-            save=True,
-            output_dir='.',
-            output_file=None,
+            output=None,
             max_particles=10000,
             sample_fraction=None,
             sample_seed=0,

--- a/tests/cli/test_sedtrails_cli.py
+++ b/tests/cli/test_sedtrails_cli.py
@@ -140,6 +140,30 @@ class TestSedtrailsCLI:
             report_domain_exits=False,
         )
 
+    def test_viz_trajectories_defaults_to_saving_and_new_plot_settings(
+        self, runner, cli_command, tmp_path, monkeypatch
+    ):
+        """Test default trajectories visualization settings."""
+        monkeypatch.chdir(tmp_path)
+
+        with patch('sedtrails.application_interfaces.api.plot_trajectories') as mock_plot_trajectories:
+            result = runner.invoke(cli_command, ['viz', 'trajectories'])
+
+        assert result.exit_code == 0
+        mock_plot_trajectories.assert_called_once_with(
+            'sedtrails_results.nc',
+            save=True,
+            output_dir='.',
+            output_file=None,
+            max_particles=10000,
+            sample_fraction=None,
+            sample_seed=0,
+            markers='end',
+            marker_size=3.0,
+            panels='spatial',
+            show=None,
+        )
+
     def test_run_simulation_error(self, runner, cli_command, sample_config_data, mock_run_simulation, tmp_path, monkeypatch):
         """Test run when simulation fails."""
         monkeypatch.chdir(tmp_path)

--- a/tests/pathway_visualizer/test_trajectories.py
+++ b/tests/pathway_visualizer/test_trajectories.py
@@ -151,7 +151,7 @@ def test_plot_trajectories_output_file_skips_show_by_default(tmp_path, monkeypat
     monkeypatch.setattr('matplotlib.pyplot.show', _show)
 
     output_file = tmp_path / 'trajectories.png'
-    plot_trajectories(ds, output_file=output_file)
+    plot_trajectories(ds, output=output_file)
 
     assert output_file.exists()
     assert not show_called
@@ -174,9 +174,31 @@ def test_plot_trajectories_saves_next_to_source_file_by_default(tmp_path, monkey
 
     monkeypatch.setattr('matplotlib.pyplot.show', lambda: None)
 
-    plot_trajectories(ds, save_plot=True)
+    plot_trajectories(ds)
 
     assert (tmp_path / 'particle_trajectories.png').exists()
+
+
+def test_plot_trajectories_output_existing_directory_uses_default_filename(tmp_path, monkeypatch):
+    ds = xr.Dataset(
+        data_vars={
+            'x': (('n_timesteps', 'n_particles'), np.array([[0.0], [1.0]])),
+            'y': (('n_timesteps', 'n_particles'), np.array([[0.0], [1.0]])),
+            'time': (('n_timesteps',), np.array([0.0, 60.0])),
+        },
+        coords={
+            'n_particles': np.arange(1),
+            'n_timesteps': np.arange(2),
+        },
+    )
+    monkeypatch.setattr('matplotlib.pyplot.show', lambda: None)
+
+    output_dir = tmp_path / 'plots'
+    output_dir.mkdir()
+
+    plot_trajectories(ds, output=output_dir)
+
+    assert (output_dir / 'particle_trajectories.png').exists()
 
 
 def test_plot_trajectories_draws_spatial_panel_by_default(monkeypatch):
@@ -250,7 +272,7 @@ def test_plot_trajectories_show_can_be_forced_with_output_file(tmp_path, monkeyp
 
     monkeypatch.setattr('matplotlib.pyplot.show', _show)
 
-    plot_trajectories(ds, output_file=tmp_path / 'trajectories.png', show=True)
+    plot_trajectories(ds, output=tmp_path / 'trajectories.png', show=True)
 
     assert show_called
 

--- a/tests/pathway_visualizer/test_trajectories.py
+++ b/tests/pathway_visualizer/test_trajectories.py
@@ -6,7 +6,14 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from sedtrails.pathway_visualizer.trajectories import _trajectory_arrays, plot_trajectories, read_netcdf
+from sedtrails.pathway_visualizer.trajectories import (
+    _sample_dataset,
+    _select_sample_indices,
+    _trajectory_arrays,
+    plot_trajectories,
+    read_netcdf,
+)
+
 
 def test_plot_trajectories_accepts_fixed_width_population_names(monkeypatch):
     n_particles = 2
@@ -119,3 +126,189 @@ def test_plot_trajectories_rejects_particle_major_layout(monkeypatch):
 
     with pytest.raises(ValueError, match='time-major trajectory arrays'):
         plot_trajectories(ds)
+
+
+def test_plot_trajectories_output_file_skips_show_by_default(tmp_path, monkeypatch):
+    ds = xr.Dataset(
+        data_vars={
+            'x': (('n_timesteps', 'n_particles'), np.array([[0.0, 0.0], [1.0, 1.5], [2.0, 3.0]])),
+            'y': (('n_timesteps', 'n_particles'), np.array([[0.0, 0.0], [0.5, 0.25], [1.0, 0.5]])),
+            'time': (('n_timesteps',), np.array([0.0, 60.0, 120.0])),
+            'population_id': (('n_particles',), np.array([0, 1], dtype=int)),
+        },
+        coords={
+            'n_particles': np.arange(2),
+            'n_timesteps': np.arange(3),
+            'n_populations': np.arange(2),
+        },
+    )
+    show_called = False
+
+    def _show():
+        nonlocal show_called
+        show_called = True
+
+    monkeypatch.setattr('matplotlib.pyplot.show', _show)
+
+    output_file = tmp_path / 'trajectories.png'
+    plot_trajectories(ds, output_file=output_file)
+
+    assert output_file.exists()
+    assert not show_called
+
+
+def test_plot_trajectories_saves_next_to_source_file_by_default(tmp_path, monkeypatch):
+    ds = xr.Dataset(
+        data_vars={
+            'x': (('n_timesteps', 'n_particles'), np.array([[0.0, 0.0], [1.0, 1.5], [2.0, 3.0]])),
+            'y': (('n_timesteps', 'n_particles'), np.array([[0.0, 0.0], [0.5, 0.25], [1.0, 0.5]])),
+            'time': (('n_timesteps',), np.array([0.0, 60.0, 120.0])),
+        },
+        coords={
+            'n_particles': np.arange(2),
+            'n_timesteps': np.arange(3),
+        },
+    )
+    source_file = tmp_path / 'results.nc'
+    ds.encoding['source'] = str(source_file)
+
+    monkeypatch.setattr('matplotlib.pyplot.show', lambda: None)
+
+    plot_trajectories(ds, save_plot=True)
+
+    assert (tmp_path / 'particle_trajectories.png').exists()
+
+
+def test_plot_trajectories_draws_spatial_panel_by_default(monkeypatch):
+    ds = xr.Dataset(
+        data_vars={
+            'x': (('n_timesteps', 'n_particles'), np.array([[0.0, 0.0], [1.0, 1.5], [2.0, 3.0]])),
+            'y': (('n_timesteps', 'n_particles'), np.array([[0.0, 0.0], [0.5, 0.25], [1.0, 0.5]])),
+            'time': (('n_timesteps',), np.array([0.0, 60.0, 120.0])),
+        },
+        coords={
+            'n_particles': np.arange(2),
+            'n_timesteps': np.arange(3),
+        },
+    )
+    monkeypatch.setattr('matplotlib.pyplot.show', lambda: None)
+
+    fig, axes = plot_trajectories(ds)
+    try:
+        assert list(axes) == ['spatial']
+        assert len(fig.axes) == 1
+    finally:
+        import matplotlib.pyplot as plt
+
+        plt.close(fig)
+
+
+def test_plot_trajectories_can_draw_all_panels(monkeypatch):
+    ds = xr.Dataset(
+        data_vars={
+            'x': (('n_timesteps', 'n_particles'), np.array([[0.0, 0.0], [1.0, 1.5], [2.0, 3.0]])),
+            'y': (('n_timesteps', 'n_particles'), np.array([[0.0, 0.0], [0.5, 0.25], [1.0, 0.5]])),
+            'time': (('n_timesteps',), np.array([0.0, 60.0, 120.0])),
+            'population_id': (('n_particles',), np.array([0, 1], dtype=int)),
+            'population_name': (('n_populations',), np.array([b'pop_A', b'pop_B'], dtype='S24')),
+        },
+        coords={
+            'n_particles': np.arange(2),
+            'n_timesteps': np.arange(3),
+            'n_populations': np.arange(2),
+        },
+    )
+    monkeypatch.setattr('matplotlib.pyplot.show', lambda: None)
+
+    fig, axes = plot_trajectories(ds, panels='all', marker_size=8)
+    try:
+        assert list(axes) == ['spatial', 'distance', 'population', 'population-distance']
+        assert len(fig.axes) == 4
+    finally:
+        import matplotlib.pyplot as plt
+
+        plt.close(fig)
+
+
+def test_plot_trajectories_show_can_be_forced_with_output_file(tmp_path, monkeypatch):
+    ds = xr.Dataset(
+        data_vars={
+            'x': (('n_timesteps', 'n_particles'), np.array([[0.0], [1.0]])),
+            'y': (('n_timesteps', 'n_particles'), np.array([[0.0], [1.0]])),
+            'time': (('n_timesteps',), np.array([0.0, 60.0])),
+        },
+        coords={
+            'n_particles': np.arange(1),
+            'n_timesteps': np.arange(2),
+        },
+    )
+    show_called = False
+
+    def _show():
+        nonlocal show_called
+        show_called = True
+
+    monkeypatch.setattr('matplotlib.pyplot.show', _show)
+
+    plot_trajectories(ds, output_file=tmp_path / 'trajectories.png', show=True)
+
+    assert show_called
+
+
+def test_select_sample_indices_is_deterministic_and_population_stratified():
+    population_ids = np.array([0] * 8 + [1] * 2)
+
+    selected = _select_sample_indices(10, population_ids, max_particles=5, sample_seed=123)
+    repeated = _select_sample_indices(10, population_ids, max_particles=5, sample_seed=123)
+
+    np.testing.assert_array_equal(selected, repeated)
+    assert len(selected) == 5
+    assert np.any(population_ids[selected] == 0)
+    assert np.any(population_ids[selected] == 1)
+
+
+def test_sample_dataset_selects_particles_before_array_conversion():
+    n_particles = 10
+    n_timesteps = 2
+    ds = xr.Dataset(
+        data_vars={
+            'x': (('n_timesteps', 'n_particles'), np.arange(n_timesteps * n_particles).reshape(n_timesteps, n_particles)),
+            'y': (('n_timesteps', 'n_particles'), np.arange(n_timesteps * n_particles).reshape(n_timesteps, n_particles)),
+            'time': (('n_timesteps',), np.array([0.0, 60.0])),
+            'population_id': (('n_particles',), np.array([0] * 5 + [1] * 5, dtype=int)),
+        },
+        coords={
+            'n_particles': np.arange(n_particles),
+            'n_timesteps': np.arange(n_timesteps),
+            'n_populations': np.arange(2),
+        },
+    )
+
+    sampled, total, selected = _sample_dataset(ds, max_particles=4, sample_seed=42)
+
+    assert total == 10
+    assert selected == 4
+    assert sampled.sizes['n_particles'] == 4
+
+
+def test_plot_trajectories_validates_sampling_options(monkeypatch):
+    ds = xr.Dataset(
+        data_vars={
+            'x': (('n_timesteps', 'n_particles'), np.array([[0.0], [1.0]])),
+            'y': (('n_timesteps', 'n_particles'), np.array([[0.0], [1.0]])),
+            'time': (('n_timesteps',), np.array([0.0, 60.0])),
+        }
+    )
+    monkeypatch.setattr('matplotlib.pyplot.show', lambda: None)
+
+    with pytest.raises(ValueError, match='mutually exclusive'):
+        plot_trajectories(ds, max_particles=1, sample_fraction=0.5)
+
+    with pytest.raises(ValueError, match='markers'):
+        plot_trajectories(ds, markers='both')
+
+    with pytest.raises(ValueError, match='panels'):
+        plot_trajectories(ds, panels='bad-panel')
+
+    with pytest.raises(ValueError, match='marker_size'):
+        plot_trajectories(ds, marker_size=0)


### PR DESCRIPTION
Note: no actual gui involved in spite of the branch name! I thought I would PR the changes to the base visualizer first so that we can use this sooner and not have it get lost in a more ambitious (potentially rabbit-hole-y) plotting gui.  I had thought about making a gui to make some of my frequently-desired plots easier/less annoying, and I have a nice plan for this but will prioritize other things first.

Essentially, I was annoyed that it took so long to use the default trajectory visualizer so I sped up the plotting routines, made it output directly to file by default (instead of pop-up), and only plot the main trajectory panel by default:

<img width="2183" height="2365" alt="image" src="https://github.com/user-attachments/assets/3ff81c2d-a3cf-4fac-a467-4367df97b91a" />

====

Refactors trajectory visualization to support faster, scalable plotting by defaulting to a single spatial panel, adding deterministic particle sampling (max/fraction with population stratification), configurable marker behavior, and panel selection. Adds direct output-file support with clearer save/show semantics and updates CLI/API signatures accordingly. Also closes datasets after plotting in the API path, updates user docs for new options/defaults, and expands tests to cover new defaults, validation, panel modes, and sampling behavior.