### PR TITLE
Fix burial-depth spatial leak: re-sample bed level inside the flow-field loop

### DIFF
--- a/src/sedtrails/simulation_orchestrator/simulation_manager.py
+++ b/src/sedtrails/simulation_orchestrator/simulation_manager.py
@@ -1406,9 +1406,19 @@ class Simulation:
                             timer.current_timestep,
                         )
 
-                    if tracer_plan.method_name == 'vanwesten':
-                        with self._profile_section('update_bed_level_after_movement'):
-                            population.update_bed_level_change_after_movement(bed_level)
+                        # Re-sample bed level at the new positions after EVERY
+                        # update_position. This must stay INSIDE the flow-field
+                        # loop: the next update_information copies bed_level to
+                        # bed_level_previous, and update_burial_depth treats the
+                        # difference as a temporal bed change. If the re-sample
+                        # runs only once per timestep, the second flow field's
+                        # update pairs a post-move bed with a pre-move previous,
+                        # leaking the spatial bed gradient into burial_depth
+                        # (see commit message: regression of bdf7a99 via merge
+                        # 90d0b5a).
+                        if tracer_plan.method_name == 'vanwesten':
+                            with self._profile_section('update_bed_level_after_movement'):
+                                population.update_bed_level_change_after_movement(bed_level)
 
                 # Update dashboard if enabled
                 if dashboard_update_due and dashboard_flow_field is not None:

--- a/src/sedtrails/simulation_orchestrator/simulation_manager.py
+++ b/src/sedtrails/simulation_orchestrator/simulation_manager.py
@@ -1420,6 +1420,10 @@ class Simulation:
                         # (see commit message: regression of bdf7a99 via merge
                         # 90d0b5a).
                         if tracer_plan.method_name == 'vanwesten':
+                            # note, maybe this should be moved out of this if 
+                            # block because other methods 
+                            # like soulsby or passive should also be able to 
+                            # navigate a morphodynamic input model
                             transport_probability_method = tracer_plan.transport_probability_method
                             if transport_probability_method != 'no_probability':
                                 with self._profile_section('update_bed_level_after_movement'):

--- a/src/sedtrails/simulation_orchestrator/simulation_manager.py
+++ b/src/sedtrails/simulation_orchestrator/simulation_manager.py
@@ -816,6 +816,23 @@ class Simulation:
         return sample_time + tolerance >= next_output_time or sample_time + tolerance >= end_time
 
     @staticmethod
+    def _should_update_bed_level_after_movement(tracer_plan) -> bool:
+        """Return whether post-move bed-level resampling should run.
+
+        Rules for current 2D workflows:
+        - Always run for ``vanwesten`` to preserve burial-depth bookkeeping.
+        - Also run for any tracer configured with ``no_probability`` so
+          particle ``z`` follows bed level after movement (passive/soulsby included).
+
+        Future quasi-3D tracers can introduce exceptions here when vertical
+        position is solved independently from bed level.
+        """
+        return (
+            tracer_plan.method_name == 'vanwesten'
+            or tracer_plan.transport_probability_method == 'no_probability'
+        )
+
+    @staticmethod
     def _initialize_population_output_status(populations, current_time: int | float) -> None:
         """Populate required status arrays before the initial trajectory sample is written."""
         for population in populations:
@@ -1409,25 +1426,14 @@ class Simulation:
                             timer.current_timestep,
                         )
 
-                        # Re-sample bed level at the new positions after EVERY
-                        # update_position. This must stay INSIDE the flow-field
-                        # loop: the next update_information copies bed_level to
-                        # bed_level_previous, and update_burial_depth treats the
-                        # difference as a temporal bed change. If the re-sample
-                        # runs only once per timestep, the second flow field's
-                        # update pairs a post-move bed with a pre-move previous,
-                        # leaking the spatial bed gradient into burial_depth
-                        # (see commit message: regression of bdf7a99 via merge
-                        # 90d0b5a).
-                        if tracer_plan.method_name == 'vanwesten':
-                            # note, maybe this should be moved out of this if 
-                            # block because other methods 
-                            # like soulsby or passive should also be able to 
-                            # navigate a morphodynamic input model
-                            transport_probability_method = tracer_plan.transport_probability_method
-                            if transport_probability_method != 'no_probability':
-                                with self._profile_section('update_bed_level_after_movement'):
-                                    population.update_bed_level_change_after_movement(bed_level)
+                        # Re-sample bed level at the new positions after movement.
+                        # Keep this INSIDE the flow-field loop so vanwesten
+                        # burial bookkeeping compares temporal bed change only,
+                        # and so no_probability tracers keep z aligned to bed
+                        # level after advection.
+                        if self._should_update_bed_level_after_movement(tracer_plan):
+                            with self._profile_section('update_bed_level_after_movement'):
+                                population.update_bed_level_change_after_movement(bed_level)
 
                 # Update dashboard if enabled
                 if dashboard_update_due and dashboard_flow_field is not None:

--- a/src/sedtrails/simulation_orchestrator/simulation_manager.py
+++ b/src/sedtrails/simulation_orchestrator/simulation_manager.py
@@ -1371,8 +1371,11 @@ class Simulation:
                             )
 
                         if tracer_plan.method_name == 'vanwesten':
-                            with self._profile_section('update_burial_depth'):
-                                population.update_burial_depth()
+                            transport_probability_method = tracer_plan.transport_probability_method
+                            if transport_probability_method != 'no_probability':
+                                with self._profile_section('update_burial_depth'):
+                                    population.update_burial_depth()
+                        
 
                         with self._profile_section('update_status'):
                             population.update_status()
@@ -1417,8 +1420,10 @@ class Simulation:
                         # (see commit message: regression of bdf7a99 via merge
                         # 90d0b5a).
                         if tracer_plan.method_name == 'vanwesten':
-                            with self._profile_section('update_bed_level_after_movement'):
-                                population.update_bed_level_change_after_movement(bed_level)
+                            transport_probability_method = tracer_plan.transport_probability_method
+                            if transport_probability_method != 'no_probability':
+                                with self._profile_section('update_bed_level_after_movement'):
+                                    population.update_bed_level_change_after_movement(bed_level)
 
                 # Update dashboard if enabled
                 if dashboard_update_due and dashboard_flow_field is not None:

--- a/tests/integration/sedtrails-example-burial-diagnostic.yaml
+++ b/tests/integration/sedtrails-example-burial-diagnostic.yaml
@@ -1,0 +1,77 @@
+general:
+  input_model: 
+    format: fm_netcdf
+    reference_date: 1970-01-01  # Default reference date for the input model
+    morfac: 1  # Morphological acceleration factor for time decompression
+inputs:
+  data: ../sample-data/inlet_sedtrails.nc
+  read_interval: 10D  # Time chunk size for reading input data
+  repeat_eulerian_fields: true  # Repeat forcing after a valid start inside the input time range
+# Optional domain controls for islands/cutouts and boundary actions.
+# Tekal .pol paths are resolved relative to this configuration file.
+# domain:
+#   pol_file: ./outer_domain.pol
+#   inner_boundary_pol_files:
+#     - ./islands.pol
+#   boundary_class_pol_files:
+#     open:
+#       - ./offshore_boundary_edges.pol
+#     land:
+#       - ./coastline_boundary_edges.pol
+time:
+  start:  2016-09-21 19:20:00
+  timestep: 60S
+  duration: 1D
+  cfl_condition: 0.7  # CFL condition for adaptive timestep (0 = disabled)
+particles:
+  populations:
+    - name: stochastic
+      particle_type: sand
+      characteristics:
+        grain_size: 0.00025 
+        density: 2650.0  
+      tracer_methods:
+        vanwesten:
+          flow_field_name: 
+            - bed_load_velocity
+            - suspended_velocity
+      transport_probability: stochastic_transport  # Options: no_probability, stochastic_transport, reduced_velocity
+      seeding:
+        burial_depth: 
+          constant: 0
+        release_start: 2016-09-21 19:30:00
+        quantity: 1
+        strategy: 
+          random:
+            bbox: "39400,16800 40600,17800"
+            seed: 42
+            nlocations: 10
+    - name: no_probability
+      particle_type: sand
+      characteristics:
+        grain_size: 0.00025 
+        density: 2650.0  
+      tracer_methods:
+        vanwesten:
+          flow_field_name: 
+            - bed_load_velocity
+            - suspended_velocity
+      transport_probability: no_probability  # Options: no_probability, stochastic_transport, reduced_velocity
+      seeding:
+        burial_depth: 
+          constant: 0
+        release_start: 2016-09-21 19:30:00
+        quantity: 1
+        strategy: 
+          random:
+            bbox: "39400,16800 40600,17800"
+            seed: 42
+            nlocations: 10
+outputs:
+  directory: ./results
+  store_tracks: true
+  save_interval: 1H
+visualization:
+  dashboard:
+    enable: false
+    update_interval: 1H

--- a/tests/integration/test_burial_diagnostics_plot.py
+++ b/tests/integration/test_burial_diagnostics_plot.py
@@ -1,0 +1,289 @@
+"""Skipped-by-default integration test for quick particle diagnostics plots.
+
+This is the resurrected quick-and-dirty plotter, turned into a test that can
+run a SedTRAILS config end-to-end and optionally save diagnostic plots for:
+- particle position maps
+- burial_depth, z, and status_buried time series
+
+Run controls:
+
+- Enable the test with ``SEDTRAILS_RUN_PLOT_INTEGRATION=1``.
+- Override the config file with ``SEDTRAILS_PLOT_CONFIG=/path/to/config.yaml``.
+- The default config is [tests/integration/sedtrails-example-burial-diagnostic.yaml](c:/sedtrails/tests/integration/sedtrails-example-burial-diagnostic.yaml).
+
+Plot controls:
+
+- Plotting is enabled by default.
+- Set ``SEDTRAILS_PLOT_PARTICLE_MAPS=0`` to disable the particle position map.
+- Set ``SEDTRAILS_PLOT_TIME_SERIES=0`` to disable the burial_depth/z/status_buried time series.
+- Set ``SEDTRAILS_PLOT_SHOW=1`` to optionally open the figures after the run.
+- Plots are written to ``tests/integration/plots`` by default.
+- Override the plot output directory with ``SEDTRAILS_PLOT_OUTPUT_DIR=/path/to/plots``.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+import yaml
+import xarray as xr
+
+from sedtrails.simulation_orchestrator.simulation_manager import Simulation
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.environ.get('SEDTRAILS_RUN_PLOT_INTEGRATION'),
+        reason='Skipped by default. Set SEDTRAILS_RUN_PLOT_INTEGRATION=1 to run the plot integration test.',
+    ),
+]
+
+DEFAULT_CONFIG = Path(__file__).resolve().parent / 'sedtrails-example-burial-diagnostic.yaml'
+DEFAULT_PLOT_OUTPUT_DIR = Path(__file__).resolve().parent / 'plots'
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _env_flag(name: str, default: bool) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() not in {'0', 'false', 'no', 'off', ''}
+
+
+def _resolve_config_path() -> Path:
+    config_override = os.environ.get('SEDTRAILS_PLOT_CONFIG')
+    config_path = Path(config_override) if config_override else DEFAULT_CONFIG
+    if not config_path.exists():
+        raise FileNotFoundError(f'Config file not found: {config_path}')
+    return config_path.resolve()
+
+
+def _resolve_plot_output_dir() -> Path:
+    output_override = os.environ.get('SEDTRAILS_PLOT_OUTPUT_DIR')
+    if output_override:
+        return Path(output_override).expanduser().resolve()
+    return DEFAULT_PLOT_OUTPUT_DIR.resolve()
+
+
+def _resolve_input_data_path(source_config: Path, configured_path: str) -> Path:
+    path = Path(configured_path)
+    if path.is_absolute():
+        return path
+
+    repo_relative_parts = list(path.parts)
+    while repo_relative_parts and repo_relative_parts[0] == '..':
+        repo_relative_parts.pop(0)
+
+    candidates = [
+        (source_config.parent / path).resolve(),
+        (REPO_ROOT.joinpath(*repo_relative_parts)).resolve(),
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+
+    return candidates[0]
+
+
+def _prepare_config_copy(source_config: Path, output_dir: Path, tmp_path: Path) -> Path:
+    """Copy a YAML config to a temp file while rewriting file paths for isolation."""
+    with source_config.open('r', encoding='utf-8') as handle:
+        config = yaml.safe_load(handle)
+
+    config['inputs']['data'] = str(_resolve_input_data_path(source_config, config['inputs']['data']))
+    config.setdefault('outputs', {})
+    config['outputs']['directory'] = str(output_dir)
+
+    temp_config = tmp_path / source_config.name
+    with temp_config.open('w', encoding='utf-8') as handle:
+        yaml.safe_dump(config, handle, sort_keys=False)
+    return temp_config
+
+
+def _open_results(results_file: Path) -> xr.Dataset:
+    if not results_file.exists():
+        raise FileNotFoundError(f'Results file not found: {results_file}')
+    return xr.open_dataset(results_file, decode_times=False)
+
+
+def _time_hours(time_values: np.ndarray) -> np.ndarray:
+    time_values = np.asarray(time_values, dtype=float)
+    if time_values.size == 0:
+        return time_values
+    return (time_values - float(time_values[0])) / 3600.0
+
+
+def _decode_netcdf_name(raw_name) -> str:
+    if isinstance(raw_name, bytes):
+        return raw_name.decode('utf-8', errors='ignore').strip('\x00 ').strip()
+
+    values = np.asarray(raw_name)
+    if values.dtype.kind == 'S':
+        return b''.join(np.ravel(values).tolist()).decode('utf-8', errors='ignore').strip('\x00 ').strip()
+    if values.dtype.kind == 'U':
+        return ''.join(np.ravel(values).tolist()).strip('\x00 ').strip()
+    return str(raw_name).strip()
+
+
+def _population_metadata(ds: xr.Dataset) -> tuple[np.ndarray, list[str]]:
+    population_ids = np.asarray(ds['population_id'].values, dtype=int) if 'population_id' in ds else np.zeros(0, dtype=int)
+    if population_ids.size == 0 and 'x' in ds and ds['x'].ndim == 2:
+        population_ids = np.zeros(ds['x'].shape[1], dtype=int)
+
+    n_populations = int(ds.sizes.get('n_populations', np.max(population_ids) + 1 if population_ids.size else 1))
+    names = [f'population_{idx}' for idx in range(n_populations)]
+
+    if 'population_name' in ds:
+        population_var = ds['population_name']
+        n_available = int(population_var.sizes.get('n_populations', population_var.shape[0]))
+        for idx in range(min(n_populations, n_available)):
+            raw_name = population_var[idx].values if population_var.ndim == 1 else population_var[idx, :].values
+            decoded = _decode_netcdf_name(raw_name)
+            if decoded:
+                names[idx] = decoded
+
+    return population_ids, names
+
+
+def _population_colors(n_populations: int):
+    import matplotlib.pyplot as plt
+
+    cmap = plt.get_cmap('Set1' if n_populations <= 8 else 'tab20')
+    if n_populations <= 1:
+        return [cmap(0)]
+    return [cmap(value) for value in np.linspace(0, 1, n_populations)]
+
+
+def _plot_position_maps(ds: xr.Dataset, output_dir: Path) -> Path:
+    """Plot particle position paths as x/y maps, colored by population."""
+    import matplotlib
+
+    matplotlib.use('Agg', force=True)
+    import matplotlib.pyplot as plt
+    from matplotlib.lines import Line2D
+
+    x = np.asarray(ds['x'].values, dtype=float)
+    y = np.asarray(ds['y'].values, dtype=float)
+    population_ids, population_names = _population_metadata(ds)
+    if x.ndim != 2 or y.ndim != 2:
+        raise ValueError('Expected time-major x/y arrays with shape (n_timesteps, n_particles).')
+
+    n_timesteps, n_particles = x.shape
+    if population_ids.shape[0] != n_particles:
+        raise ValueError('population_id length does not match number of particles.')
+
+    pop_colors = _population_colors(max(1, len(population_names)))
+    fig, ax = plt.subplots(figsize=(8.5, 7.5))
+
+    for particle_index in range(n_particles):
+        pop_idx = int(population_ids[particle_index])
+        color = pop_colors[pop_idx % len(pop_colors)]
+        ax.plot(x[:, particle_index], y[:, particle_index], lw=1.0, alpha=0.8, color=color)
+        ax.scatter(x[0, particle_index], y[0, particle_index], s=18, marker='o', color=color)
+        ax.scatter(x[-1, particle_index], y[-1, particle_index], s=18, marker='x', color=color)
+
+    legend_handles = [
+        Line2D([0], [0], color=pop_colors[idx], lw=2.0, label=population_names[idx])
+        for idx in range(len(population_names))
+    ]
+
+    ax.set_title(f'Particle position maps by population ({n_particles} particles, {n_timesteps} timesteps)')
+    ax.set_xlabel('x')
+    ax.set_ylabel('y')
+    ax.set_aspect('equal', adjustable='box')
+    ax.grid(True, alpha=0.25)
+    ax.legend(handles=legend_handles, title='Population', loc='best')
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    figure_path = output_dir / 'particle_position_maps.png'
+    fig.tight_layout()
+    fig.savefig(figure_path, dpi=180)
+    plt.close(fig)
+    return figure_path
+
+
+def _plot_time_series(ds: xr.Dataset, output_dir: Path) -> Path:
+    """Plot burial_depth, z, and status_buried time series split by population."""
+    import matplotlib
+
+    matplotlib.use('Agg', force=True)
+    import matplotlib.pyplot as plt
+
+    time_values = _time_hours(np.asarray(ds['time'].values, dtype=float))
+    burial_depth = np.asarray(ds['burial_depth'].values, dtype=float)
+    z = np.asarray(ds['z'].values, dtype=float)
+    status_buried = np.asarray(ds['status_buried'].values, dtype=float)
+    population_ids, population_names = _population_metadata(ds)
+
+    if burial_depth.ndim != 2 or z.ndim != 2 or status_buried.ndim != 2:
+        raise ValueError('Expected time-major burial_depth, z, and status_buried arrays.')
+
+    n_timesteps, n_particles = burial_depth.shape
+    if z.shape != burial_depth.shape or status_buried.shape != burial_depth.shape:
+        raise ValueError('Time-series arrays must all have the same shape.')
+    if population_ids.shape[0] != n_particles:
+        raise ValueError('population_id length does not match number of particles.')
+
+    n_populations = max(1, len(population_names))
+    pop_colors = _population_colors(n_populations)
+    fig, axes = plt.subplots(3, n_populations, figsize=(6.2 * n_populations, 9.0), sharex=True, squeeze=False)
+    series = [
+        ('burial_depth', burial_depth),
+        ('z', z),
+        ('status_buried', status_buried),
+    ]
+
+    for pop_idx, pop_name in enumerate(population_names):
+        particle_indices = np.flatnonzero(population_ids == pop_idx)
+        for row_idx, (label, data) in enumerate(series):
+            axis = axes[row_idx, pop_idx]
+            for particle_index in particle_indices:
+                color = pop_colors[pop_idx % len(pop_colors)]
+                if label == 'status_buried':
+                    axis.step(time_values, data[:, particle_index], where='post', lw=1.0, alpha=0.8, color=color)
+                else:
+                    axis.plot(time_values, data[:, particle_index], lw=1.0, alpha=0.8, color=color)
+            if pop_idx == 0:
+                axis.set_ylabel(label)
+            axis.set_title(f'Population: {pop_name} (n={len(particle_indices)})')
+            axis.grid(True, alpha=0.25)
+
+    for axis in axes[-1, :]:
+        axis.set_xlabel('time (hours since first saved slot)')
+    fig.suptitle(f'Particle time series by population ({n_particles} particles, {n_timesteps} timesteps)')
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    figure_path = output_dir / 'particle_time_series.png'
+    fig.tight_layout(rect=(0.0, 0.0, 1.0, 0.97))
+    fig.savefig(figure_path, dpi=180)
+    plt.close(fig)
+    return figure_path
+
+
+@pytest.mark.integration
+def test_particle_diagnostics_plotter(tmp_path):
+    """Run the example config and optionally save quick diagnostic plots."""
+    config_path = _resolve_config_path()
+    output_dir = tmp_path / 'results'
+    plot_output_dir = _resolve_plot_output_dir()
+    temp_config = _prepare_config_copy(config_path, output_dir, tmp_path)
+
+    Simulation(str(temp_config), enable_dashboard=False).run()
+
+    results_file = output_dir / 'sedtrails_results.nc'
+    with _open_results(results_file) as ds:
+        for field_name in ('x', 'y', 'burial_depth', 'z', 'status_buried', 'time'):
+            assert field_name in ds, f"Missing expected output field: {field_name}"
+
+        if _env_flag('SEDTRAILS_PLOT_PARTICLE_MAPS', True):
+            _plot_position_maps(ds, plot_output_dir)
+        if _env_flag('SEDTRAILS_PLOT_TIME_SERIES', True):
+            _plot_time_series(ds, plot_output_dir)
+
+    if _env_flag('SEDTRAILS_PLOT_SHOW', False):
+        import matplotlib.pyplot as plt
+
+        plt.show()

--- a/tests/particle_tracer/test_particle_seeder.py
+++ b/tests/particle_tracer/test_particle_seeder.py
@@ -19,10 +19,10 @@ from sedtrails.particle_tracer.particle_seeder import (
     PopulationConfig,
     RandomStrategy,
     TransectStrategy,
-    _parse_polygon,
-    _read_polygon_file,
     _compute_seeding_area,
     _log_seeding_box_volume,
+    _parse_polygon,
+    _read_polygon_file,
 )
 
 
@@ -1154,7 +1154,7 @@ def population_config():
 
 
 class TestParticlePopulation:
-@staticmethod
+    @staticmethod
     def _diffusing_passive_population(diffusion_coefficient=0.5):
         """Create mobile passive particles on a unit-square grid."""
         config = PopulationConfig(
@@ -1293,7 +1293,11 @@ class TestParticlePopulation:
         ('particle_type', 'tracer_methods', 'characteristics'),
         [
             ('passive', {'passive_tracer': {}}, {}),
-            ('sand', {'vanwesten': {'flow_field_name': ['bed_load_velocity']}}, {'density': 2650.0, 'grain_size': 0.00025}),
+            (
+                'sand',
+                {'vanwesten': {'flow_field_name': ['bed_load_velocity']}},
+                {'density': 2650.0, 'grain_size': 0.00025},
+            ),
             ('mud', {'soulsby': {'flow_field_name': ['grain_velocity']}}, {'density': 2000.0, 'size': 0.00005}),
         ],
     )
@@ -1333,7 +1337,6 @@ class TestParticlePopulation:
 
     @staticmethod
     def _status_test_population(current_time=0.0):
-
 
         config = PopulationConfig(
             {
@@ -1507,10 +1510,7 @@ class TestParticlePopulation:
             calls.append(len(fields))
             assert len(fields) == 3
             np.testing.assert_array_equal(simplex_ids, population._particle_simplices)
-            particle_values = tuple(
-                np.full(len(x_points), value, dtype=float)
-                for value in (0.5, 0.75, 1.25)
-            )
+            particle_values = tuple(np.full(len(x_points), value, dtype=float) for value in (0.5, 0.75, 1.25))
             return particle_values, np.zeros(len(x_points), dtype=np.int64)
 
         population._field_interpolator = fail_single_field
@@ -1721,11 +1721,7 @@ class TestParticlePopulation:
         population._outer_envelope = type(
             'FailingEnvelope',
             (),
-            {
-                'contains_points': lambda self, points: pytest.fail(
-                    'status_domain should use cached simplex ids'
-                )
-            },
+            {'contains_points': lambda self, points: pytest.fail('status_domain should use cached simplex ids')},
         )()
         monkeypatch.setattr(np.random, 'rand', lambda n_particles: np.zeros(n_particles))
 
@@ -1821,7 +1817,6 @@ class TestParticlePopulation:
 
         np.testing.assert_array_equal(population.particles['status_transported'], np.array([True]))
         np.testing.assert_array_equal(population.particles['status_buried'], np.array([False]))
-
 
     def test_update_status_reuses_cached_particle_locations(self, monkeypatch):
         """Unchanged particles should not be relocated on every status update."""
@@ -2045,6 +2040,7 @@ class TestParticlePopulation:
 # Polygon helpers
 # ---------------------------------------------------------------------------
 
+
 class TestParsePolygon:
     """Tests for _parse_polygon and _read_polygon_file."""
 
@@ -2104,18 +2100,20 @@ class TestParsePolygon:
 # RandomStrategy with poly
 # ---------------------------------------------------------------------------
 
-class TestRandomStrategyPoly:
 
+class TestRandomStrategyPoly:
     def _make_config(self, poly, nlocations=10, seed=42):
-        return PopulationConfig({
-            'particle_type': 'sand',
-            'seeding': {
-                'strategy': {'random': {'poly': poly, 'nlocations': nlocations, 'seed': seed}},
-                'quantity': 1,
-                'release_start': '2025-01-01 00:00:00',
-                'burial_depth': {'constant': 0.0},
-            },
-        })
+        return PopulationConfig(
+            {
+                'particle_type': 'sand',
+                'seeding': {
+                    'strategy': {'random': {'poly': poly, 'nlocations': nlocations, 'seed': seed}},
+                    'quantity': 1,
+                    'release_start': '2025-01-01 00:00:00',
+                    'burial_depth': {'constant': 0.0},
+                },
+            }
+        )
 
     def test_inline_poly_all_inside(self):
         # Unit square polygon
@@ -2143,15 +2141,17 @@ class TestRandomStrategyPoly:
         assert len(result) == 5
 
     def test_missing_both_bbox_and_poly(self):
-        config = PopulationConfig({
-            'particle_type': 'sand',
-            'seeding': {
-                'strategy': {'random': {'nlocations': 1, 'seed': 1}},
-                'quantity': 1,
-                'release_start': '2025-01-01 00:00:00',
-                'burial_depth': {'constant': 0.0},
-            },
-        })
+        config = PopulationConfig(
+            {
+                'particle_type': 'sand',
+                'seeding': {
+                    'strategy': {'random': {'nlocations': 1, 'seed': 1}},
+                    'quantity': 1,
+                    'release_start': '2025-01-01 00:00:00',
+                    'burial_depth': {'constant': 0.0},
+                },
+            }
+        )
         with pytest.raises(MissingConfigurationParameter, match='"bbox" or "poly"'):
             RandomStrategy().seed(config)
 
@@ -2170,21 +2170,25 @@ class TestRandomStrategyPoly:
 # GridStrategy with poly
 # ---------------------------------------------------------------------------
 
-class TestGridStrategyPoly:
 
+class TestGridStrategyPoly:
     def _make_config(self, poly, dx=1.0, dy=1.0):
-        return PopulationConfig({
-            'particle_type': 'sand',
-            'seeding': {
-                'strategy': {'grid': {
-                    'poly': poly,
-                    'separation': {'dx': dx, 'dy': dy},
-                }},
-                'quantity': 1,
-                'release_start': '2025-01-01 00:00:00',
-                'burial_depth': {'constant': 0.0},
-            },
-        })
+        return PopulationConfig(
+            {
+                'particle_type': 'sand',
+                'seeding': {
+                    'strategy': {
+                        'grid': {
+                            'poly': poly,
+                            'separation': {'dx': dx, 'dy': dy},
+                        }
+                    },
+                    'quantity': 1,
+                    'release_start': '2025-01-01 00:00:00',
+                    'burial_depth': {'constant': 0.0},
+                },
+            }
+        )
 
     def test_inline_unit_square_grid(self):
         # 2x2 unit square: grid at 0,0  0,1  1,0  1,1 (corners on boundary)
@@ -2222,15 +2226,17 @@ class TestGridStrategyPoly:
         assert (3.0, 3.0) in positions
 
     def test_missing_both_bbox_and_poly(self):
-        config = PopulationConfig({
-            'particle_type': 'sand',
-            'seeding': {
-                'strategy': {'grid': {'separation': {'dx': 1.0, 'dy': 1.0}}},
-                'quantity': 1,
-                'release_start': '2025-01-01 00:00:00',
-                'burial_depth': {'constant': 0.0},
-            },
-        })
+        config = PopulationConfig(
+            {
+                'particle_type': 'sand',
+                'seeding': {
+                    'strategy': {'grid': {'separation': {'dx': 1.0, 'dy': 1.0}}},
+                    'quantity': 1,
+                    'release_start': '2025-01-01 00:00:00',
+                    'burial_depth': {'constant': 0.0},
+                },
+            }
+        )
         with pytest.raises(MissingConfigurationParameter, match='"bbox" or "poly"'):
             GridStrategy().seed(config)
 
@@ -2248,8 +2254,8 @@ class TestGridStrategyPoly:
 # Seeding box volume logging
 # ---------------------------------------------------------------------------
 
-class TestComputeSeedingArea:
 
+class TestComputeSeedingArea:
     def test_bbox_string(self):
         area = _compute_seeding_area('random', {'bbox': '0,0 4,3'})
         assert area == pytest.approx(12.0)
@@ -2281,18 +2287,19 @@ class TestComputeSeedingArea:
 
 
 class TestLogSeedingBoxVolume:
-
     def _make_random_config(self, burial_depth, bbox='0,0 4,3', nlocations=6, quantity=2):
-        return PopulationConfig({
-            'name': 'test_pop',
-            'particle_type': 'sand',
-            'seeding': {
-                'strategy': {'random': {'bbox': bbox, 'nlocations': nlocations, 'seed': 1}},
-                'quantity': quantity,
-                'release_start': '2025-01-01 00:00:00',
-                'burial_depth': burial_depth,
-            },
-        })
+        return PopulationConfig(
+            {
+                'name': 'test_pop',
+                'particle_type': 'sand',
+                'seeding': {
+                    'strategy': {'random': {'bbox': bbox, 'nlocations': nlocations, 'seed': 1}},
+                    'quantity': quantity,
+                    'release_start': '2025-01-01 00:00:00',
+                    'burial_depth': burial_depth,
+                },
+            }
+        )
 
     def test_logs_when_random_burial_and_bbox(self, caplog):
         config = self._make_random_config({'random': 3.0})
@@ -2315,53 +2322,59 @@ class TestLogSeedingBoxVolume:
         assert caplog.records == []
 
     def test_no_log_for_point_strategy(self, caplog):
-        config = PopulationConfig({
-            'name': 'pts',
-            'particle_type': 'sand',
-            'seeding': {
-                'strategy': {'point': {'locations': ['0,0', '1,1']}},
-                'quantity': 1,
-                'release_start': '2025-01-01 00:00:00',
-                'burial_depth': {'random': 2.0},
-            },
-        })
+        config = PopulationConfig(
+            {
+                'name': 'pts',
+                'particle_type': 'sand',
+                'seeding': {
+                    'strategy': {'point': {'locations': ['0,0', '1,1']}},
+                    'quantity': 1,
+                    'release_start': '2025-01-01 00:00:00',
+                    'burial_depth': {'random': 2.0},
+                },
+            }
+        )
         positions = [(1, 0.0, 0.0), (1, 1.0, 1.0)]
         with caplog.at_level('INFO', logger='sedtrails.particle_tracer.particle_seeder'):
             _log_seeding_box_volume(config, positions)
         assert caplog.records == []
 
     def test_logs_with_poly(self, caplog):
-        config = PopulationConfig({
-            'name': 'poly_pop',
-            'particle_type': 'sand',
-            'seeding': {
-                'strategy': {'random': {'poly': ['0,0', '2,0', '2,2', '0,2'], 'nlocations': 4, 'seed': 1}},
-                'quantity': 1,
-                'release_start': '2025-01-01 00:00:00',
-                'burial_depth': {'random': 5.0},
-            },
-        })
+        config = PopulationConfig(
+            {
+                'name': 'poly_pop',
+                'particle_type': 'sand',
+                'seeding': {
+                    'strategy': {'random': {'poly': ['0,0', '2,0', '2,2', '0,2'], 'nlocations': 4, 'seed': 1}},
+                    'quantity': 1,
+                    'release_start': '2025-01-01 00:00:00',
+                    'burial_depth': {'random': 5.0},
+                },
+            }
+        )
         # 4 positions × qty 1 = 4 particles; area=4, depth=5, volume=20, repr=5
         positions = [(1, 0.5, 0.5), (1, 1.5, 0.5), (1, 0.5, 1.5), (1, 1.5, 1.5)]
         with caplog.at_level('INFO', logger='sedtrails.particle_tracer.particle_seeder'):
             _log_seeding_box_volume(config, positions)
         assert len(caplog.records) == 1
         msg = caplog.records[0].message
-        assert '20' in msg   # volume
-        assert '4' in msg    # n_particles or area
-        assert '5' in msg    # depth or repr volume
+        assert '20' in msg  # volume
+        assert '4' in msg  # n_particles or area
+        assert '5' in msg  # depth or repr volume
 
     def test_factory_emits_log_for_random_burial_bbox(self, caplog):
-        config = PopulationConfig({
-            'name': 'factory_test',
-            'particle_type': 'sand',
-            'seeding': {
-                'strategy': {'random': {'bbox': '0,0 10,10', 'nlocations': 5, 'seed': 42}},
-                'quantity': 2,
-                'release_start': '2025-01-01 00:00:00',
-                'burial_depth': {'random': 2.0},
-            },
-        })
+        config = PopulationConfig(
+            {
+                'name': 'factory_test',
+                'particle_type': 'sand',
+                'seeding': {
+                    'strategy': {'random': {'bbox': '0,0 10,10', 'nlocations': 5, 'seed': 42}},
+                    'quantity': 2,
+                    'release_start': '2025-01-01 00:00:00',
+                    'burial_depth': {'random': 2.0},
+                },
+            }
+        )
         with caplog.at_level('INFO', logger='sedtrails.particle_tracer.particle_seeder'):
             ParticleFactory.create_particles(config)
         assert any('volume' in r.message.lower() for r in caplog.records)
@@ -2371,19 +2384,22 @@ class TestLogSeedingBoxVolume:
 # Permanently-buried particle removal
 # ---------------------------------------------------------------------------
 
+
 def _make_population(burial_depth_cfg, remove_flag=False, n_pts=4):
     """Create a minimal ParticlePopulation on a unit-square grid."""
-    config = PopulationConfig({
-        'name': 'test_pop',
-        'particle_type': 'sand',
-        'seeding': {
-            'strategy': {'point': {'locations': [f'{i},{i}' for i in range(n_pts)]}},
-            'quantity': 1,
-            'release_start': '2025-01-01 00:00:00',
-            'burial_depth': burial_depth_cfg,
-            'remove_permanently_buried': remove_flag,
-        },
-    })
+    config = PopulationConfig(
+        {
+            'name': 'test_pop',
+            'particle_type': 'sand',
+            'seeding': {
+                'strategy': {'point': {'locations': [f'{i},{i}' for i in range(n_pts)]}},
+                'quantity': 1,
+                'release_start': '2025-01-01 00:00:00',
+                'burial_depth': burial_depth_cfg,
+                'remove_permanently_buried': remove_flag,
+            },
+        }
+    )
     # Grid: unit square with enough nodes to contain the seed points
     field_x = np.array([0.0, 4.0, 4.0, 0.0])
     field_y = np.array([0.0, 0.0, 4.0, 4.0])
@@ -2391,7 +2407,6 @@ def _make_population(burial_depth_cfg, remove_flag=False, n_pts=4):
 
 
 class TestRemovePermanentlyBuriedParticles:
-
     def test_flag_off_removes_nothing(self):
         pop = _make_population({'constant': 5.0}, remove_flag=False)
         n_before = len(pop.particles['x'])
@@ -2427,17 +2442,19 @@ class TestRemovePermanentlyBuriedParticles:
         # max_exposure at nodes: [10, 10, 0.5, 0.5]
         #   → particles at (0,0),(4,0): 2.0 ≤ 10  → kept
         #   → particles at (4,4),(0,4): 2.0 > 0.5 → removed
-        config = PopulationConfig({
-            'name': 'partial_test',
-            'particle_type': 'sand',
-            'seeding': {
-                'strategy': {'point': {'locations': ['0,0', '4,0', '4,4', '0,4']}},
-                'quantity': 1,
-                'release_start': '2025-01-01 00:00:00',
-                'burial_depth': {'constant': 2.0},
-                'remove_permanently_buried': True,
-            },
-        })
+        config = PopulationConfig(
+            {
+                'name': 'partial_test',
+                'particle_type': 'sand',
+                'seeding': {
+                    'strategy': {'point': {'locations': ['0,0', '4,0', '4,4', '0,4']}},
+                    'quantity': 1,
+                    'release_start': '2025-01-01 00:00:00',
+                    'burial_depth': {'constant': 2.0},
+                    'remove_permanently_buried': True,
+                },
+            }
+        )
         field_x = np.array([0.0, 4.0, 4.0, 0.0])
         field_y = np.array([0.0, 0.0, 4.0, 4.0])
         pop = ParticlePopulation(field_x=field_x, field_y=field_y, population_config=config)
@@ -2487,29 +2504,35 @@ class TestRemovePermanentlyBuriedParticles:
         assert any('no permanently buried' in r.message.lower() for r in caplog.records)
 
     def test_config_flag_read_from_population_config(self):
-        config = PopulationConfig({
-            'name': 'p', 'particle_type': 'sand',
-            'seeding': {
-                'strategy': {'point': {'locations': ['0,0']}},
-                'quantity': 1,
-                'release_start': '2025-01-01 00:00:00',
-                'burial_depth': {'constant': 0.0},
-                'remove_permanently_buried': True,
-            },
-        })
+        config = PopulationConfig(
+            {
+                'name': 'p',
+                'particle_type': 'sand',
+                'seeding': {
+                    'strategy': {'point': {'locations': ['0,0']}},
+                    'quantity': 1,
+                    'release_start': '2025-01-01 00:00:00',
+                    'burial_depth': {'constant': 0.0},
+                    'remove_permanently_buried': True,
+                },
+            }
+        )
         assert config.remove_permanently_buried is True
 
     def test_config_flag_defaults_to_false(self):
-        config = PopulationConfig({
-            'name': 'p', 'particle_type': 'sand',
-            'seeding': {
-                'strategy': {'point': {'locations': ['0,0']}},
-                'quantity': 1,
-                'release_start': '2025-01-01 00:00:00',
-                'burial_depth': {'constant': 0.0},
-                # remove_permanently_buried not specified
-            },
-        })
+        config = PopulationConfig(
+            {
+                'name': 'p',
+                'particle_type': 'sand',
+                'seeding': {
+                    'strategy': {'point': {'locations': ['0,0']}},
+                    'quantity': 1,
+                    'release_start': '2025-01-01 00:00:00',
+                    'burial_depth': {'constant': 0.0},
+                    # remove_permanently_buried not specified
+                },
+            }
+        )
         assert config.remove_permanently_buried is False
 
     def test_release_time_is_converted_to_seconds_since_reference_date(self):

--- a/tests/particle_tracer/test_particle_seeder.py
+++ b/tests/particle_tracer/test_particle_seeder.py
@@ -1592,6 +1592,28 @@ class TestParticlePopulation:
         np.testing.assert_array_equal(population.particles['status_transported'], np.array([True]))
         np.testing.assert_array_equal(population.particles['status_mobile'], np.array([True]))
 
+    def test_no_probability_keeps_burial_and_buried_status_zero_over_time(self, monkeypatch):
+        """With no_probability, burial/state stay zero and z follows bed level each timestep."""
+        population = _single_particle_population(release_start='0')
+        monkeypatch.setattr(np.random, 'rand', lambda n_particles: pytest.fail('np.random.rand should not be called'))
+
+        bed_levels = [0.0, 0.35, -0.2, 0.8]
+        for step, bed_level in enumerate(bed_levels):
+            current_time = float(step)
+            population.update_information(
+                current_time=current_time,
+                mixing_depth=1.0,
+                transport_probability=0.2,
+                bed_level=bed_level,
+            )
+            population.update_status()
+            population.update_bed_level_change_after_movement(bed_level)
+
+            np.testing.assert_allclose(population.particles['burial_depth'], np.array([0.0]))
+            np.testing.assert_array_equal(population.particles['status_buried'], np.array([False]))
+            np.testing.assert_allclose(population.particles['z'], np.array([bed_level]))
+            np.testing.assert_allclose(population.particles['bed_level'], np.array([bed_level]))
+
     def test_update_status_reuses_cached_particle_locations(self, monkeypatch):
         """Unchanged particles should not be relocated on every status update."""
         population = _single_particle_population(release_start='0')

--- a/tests/simulation_orchestrator/test_burial_static_bed.py
+++ b/tests/simulation_orchestrator/test_burial_static_bed.py
@@ -1,0 +1,184 @@
+"""Regression test: burial depth must stay exactly zero on a static bed.
+
+Guards the invariant documented in ``ParticlePopulation.update_burial_depth``:
+``bed_level_previous`` always holds the bed level at the particle's *current*
+position, so the burial increment is a purely temporal bed change (zero for a
+static bed). The invariant requires ``update_bed_level_change_after_movement``
+to run after EVERY ``update_position`` — i.e. inside the per-flow-field loop
+of the simulation manager, because the vanwesten tracer moves particles once
+per flow field (bed load + suspended).
+
+History: the invariant was established in bdf7a99 (2026-06-02) and silently
+regressed in merge 90d0b5a (2026-06-12), where an upstream re-indent of the
+flow-field loop left the re-sample call outside the loop without any of its
+lines changing. The result: the spatial bed gradient along each bed-load
+displacement was booked as a temporal bed change, and the ``max(burial, 0)``
+floor rectified that noise into a one-way burial ratchet. In a year-long
+morphostatic Westerschelde run this spuriously buried and immobilised ~99% of
+all particles.
+
+The test runs a real end-to-end simulation on a synthetic forcing with a
+STATIC sloped bed and steady eastward transport: particles must move, and
+burial depth must remain exactly zero.
+"""
+
+import logging
+from pathlib import Path
+
+import netCDF4 as nc
+import numpy as np
+import pytest
+
+from sedtrails.simulation_orchestrator.simulation_manager import Simulation
+
+REFERENCE_DATE = '2020-01-01 00:00:00'
+
+
+def _write_forcing(path: Path) -> None:
+    """Synthetic SedTRAILS forcing: static bed sloping up in x, steady flow."""
+    nx = ny = 60
+    xs = np.linspace(0.0, 10_000.0, nx)
+    ys = np.linspace(0.0, 10_000.0, ny)
+    xg, yg = np.meshgrid(xs, ys, indexing='xy')
+    x = xg.ravel()
+    y = yg.ravel()
+    n_nodes = x.size
+    times = np.array([0.0, 43_200.0, 86_400.0])  # 3 steps, 12 h apart
+
+    bedlevel = -10.0 + 1.0e-3 * x  # static slope: 1 m per km, up-slope eastward
+
+    with nc.Dataset(path, 'w', format='NETCDF4') as ds:
+        ds.createDimension('time', len(times))
+        ds.createDimension('nNodes', n_nodes)
+        ds.createDimension('nSedTot', 1)
+
+        v = ds.createVariable('time', 'f8', ('time',))
+        v.units = f'seconds since {REFERENCE_DATE}'
+        v.calendar = 'standard'
+        v[:] = times
+
+        for name, values in (('net_xcc', x), ('net_ycc', y)):
+            v = ds.createVariable(name, 'f8', ('nNodes',))
+            v.units = 'm'
+            v[:] = values
+
+        def _steady_2d(name, value_per_node):
+            var = ds.createVariable(name, 'f8', ('time', 'nNodes'))
+            var[:] = np.tile(value_per_node, (len(times), 1))
+
+        def _steady_3d(name, value_per_node):
+            var = ds.createVariable(name, 'f8', ('time', 'nSedTot', 'nNodes'))
+            var[:] = np.tile(value_per_node, (len(times), 1, 1))
+
+        _steady_2d('bedlevel', bedlevel)
+        _steady_2d('waterdepth', np.full(n_nodes, 5.0))
+        _steady_2d('sea_water_x_velocity', np.full(n_nodes, 0.5))
+        _steady_2d('sea_water_y_velocity', np.zeros(n_nodes))
+        _steady_2d('mean_bss_magnitude', np.full(n_nodes, 1.0))
+        _steady_2d('max_bss_magnitude', np.full(n_nodes, 2.0))  # >> tau_cr: mobile everywhere
+        _steady_3d('bedload_x_comp', np.full(n_nodes, 0.1))
+        _steady_3d('bedload_y_comp', np.zeros(n_nodes))
+        _steady_3d('susload_x_comp', np.full(n_nodes, 0.05))
+        _steady_3d('susload_y_comp', np.zeros(n_nodes))
+        _steady_3d('suspended_sed_conc', np.full(n_nodes, 0.05))
+
+
+def _write_config(path: Path, forcing: Path, output_dir: Path) -> None:
+    path.write_text(
+        f"""general:
+  input_model:
+    format: fm_netcdf
+    reference_date: 2020-01-01
+    morfac: 1
+inputs:
+  data: {forcing.as_posix()}
+  read_interval: 2D
+time:
+  start: 2020-01-01 00:00:00
+  timestep: 60S
+  duration: 1H
+  cfl_condition: 0.9
+particles:
+  populations:
+    - name: static_bed_sand
+      particle_type: sand
+      characteristics:
+        grain_size: 0.00018
+        density: 2650.0
+      tracer_methods:
+        vanwesten:
+          flow_field_name:
+            - bed_load_velocity
+            - suspended_velocity
+          suspended_velocity_method: soulsby_2011
+      transport_probability: reduced_velocity
+      seeding:
+        burial_depth:
+          constant: 0
+        release_start: 2020-01-01 00:00:00
+        quantity: 1
+        strategy:
+          point:
+            locations:
+              - "3000,5000"
+              - "4000,4000"
+              - "5000,5000"
+              - "6000,6000"
+outputs:
+  directory: {output_dir.as_posix()}
+  store_tracks: true
+  save_interval: 600S
+visualization:
+  dashboard:
+    enable: false
+    update_interval: 1H
+""",
+        encoding='utf-8',
+    )
+
+
+@pytest.fixture
+def _preserve_logging_state():
+    """Running a full Simulation reconfigures the global 'sedtrails' logger;
+    restore it afterwards so log-capture tests elsewhere keep working."""
+    loggers = [logging.getLogger(), logging.getLogger('sedtrails')]
+    saved = [(lg, lg.level, lg.propagate, list(lg.handlers)) for lg in loggers]
+    yield
+    for lg, level, propagate, handlers in saved:
+        for handler in list(lg.handlers):
+            if handler not in handlers:
+                handler.close()
+                lg.removeHandler(handler)
+        lg.level = level
+        lg.propagate = propagate
+
+
+@pytest.mark.integration
+def test_burial_depth_stays_zero_on_static_bed(tmp_path, _preserve_logging_state):
+    forcing = tmp_path / 'static_bed_forcing.nc'
+    config = tmp_path / 'static_bed.yaml'
+    output_dir = tmp_path / 'output'
+    _write_forcing(forcing)
+    _write_config(config, forcing, output_dir)
+
+    Simulation(str(config), enable_dashboard=False).run()
+
+    results = output_dir / 'sedtrails_results.nc'
+    assert results.exists(), 'simulation did not produce sedtrails_results.nc'
+
+    with nc.Dataset(results) as ds:
+        x = np.asarray(ds.variables['x'][:], dtype=float)
+        burial = np.asarray(ds.variables['burial_depth'][:], dtype=float)
+
+    # The particles must actually have moved (the bug only manifests during
+    # transport over a bed gradient) ...
+    assert np.nanmax(np.abs(x[-1, :] - x[0, :])) > 1.0, (
+        'particles did not move; the burial assertion below would be vacuous'
+    )
+
+    # ... and the bed is static, so burial depth must remain exactly zero.
+    # Any positive value means spatial bed differences leaked into the
+    # burial bookkeeping (regression of bdf7a99, see module docstring).
+    assert np.nanmax(burial) <= 1e-12, (
+        f'burial_depth reached {np.nanmax(burial):.6f} m on a static bed'
+    )

--- a/tests/simulation_orchestrator/test_burial_static_bed.py
+++ b/tests/simulation_orchestrator/test_burial_static_bed.py
@@ -83,7 +83,12 @@ def _write_forcing(path: Path) -> None:
         _steady_3d('suspended_sed_conc', np.full(n_nodes, 0.05))
 
 
-def _write_config(path: Path, forcing: Path, output_dir: Path) -> None:
+def _write_config(
+  path: Path,
+  forcing: Path,
+  output_dir: Path,
+  transport_probability: str = 'reduced_velocity',
+) -> None:
     path.write_text(
         f"""general:
   input_model:
@@ -111,7 +116,7 @@ particles:
             - bed_load_velocity
             - suspended_velocity
           suspended_velocity_method: soulsby_2011
-      transport_probability: reduced_velocity
+      transport_probability: {transport_probability}
       seeding:
         burial_depth:
           constant: 0
@@ -181,4 +186,47 @@ def test_burial_depth_stays_zero_on_static_bed(tmp_path, _preserve_logging_state
     # burial bookkeeping (regression of bdf7a99, see module docstring).
     assert np.nanmax(burial) <= 1e-12, (
         f'burial_depth reached {np.nanmax(burial):.6f} m on a static bed'
+    )
+
+
+@pytest.mark.integration
+def test_no_probability_keeps_status_unburied_and_z_on_bed_level(tmp_path, _preserve_logging_state):
+    forcing = tmp_path / 'static_bed_forcing.nc'
+    config = tmp_path / 'static_bed_no_probability.yaml'
+    output_dir = tmp_path / 'output_no_probability'
+    _write_forcing(forcing)
+    _write_config(config, forcing, output_dir, transport_probability='no_probability')
+
+    Simulation(str(config), enable_dashboard=False).run()
+
+    results = output_dir / 'sedtrails_results.nc'
+    assert results.exists(), 'simulation did not produce sedtrails_results.nc'
+
+    with nc.Dataset(results) as ds:
+        x = np.asarray(ds.variables['x'][:], dtype=float)
+        z = np.asarray(ds.variables['z'][:], dtype=float)
+        burial = np.asarray(ds.variables['burial_depth'][:], dtype=float)
+        status_buried = np.asarray(ds.variables['status_buried'][:], dtype=float)
+
+    # Sanity: particles must move so the z-vs-bed check is meaningful.
+    assert np.nanmax(np.abs(x[-1, :] - x[0, :])) > 1.0, (
+        'particles did not move; no_probability invariants were not meaningfully exercised'
+    )
+
+    # no_probability disables burial updates; burial and buried status stay zero.
+    assert np.nanmax(burial) <= 1e-12, (
+        f'burial_depth reached {np.nanmax(burial):.6f} m with no_probability'
+    )
+    assert np.nanmax(status_buried) <= 0.0, (
+        f'status_buried contains non-zero entries (max={np.nanmax(status_buried):.0f}) with no_probability'
+    )
+
+    # On a static bed bedlevel(x) = -10 + 1e-3*x, so z should match that bed
+    # level after the first runtime update.
+    expected_bed_level = -10.0 + 1.0e-3 * x
+    z_runtime = z[1:, :]
+    expected_runtime = expected_bed_level[1:, :]
+    assert np.nanmax(np.abs(z_runtime - expected_runtime)) <= 1e-6, (
+      'z does not match static bed level under no_probability during runtime '
+      f"(max abs error={np.nanmax(np.abs(z_runtime - expected_runtime)):.3e} m)"
     )

--- a/tests/simulation_orchestrator/test_simulationmanager.py
+++ b/tests/simulation_orchestrator/test_simulationmanager.py
@@ -443,6 +443,32 @@ class TestSimulationManagerTimeConfig:
         """Samples should be saved only on configured boundaries or at final time."""
         assert Simulation._is_output_sample_due(sample_time, next_output_time, end_time) is expected
 
+    @pytest.mark.parametrize(
+        'method_name,transport_probability_method,expected',
+        [
+            ('vanwesten', 'stochastic_transport', True),
+            ('vanwesten', 'reduced_velocity', True),
+            ('vanwesten', 'no_probability', True),
+            ('soulsby', 'no_probability', True),
+            ('passive_tracer', 'no_probability', True),
+            ('soulsby', 'reduced_velocity', False),
+            ('passive_tracer', 'stochastic_transport', False),
+        ],
+    )
+    def test_should_update_bed_level_after_movement_policy(
+        self,
+        method_name,
+        transport_probability_method,
+        expected,
+    ):
+        """Post-move bed-level updates should follow tracer and transport policy rules."""
+        tracer_plan = SimpleNamespace(
+            method_name=method_name,
+            transport_probability_method=transport_probability_method,
+        )
+
+        assert Simulation._should_update_bed_level_after_movement(tracer_plan) is expected
+
     def test_initialize_population_output_status_supplies_required_fields(self):
         """The seeded initial sample should have status fields before the first physics update."""
 


### PR DESCRIPTION
## Summary

Particles in long runs progressively acquire spurious burial depth and become immobile — even on a **static bed**. In a year-long morphostatic Westerschelde run (1M particles, vanwesten tracer), 81% of particles had nonzero burial after one day and ~99% were flagged buried/immobile by year end, on a bed that never changes. This PR restores a previously-fixed invariant that was silently lost in a merge, and adds a regression test that guards it.

This also explains the earlier observation by @sgpearson17 that *"particles get buried and stop"* in a non-morphodynamic run.

## The invariant

`update_burial_depth()` books `bed_level - bed_level_previous` as a **temporal** bed change (zero on a static bed). That is only valid if `bed_level_previous` holds the bed at the particle's *current* position — which requires `update_bed_level_change_after_movement()` to run after **every** `update_position()`, i.e. **inside** the per-flow-field loop: the vanwesten tracer moves particles once per flow field (bed load + suspended), and the next flow field's `update_information()` re-interpolates the bed at the post-move positions.

## How it regressed

- `bdf7a99` (2026-06-02): invariant established — the re-sample call sits inside the flow-field loop.
- `90d0b5a` (2026-06-12, merge of upstream/dev into `particle_burial`): upstream had re-indented the main loop one level deeper; the merge resolution kept the re-sample block at its old indentation, which in the new structure sits **after** the loop. No line of the fix changed, so the regression was invisible in the merge diff, and no test guarded the invariant.

Since then, for two-flow-field tracers, every timestep booked `bed(post-bedload-move) - bed(pre-move)` — a **spatial gradient** term — as burial change. The `max(burial, 0)` floor rectifies this zero-mean noise into a monotonic ratchet (a reflected random walk), so burial grows ∝√t until it crosses the local mixing depth and the particle is flagged buried.

## The fix

Move the re-sample block back inside the flow-field loop (re-indent, plus a comment explaining why it must live there).

## Regression test

`tests/simulation_orchestrator/test_burial_static_bed.py`: an end-to-end vanwesten run on a synthetic static sloped bed with steady transport — particles must move while burial stays exactly zero. Verified both ways: **fails on pre-fix code** (4 mm spurious burial per simulated hour, matching the leak mechanism quantitatively) and passes with the fix.

## Validation

Re-ran three year-long Westerschelde production runs (1M particles) with the fix: the morphostatic run now keeps burial depth at exactly 0 for the full year, and the morphodynamic/observed-burial variants show slow, spatially coherent burial instead of the week-one ratchet.