### PR TITLE
SedTRAILS GUI: setup, run and analyze simulations (early development)

### DIFF
--- a/sedtrails-gui/README.md
+++ b/sedtrails-gui/README.md
@@ -1,0 +1,50 @@
+# SedTRAILS GUI
+
+A local GUI covering the full SedTRAILS workflow in five tabs:
+
+| Tab | What it does |
+|---|---|
+| **Settings** | Open/edit/save a simulation yaml. The form is generated from the packaged JSON schemas (`sedtrails/config/*.schema.json`), so every option shows its documentation (ⓘ), defaults and allowed values, with live validation and an estimated output-file size. Saves preserve your comments and layout (ruamel.yaml). |
+| **Populations** | Draw seeding per population directly on the map — points, transects, boxes, polygons — and preview the *exact* seed locations (computed by sedtrails' own seeding strategies, including RNG seeds). Values are written into the loaded yaml. |
+| **Run** | Start/stop `sedtrails run` on the loaded config, with live log, progress bar (output slots from the streaming netCDF) and ETA. One click imports the finished result into the Viewer. |
+| **Viewer** | Particles and forcing in one map: the full standalone particle viewer (trajectories, paths, polygon classification, rule-based filtering/coloring, PNG/MP4 export) plus netCDF forcing layers — Voronoi-cell scalar fields (bed level, water depth, BSS, …) with time scrubbing and quiver arrows for the vector pairs. The forcing file follows Settings → inputs → data. |
+| **Connectivity** | v0: polygon→polygon connectivity matrix (start→end or start→ever-visited, counts or fractions) over an imported run, with CSV export and a network overlay on the map. Built on the viewer's cached classification; new metrics slot in as new modes on the same endpoint. |
+
+## Run it
+
+Select the sedtrails venv interpreter and run directly (VS Code or terminal):
+
+```
+python sedtrails_gui.py
+```
+
+Opens its own app window (Edge/Chrome `--app` mode, no address bar) serving
+`http://127.0.0.1:8766/`; set `APP_WINDOW = False` for a plain browser tab.
+The standalone viewer (`sedtrails-viewer/`, port 8765) is untouched and can run
+at the same time; runs imported there show up here too.
+
+## Dependencies
+
+- required: `numpy`, `netCDF4`
+- viewer extras: `matplotlib` + `scipy` (model layers, classification), `tkinter`
+  (native file dialogs), `ffmpeg` on PATH (MP4 export)
+- GUI extras: the `sedtrails` package + `jsonschema` (Settings/Seeding/Run tabs),
+  `ruamel.yaml` (comment-preserving saves; without it saves fall back to a
+  schema-ordered dump that drops comments)
+
+## Configuration
+
+`HOST` / `PORT` / `OPEN_BROWSER` / `APP_WINDOW` / `DATA_ROOTS` at the top of
+`sedtrails_gui.py`;
+import slab sizes and the app dir (`~/.sedtrails_gui`) in `backend/settings.py`.
+
+## Layout
+
+- `sedtrails_gui.py` — entry point (constants + server startup)
+- `backend/` — HTTP routes (`httpd.py`), results-bundle importer/classifier
+  (`bundle.py`, verbatim from the standalone viewer), config API (`config_api.py`),
+  forcing reader/mesh (`forcing.py`), seeding preview (`seeding_api.py`),
+  run manager (`run_manager.py`), connectivity (`connectivity.py`)
+- `web/` — `index.html` + `css/app.css` + `js/core/*` (shared WebGL map, tabs,
+  playback) + `js/tabs/*` (one file per section; `viewer*.js` are the split-up
+  standalone viewer, kept byte-identical where possible)

--- a/sedtrails-gui/README.md
+++ b/sedtrails-gui/README.md
@@ -12,7 +12,13 @@ A local GUI covering the full SedTRAILS workflow in five tabs:
 
 ## Run it
 
-Select the sedtrails venv interpreter and run directly (VS Code or terminal):
+With the sedtrails venv active, from anywhere in the repository:
+
+```
+sedtrails gui
+```
+
+or select the sedtrails venv interpreter and run directly (VS Code or terminal):
 
 ```
 python sedtrails_gui.py

--- a/sedtrails-gui/backend/__init__.py
+++ b/sedtrails-gui/backend/__init__.py
@@ -1,0 +1,1 @@
+"""SedTRAILS GUI backend package."""

--- a/sedtrails-gui/backend/bundle.py
+++ b/sedtrails-gui/backend/bundle.py
@@ -1,0 +1,777 @@
+"""Results netCDF -> viewer bundle importer, registry, mesh, classification.
+
+Extracted verbatim from sedtrails-viewer/sedtrails_viewer.py (Phase 0 split).
+"""
+
+import hashlib
+import json
+import math
+import os
+import re
+import threading
+import time
+import traceback
+from pathlib import Path
+
+import numpy as np
+
+from .settings import (APP_DIR, BG_DZ_PCTL, BG_ELEV_PCTL, CMAP_NPY,
+                       FORMAT_VERSION, LOAD_WHOLE_LIMIT, PAD_FRAC, QMAX,
+                       REFERENCE_DATE_FALLBACK, SENTINEL, SLAB_PARTICLES,
+                       SLAB_STEPS, VIEWER_APP_DIR)
+from .util import NC_LOCK, _log, _nanfilled, _read_json, _write_json
+
+_registry_lock = threading.Lock()
+_polygons_lock = threading.Lock()
+
+# bumped when only meta-derived fields change (reference-date time-of-day fix);
+# lets cached bundles refresh meta.json cheaply without re-writing the bins
+META_VERSION = 2
+
+# bumped when the model-layer mesh construction changes; cached bundles then
+# rebuild mesh.bin on their next load (v2: cell cutoff vs 8th neighbor)
+MESH_VERSION = 2
+
+
+def _registry_path():
+    return APP_DIR / "registry.json"
+
+
+def _polygons_path():
+    return APP_DIR / "polygons.json"
+
+
+def load_registry():
+    reg = _read_json(_registry_path(), {"simulations": []})
+    # Merge bundles imported with the standalone viewer (read-only; entries
+    # forgotten in the GUI are remembered in reg["hidden"]).
+    old = _read_json(VIEWER_APP_DIR / "registry.json", None)
+    if old:
+        known = {s["id"] for s in reg["simulations"]}
+        hidden = set(reg.get("hidden", []))
+        reg["simulations"] += [s for s in old.get("simulations", [])
+                               if s["id"] not in known and s["id"] not in hidden]
+    return reg
+
+
+def save_registry(reg):
+    _write_json(_registry_path(), reg)
+
+
+def registry_add(entry):
+    with _registry_lock:
+        reg = load_registry()
+        reg["simulations"] = [s for s in reg["simulations"] if s["id"] != entry["id"]]
+        reg["simulations"].insert(0, entry)
+        save_registry(reg)
+
+
+def registry_find(bundle_id):
+    for s in load_registry()["simulations"]:
+        if s["id"] == bundle_id:
+            return s
+    return None
+
+
+# ── netCDF track reading (both layouts) ───────────────────────────────────────
+def open_tracks(nc_path):
+    """Open a SedTRAILS results netCDF; return (ds, info dict).
+
+    Layout handling mirrors westerschelde/scripts/evaluate_source_sink.py
+    load_tracks(): time-major files have x.dims[0] in (n_timesteps, time, obs);
+    legacy files are particle-major with a 2D time variable.
+    """
+    import netCDF4 as nc
+
+    with NC_LOCK:
+        return _open_tracks_locked(nc.Dataset(nc_path, "r"))
+
+
+def _open_tracks_locked(ds):
+    x = ds.variables["x"]
+    time_major = x.dimensions[0] in ("n_timesteps", "time", "obs")
+    T_raw = x.shape[0] if time_major else x.shape[1]
+    N = x.shape[1] if time_major else x.shape[0]
+
+    t_var = ds.variables["time"]
+    t = _nanfilled(t_var[:] if t_var.ndim == 1 else t_var[0, :]).ravel()
+    finite = np.isfinite(t)
+    T = int(np.argmin(finite)) if not finite.all() else len(t)  # longest finite prefix
+    T = min(T if T > 0 else len(t), T_raw)
+    t = t[:T]
+
+    units = getattr(t_var, "units", "") or ""
+    # keep the time-of-day of the reference date (e.g. "seconds since
+    # 2025-08-03 21:40:00") — dropping it shifted the particle timeline vs the
+    # forcing timeline by up to a day
+    m = re.search(r"since\s+(\d{4}-\d{2}-\d{2})[T ]?(\d{2}:\d{2}:\d{2})?", units)
+    reference_date = m.group(1) if m else REFERENCE_DATE_FALLBACK
+    if m and m.group(2) and m.group(2) != "00:00:00":
+        reference_date += " " + m.group(2)
+    time_days = ((t - 0.0) / 86400.0).tolist()  # days since reference_date
+
+    has_burial = "burial_depth" in ds.variables
+    has_flags = "status_mobile" in ds.variables
+    return ds, {
+        "time_major": time_major,
+        "T": T,
+        "N": N,
+        "reference_date": reference_date,
+        "time_days": time_days,
+        "has_burial": has_burial,
+        "has_flags": has_flags,
+    }
+
+
+def iter_slabs(ds, info, names):
+    """Yield (axis, i0, i1, {name: float array (t, n) time-major-normalized}).
+
+    axis is 'time' (i0:i1 timesteps, all particles) or 'particle'
+    (all timesteps, i0:i1 particles). Arrays are always (n_timesteps, n_particles).
+    """
+    T, N, time_major = info["T"], info["N"], info["time_major"]
+    variables = {name: ds.variables[name] for name in names}
+    if time_major:
+        for i0 in range(0, T, SLAB_STEPS):
+            i1 = min(i0 + SLAB_STEPS, T)
+            with NC_LOCK:
+                arrs = {n: _nanfilled(v[i0:i1, :]) for n, v in variables.items()}
+            yield "time", i0, i1, arrs
+    else:
+        per_var_bytes = T * N * 8
+        step = N if per_var_bytes < LOAD_WHOLE_LIMIT else SLAB_PARTICLES
+        for i0 in range(0, N, step):
+            i1 = min(i0 + step, N)
+            with NC_LOCK:
+                arrs = {n: _nanfilled(v[i0:i1, :T]).T for n, v in variables.items()}
+            yield "particle", i0, i1, arrs
+
+
+# ── Importer ───────────────────────────────────────────────────────────────────
+def _quantize_pair(x, y, quant):
+    qx = np.round((x - quant["xmin"]) / quant["sx"])
+    qy = np.round((y - quant["ymin"]) / quant["sy"])
+    bad = (~np.isfinite(qx) | ~np.isfinite(qy)
+           | (qx < 0) | (qx > QMAX) | (qy < 0) | (qy > QMAX))
+    qx = np.where(bad, SENTINEL, qx).astype("<u2")
+    qy = np.where(bad, SENTINEL, qy).astype("<u2")
+    return qx, qy
+
+
+def bundle_dir_for(nc_path):
+    p = Path(nc_path)
+    return p.parent / (p.stem + ".viewer")
+
+
+def bundle_id_for(nc_path):
+    p = Path(nc_path).resolve()
+    h = hashlib.sha1(str(p).lower().encode("utf-8")).hexdigest()[:10]
+    label = p.parent.name if p.stem == "sedtrails_results" else p.stem
+    return f"{label}-{h}"
+
+
+def import_run(nc_path, forcing_path=None, name=None, job=None, grid_path=None):
+    """Convert a results netCDF to a viewer bundle (cached). Returns meta."""
+    def prog(frac, msg):
+        if job is not None:
+            job["progress"] = round(float(frac), 3)
+            job["message"] = msg
+        _log(f"import: {msg}")
+
+    nc_path = str(Path(nc_path).resolve())
+    bdir = bundle_dir_for(nc_path)
+    bid = bundle_id_for(nc_path)
+    meta_path = bdir / "meta.json"
+    src_stat = os.stat(nc_path)
+    src_sig = [int(src_stat.st_size), int(src_stat.st_mtime)]
+
+    meta = _read_json(meta_path, None)
+    fresh = (meta is not None and meta.get("format_version") == FORMAT_VERSION
+             and meta.get("source_signature") == src_sig
+             and (bdir / "positions.bin").exists())
+
+    if not fresh:
+        ds, info = open_tracks(nc_path)
+        try:
+            T, N = info["T"], info["N"]
+            prog(0.02, f"scanning extent ({T} steps x {N} particles)")
+
+            names = ["x", "y"] + (["burial_depth"] if info["has_burial"] else [])
+            xmin = ymin = np.inf
+            xmax = ymax = -np.inf
+            burial_max = 0.0
+            if info["time_major"]:
+                n_slabs = math.ceil(T / SLAB_STEPS)
+            else:
+                p_step = N if T * N * 8 < LOAD_WHOLE_LIMIT else SLAB_PARTICLES
+                n_slabs = math.ceil(N / p_step)
+            for k, (_, _, _, arrs) in enumerate(iter_slabs(ds, info, names)):
+                with np.errstate(all="ignore"):
+                    xmin = min(xmin, np.nanmin(arrs["x"])) if np.isfinite(arrs["x"]).any() else xmin
+                    xmax = max(xmax, np.nanmax(arrs["x"])) if np.isfinite(arrs["x"]).any() else xmax
+                    ymin = min(ymin, np.nanmin(arrs["y"])) if np.isfinite(arrs["y"]).any() else ymin
+                    ymax = max(ymax, np.nanmax(arrs["y"])) if np.isfinite(arrs["y"]).any() else ymax
+                    if "burial_depth" in arrs and np.isfinite(arrs["burial_depth"]).any():
+                        burial_max = max(burial_max, float(np.nanmax(arrs["burial_depth"])))
+                del arrs
+                prog(0.02 + 0.28 * (k + 1) / n_slabs, f"scanning extent (slab {k + 1})")
+
+            if not (np.isfinite(xmin) and np.isfinite(ymin)):
+                raise ValueError("no finite particle positions found")
+            pad_x = max((xmax - xmin) * PAD_FRAC, 1.0)
+            pad_y = max((ymax - ymin) * PAD_FRAC, 1.0)
+            xmin, xmax = xmin - pad_x, xmax + pad_x
+            ymin, ymax = ymin - pad_y, ymax + pad_y
+            quant = {"xmin": xmin, "ymin": ymin,
+                     "sx": (xmax - xmin) / QMAX, "sy": (ymax - ymin) / QMAX,
+                     "sentinel": SENTINEL}
+            # Floor avoids amplifying numerical noise into the color range on
+            # runs where burial is physically (near-)zero.
+            burial_max = max(burial_max, 0.01)
+
+            bdir.mkdir(parents=True, exist_ok=True)
+            pos_mm = np.memmap(bdir / "positions.bin", dtype="<u2", mode="w+", shape=(T, N, 2))
+            bur_mm = (np.memmap(bdir / "burial.bin", dtype="<u2", mode="w+", shape=(T, N))
+                      if info["has_burial"] else None)
+
+            for k, (axis, i0, i1, arrs) in enumerate(iter_slabs(ds, info, names)):
+                qx, qy = _quantize_pair(arrs["x"], arrs["y"], quant)
+                if axis == "time":
+                    pos_mm[i0:i1, :, 0] = qx
+                    pos_mm[i0:i1, :, 1] = qy
+                else:
+                    pos_mm[:, i0:i1, 0] = qx
+                    pos_mm[:, i0:i1, 1] = qy
+                if bur_mm is not None:
+                    b = arrs["burial_depth"]
+                    qb = np.round(np.clip(b, 0.0, burial_max) / burial_max * QMAX)
+                    qb = np.where(np.isfinite(qb), qb, SENTINEL).astype("<u2")
+                    if axis == "time":
+                        bur_mm[i0:i1, :] = qb
+                    else:
+                        bur_mm[:, i0:i1] = qb
+                    del b, qb
+                del arrs, qx, qy
+                prog(0.30 + 0.55 * (k + 1) / n_slabs, f"writing bundle (slab {k + 1})")
+
+            pos_mm.flush()
+            del pos_mm
+            if bur_mm is not None:
+                bur_mm.flush()
+                del bur_mm
+
+            meta = {
+                "format_version": FORMAT_VERSION,
+                "meta_version": META_VERSION,
+                "id": bid,
+                "run_name": name or Path(nc_path).parent.name,
+                "source_nc": nc_path,
+                "source_signature": src_sig,
+                "n_particles": N,
+                "n_timesteps": T,
+                "reference_date": info["reference_date"],
+                "time_days": info["time_days"],
+                "quant": quant,
+                "burial_max": burial_max,
+                "has_burial": info["has_burial"],
+                "extent": [xmin, xmax, ymin, ymax],
+                "backgrounds": [],
+                "files": {"positions": "positions.bin",
+                          **({"burial": "burial.bin"} if info["has_burial"] else {})},
+            }
+            _write_json(meta_path, meta)
+        finally:
+            with NC_LOCK:
+                ds.close()
+    else:
+        prog(0.85, "bundle up to date (cached)")
+        if name:
+            meta["run_name"] = name
+        if meta.get("meta_version") != META_VERSION:
+            # meta-only refresh: time handling changed but the bins are fine
+            ds, info = open_tracks(nc_path)
+            with NC_LOCK:
+                ds.close()
+            meta["reference_date"] = info["reference_date"]
+            meta["time_days"] = info["time_days"]
+            meta["meta_version"] = META_VERSION
+
+    _ensure_flags(nc_path, bdir, meta, prog)
+    if forcing_path:
+        meta["forcing_nc"] = str(Path(forcing_path).resolve())
+    if grid_path:
+        meta["grid_nc"] = str(Path(grid_path).resolve())
+    prog(0.86, "building model-layer mesh")
+    make_mesh(bdir, meta, meta.get("forcing_nc"), meta.get("grid_nc"))
+    _write_json(meta_path, meta)
+
+    registry_add({
+        "id": bid, "name": meta["run_name"], "nc_path": nc_path,
+        "bundle_dir": str(bdir), "forcing_path": meta.get("forcing_nc"),
+        "grid_path": meta.get("grid_nc"),
+        "n_particles": meta["n_particles"], "n_timesteps": meta["n_timesteps"],
+        "imported_at": time.strftime("%Y-%m-%d %H:%M"),
+    })
+    prog(1.0, "done")
+
+    # Verification print: dequantized first/last frame round-trip error bound.
+    q = meta["quant"]
+    _log(f"import: quantization step sx={q['sx']:.3f} m, sy={q['sy']:.3f} m "
+         f"(max round-trip error {max(q['sx'], q['sy']) / 2:.3f} m)")
+    return meta
+
+
+def _ensure_flags(nc_path, bdir, meta, prog):
+    """Extract per-particle status flags (flags.bin, uint8 (T,N)) from the
+    results netCDF: 1 = mobile, 0 = immobile, 255 = unknown. Streamed by the
+    viewer on demand for the 'fade immobile particles' option. Runs as a
+    cheap separate pass so existing bundles are upgraded without re-import."""
+    if meta.get("has_flags") and (bdir / "flags.bin").exists():
+        return
+    ds, info = open_tracks(nc_path)
+    try:
+        if not info["has_flags"]:
+            meta["has_flags"] = False
+            return
+        T, N = meta["n_timesteps"], meta["n_particles"]
+        prog(0.85, "extracting particle status flags")
+        flg_mm = np.memmap(bdir / "flags.bin", dtype="u1", mode="w+", shape=(T, N))
+        for axis, i0, i1, arrs in iter_slabs(ds, info, ["status_mobile"]):
+            f = arrs["status_mobile"]
+            qf = np.full(f.shape, 255, np.uint8)
+            fin = np.isfinite(f) & (f < 254)
+            qf[fin] = f[fin] > 0.5
+            if axis == "time":
+                flg_mm[i0:i1, :] = qf
+            else:
+                flg_mm[:, i0:i1] = qf
+            del arrs, f, qf
+        flg_mm.flush()
+        del flg_mm
+        meta["has_flags"] = True
+        meta["files"]["flags"] = "flags.bin"
+        _log("flags: extracted status_mobile -> flags.bin")
+    except Exception as e:
+        traceback.print_exc()
+        _log(f"flags: FAILED ({e})")
+    finally:
+        with NC_LOCK:
+            ds.close()
+
+
+# ── Model-layer mesh (rendered live in the viewer, like the analysis scripts) ──
+def _cmap_triplets(name_or_npy, n=256):
+    """256 RGB triplets (0-255) for a matplotlib colormap or a .npy colormap."""
+    import matplotlib
+    matplotlib.use("Agg")
+    from matplotlib import colormaps
+    from matplotlib.colors import ListedColormap
+
+    if name_or_npy and os.path.exists(str(name_or_npy)):
+        cmap = ListedColormap(np.load(name_or_npy))
+    else:
+        cmap = colormaps[name_or_npy]
+    cols = cmap(np.linspace(0.0, 1.0, n))[:, :3]
+    return (cols * 255).round().astype(int).tolist()
+
+
+def _cells_geometry(grid_path, forcing_path):
+    """Exact model cells: faces from the grid/net file, values mapped from the
+    forcing's cell-centre nodes via cKDTree — the same technique as the
+    analysis scripts' PolyCollection. Values are FLAT per face (each face's
+    corners are emitted as dedicated vertices carrying the face value)."""
+    import netCDF4 as nc
+    from scipy.spatial import cKDTree
+
+    with NC_LOCK, nc.Dataset(grid_path, "r") as gm:
+        node_x = _nanfilled(gm.variables["mesh2d_node_x"][:])
+        node_y = _nanfilled(gm.variables["mesh2d_node_y"][:])
+        face_x = _nanfilled(gm.variables["mesh2d_face_x"][:])
+        face_y = _nanfilled(gm.variables["mesh2d_face_y"][:])
+        fn_var = gm.variables["mesh2d_face_nodes"]
+        fill = int(getattr(fn_var, "_FillValue", -999))
+        fn = np.ma.filled(fn_var[:], fill).astype(np.int64)
+    with NC_LOCK, nc.Dataset(forcing_path, "r") as ds:
+        xn = _nanfilled(ds.variables["net_xcc"][:])
+        yn = _nanfilled(ds.variables["net_ycc"][:])
+        bed0 = _nanfilled(ds.variables["bedlevel"][0, :])
+        nt = ds.variables["bedlevel"].shape[0]
+        bed1 = _nanfilled(ds.variables["bedlevel"][nt - 1, :]) if nt > 1 else bed0
+
+    dist, idx = cKDTree(np.column_stack([xn, yn])).query(np.column_stack([face_x, face_y]))
+    face_bed = np.where(dist < 500.0, bed0[idx], np.nan)
+    face_dz = np.where(dist < 500.0, bed1[idx] - bed0[idx], np.nan)
+
+    max_nodes = fn.shape[1]
+    counts = (fn != fill).sum(axis=1)
+    keep = counts >= 3
+    fn = fn[keep] - 1                    # 1-based -> 0-based
+    counts = counts[keep]
+    face_bed = face_bed[keep]
+    face_dz = face_dz[keep]
+
+    n_verts = int(counts.sum())
+    n_tris = int((counts - 2).sum())
+    xy = np.empty((n_verts, 2), "<f4")
+    bed_v = np.empty(n_verts, "<f4")
+    dz_v = np.empty(n_verts, "<f4")
+    tris = np.empty((n_tris, 3), "<u4")
+
+    vo = 0
+    to = 0
+    for c in range(3, max_nodes + 1):    # vectorized per corner-count group
+        sel = counts == c
+        m = int(sel.sum())
+        if m == 0:
+            continue
+        nodes = fn[sel][:, :c]                     # (m, c)
+        base = vo + np.arange(m, dtype=np.int64) * c
+        xy[vo:vo + m*c, 0] = node_x[nodes].reshape(-1)
+        xy[vo:vo + m*c, 1] = node_y[nodes].reshape(-1)
+        fb = np.where(np.isfinite(face_bed[sel]), face_bed[sel], -9999.0)
+        fd = np.where(np.isfinite(face_dz[sel]), face_dz[sel], -9999.0)
+        bed_v[vo:vo + m*c] = np.repeat(fb, c)
+        dz_v[vo:vo + m*c] = np.repeat(fd, c)
+        for k in range(c - 2):                     # fan triangulation
+            tris[to + k*m:to + (k+1)*m, 0] = base
+            tris[to + k*m:to + (k+1)*m, 1] = base + k + 1
+            tris[to + k*m:to + (k+1)*m, 2] = base + k + 2
+        vo += m * c
+        to += m * (c - 2)
+    return xy, bed_v, dz_v, tris, face_bed, face_dz
+
+
+def _voronoi_cells_geometry(forcing_path):
+    """Approximate model cells from the forcing file ALONE: the Voronoi
+    tessellation of the cell centres (net_xcc/net_ycc). Exact topology needs
+    the grid/net file, but this already gives crisp, flat-colored cells
+    instead of a smooth interpolation — one input file suffices."""
+    import netCDF4 as nc
+    from scipy.spatial import Voronoi, cKDTree
+
+    with NC_LOCK, nc.Dataset(forcing_path, "r") as ds:
+        xn = _nanfilled(ds.variables["net_xcc"][:])
+        yn = _nanfilled(ds.variables["net_ycc"][:])
+        bed0 = _nanfilled(ds.variables["bedlevel"][0, :])
+        nt = ds.variables["bedlevel"].shape[0]
+        bed1 = _nanfilled(ds.variables["bedlevel"][nt - 1, :]) if nt > 1 else bed0
+
+    ok = np.isfinite(xn) & np.isfinite(yn)
+    pts = np.column_stack([xn[ok], yn[ok]])
+    v_bed = bed0[ok]
+    v_dz = (bed1 - bed0)[ok]
+    n_real = len(pts)
+
+    # guard ring closes off the outer cells; per-point cutoff (3x the local
+    # spacing) trims the remaining slivers along the concave coastline
+    x0, x1 = pts[:, 0].min(), pts[:, 0].max()
+    y0, y1 = pts[:, 1].min(), pts[:, 1].max()
+    mx, my = (x1 - x0) * 0.2 + 1.0, (y1 - y0) * 0.2 + 1.0
+    ts = np.linspace(0.0, 1.0, 100, endpoint=False)
+    ring = np.concatenate([
+        np.column_stack([x0 - mx + ts * (x1 - x0 + 2*mx), np.full(100, y0 - my)]),
+        np.column_stack([x0 - mx + ts * (x1 - x0 + 2*mx), np.full(100, y1 + my)]),
+        np.column_stack([np.full(100, x0 - mx), y0 - my + ts * (y1 - y0 + 2*my)]),
+        np.column_stack([np.full(100, x1 + mx), y0 - my + ts * (y1 - y0 + 2*my)]),
+    ])
+    vor = Voronoi(np.vstack([pts, ring]))
+    # cutoff radius from the 8th neighbor, not the 1st: on strongly anisotropic
+    # grids (alongshore spacing >> cross-shore) the 1st neighbor is the short
+    # axis and whole rows of valid cells would be cut (sandengine grid)
+    tree = cKDTree(pts)
+    k8 = min(9, n_real)
+    nn = tree.query(pts, k=k8)[0][:, k8 - 1]
+    r_cut2 = (3.0 * np.maximum(nn, 1e-3)) ** 2
+
+    verts_l, bed_l, dz_l, tris_l = [], [], [], []
+    vo = 0
+    vv = vor.vertices
+    for i in range(n_real):
+        region = vor.regions[vor.point_region[i]]
+        c = len(region)
+        if c < 3 or -1 in region:
+            continue
+        cell = vv[region]
+        d2 = (cell[:, 0] - pts[i, 0])**2 + (cell[:, 1] - pts[i, 1])**2
+        if d2.max() > r_cut2[i]:
+            continue
+        verts_l.append(cell)
+        bed_l.append(np.full(c, v_bed[i] if np.isfinite(v_bed[i]) else -9999.0))
+        dz_l.append(np.full(c, v_dz[i] if np.isfinite(v_dz[i]) else -9999.0))
+        fan = np.empty((c - 2, 3), np.int64)
+        fan[:, 0] = vo
+        fan[:, 1] = vo + np.arange(1, c - 1)
+        fan[:, 2] = vo + np.arange(2, c)
+        tris_l.append(fan)
+        vo += c
+
+    xy = np.concatenate(verts_l).astype("<f4")
+    bed_v = np.concatenate(bed_l).astype("<f4")
+    dz_v = np.concatenate(dz_l).astype("<f4")
+    tris = np.concatenate(tris_l).astype("<u4")
+    return xy, bed_v, dz_v, tris, v_bed, v_dz
+
+
+def make_mesh(bdir, meta, forcing_path, grid_path=None):
+    """Write mesh.bin for the model layer (rendered live on the GPU).
+
+    With a grid/net file: the TRUE model cells, flat-colored per face — the
+    same look as the analysis scripts. With only the forcing file: Voronoi
+    cells of the cell centres (flat-colored approximation, single file)."""
+    if not (forcing_path and os.path.exists(forcing_path)):
+        return
+    style = "cells" if (grid_path and os.path.exists(grid_path)) else "voronoi"
+    if meta.get("mesh") and meta["mesh"].get("style") == style \
+            and meta["mesh"].get("mesh_version") == MESH_VERSION \
+            and (bdir / "mesh.bin").exists():
+        return
+    try:
+        if style == "cells":
+            xy, bed_v, dz_v, tris, fb, fd = _cells_geometry(grid_path, forcing_path)
+            clim_src, dz_src = fb, fd
+        else:
+            xy, bed_v, dz_v, tris, fb, fd = _voronoi_cells_geometry(forcing_path)
+            clim_src, dz_src = fb, fd
+
+        q = meta["quant"]
+        xy[:, 0] -= q["xmin"]
+        xy[:, 1] -= q["ymin"]
+        fin_dz = dz_src[np.isfinite(dz_src)]
+        has_dz = bool(fin_dz.size and np.max(np.abs(fin_dz)) > 1e-6)
+        clim_bed = [float(v) for v in np.nanpercentile(clim_src, BG_ELEV_PCTL)]
+        dz_lim = float(np.nanpercentile(np.abs(fin_dz), BG_DZ_PCTL)) if has_dz else 1.0
+
+        with open(bdir / "mesh.bin", "wb") as f:
+            f.write(np.ascontiguousarray(xy).tobytes())
+            f.write(np.ascontiguousarray(bed_v).tobytes())
+            f.write(np.ascontiguousarray(dz_v).tobytes())
+            f.write(np.ascontiguousarray(tris).tobytes())
+        meta["mesh"] = {
+            "file": "mesh.bin",
+            "style": style,
+            "mesh_version": MESH_VERSION,
+            "n_nodes": int(len(bed_v)),
+            "n_tris": int(len(tris)),
+            "clim_bed": clim_bed,
+            "clim_dz": [-dz_lim, dz_lim],
+            "has_dz": has_dz,
+            "cmap_bed": _cmap_triplets(CMAP_NPY if CMAP_NPY else "gist_earth"),
+            "cmap_dz": _cmap_triplets("RdBu_r"),
+        }
+        _log(f"mesh layer ({style}): {len(bed_v)} vertices, {len(tris)} triangles"
+             + ("" if has_dz else " (static bed — no bed-change layer)"))
+    except Exception as e:
+        traceback.print_exc()
+        _log(f"mesh layer: FAILED ({e})")
+
+
+# ── Polygon classification ─────────────────────────────────────────────────────
+def _poly_paths(polygons):
+    from matplotlib.path import Path as MplPath
+    out = []
+    for p in polygons:
+        verts = np.asarray(p["verts"], dtype=np.float64)
+        if verts.ndim != 2 or len(verts) < 3:
+            continue
+        out.append({
+            "key": p["key"],
+            "geom_key": hashlib.sha1(b"v3" + verts.round(2).tobytes()).hexdigest()[:16],
+            "path": MplPath(verts),
+            "bbox": (verts[:, 0].min(), verts[:, 0].max(),
+                     verts[:, 1].min(), verts[:, 1].max()),
+        })
+    return out
+
+
+def _contains(poly, x, y, idx):
+    """Indices (subset of idx) inside poly, with bbox prefilter. x/y are metres."""
+    bx0, bx1, by0, by1 = poly["bbox"]
+    xi = x[idx]
+    yi = y[idx]
+    cand = (xi >= bx0) & (xi <= bx1) & (yi >= by0) & (yi <= by1)
+    if not cand.any():
+        return idx[:0]
+    sub = idx[cand]
+    inside = poly["path"].contains_points(np.column_stack([x[sub], y[sub]]))
+    return sub[inside]
+
+
+_classify_progress = {}   # bundle_id -> {"t": step, "T": total, "n": n_polygons}
+
+
+def _classify_missing(bdir, meta, missing, bundle_id=""):
+    """One streaming pass computing per-polygon particle flags for every
+    polygon in `missing` simultaneously. Cached per polygon GEOMETRY, so a
+    newly drawn polygon costs one polygon — not a full re-classification.
+
+    Per polygon and particle: at0 (inside at the first position), at_end
+    (inside at the last finite position), visited (ever inside, with the
+    re-entry rule: a particle starting inside only counts after leaving
+    once), first (timestep of first counted entry).
+
+    The hot path stays in quantized uint16 space: a per-polygon quantized
+    bounding box selects candidates with cheap integer compares, and only
+    those few positions are dequantized for the exact point-in-polygon test.
+    Being outside the bbox also proves 'left the start polygon' for free.
+    """
+    T, N = meta["n_timesteps"], meta["n_particles"]
+    q = meta["quant"]
+    pos = np.memmap(bdir / "positions.bin", dtype="<u2", mode="r", shape=(T, N, 2))
+
+    def qbox(poly):
+        bx0, bx1, by0, by1 = poly["bbox"]
+        c = lambda v, vmin, s: np.uint16(min(max((v - vmin) / s, 0), QMAX))
+        return (c(bx0, q["xmin"], q["sx"]), c(bx1, q["xmin"], q["sx"]) + 1,
+                c(by0, q["ymin"], q["sy"]), c(by1, q["ymin"], q["sy"]) + 1)
+
+    st = [{"at0": np.zeros(N, bool), "visited": np.zeros(N, bool),
+           "left": np.zeros(N, bool), "first": np.full(N, SENTINEL, np.uint16),
+           "qbox": qbox(p)} for p in missing]
+    last_qx = np.full(N, SENTINEL, np.uint16)
+    last_qy = np.full(N, SENTINEL, np.uint16)
+
+    t0 = time.time()
+    for t in range(T):
+        _classify_progress[bundle_id] = {"t": t, "T": T, "n": len(missing)}
+        frame = np.asarray(pos[t])
+        qx = frame[:, 0]
+        qy = frame[:, 1]
+        valid = qx != SENTINEL
+        if not valid.any():
+            continue
+        last_qx[valid] = qx[valid]
+        last_qy[valid] = qy[valid]
+
+        for poly, s in zip(missing, st):
+            bx0, bx1, by0, by1 = s["qbox"]
+            inbox = (qx >= bx0) & (qx < bx1) & (qy >= by0) & (qy < by1)
+            track = s["at0"] & ~s["left"]
+            if t > 0:
+                # outside the bbox ⇒ certainly outside the polygon ⇒ has left
+                s["left"][track & valid & ~inbox] = True
+                track = s["at0"] & ~s["left"]
+            cand = np.flatnonzero(inbox & valid & (~s["visited"] | track))
+            if cand.size == 0:
+                continue
+            x = qx[cand].astype(np.float64) * q["sx"] + q["xmin"]
+            y = qy[cand].astype(np.float64) * q["sy"] + q["ymin"]
+            inside_l = poly["path"].contains_points(np.column_stack([x, y]))
+            inside_idx = cand[inside_l]
+            if t == 0:
+                s["at0"][inside_idx] = True
+            else:
+                visit = inside_idx[(~s["at0"][inside_idx]) | s["left"][inside_idx]]
+                fresh = visit[~s["visited"][visit]]
+                s["visited"][fresh] = True
+                s["first"][fresh] = t
+                # inside the bbox but outside the polygon ⇒ also left
+                leavers = cand[~inside_l]
+                leavers = leavers[s["at0"][leavers] & ~s["left"][leavers]]
+                s["left"][leavers] = True
+
+    fx = last_qx.astype(np.float64) * q["sx"] + q["xmin"]
+    fy = last_qy.astype(np.float64) * q["sy"] + q["ymin"]
+    has_last = np.flatnonzero(last_qx != SENTINEL)
+    for poly, s in zip(missing, st):
+        at_end = np.zeros(N, bool)
+        at_end[_contains(poly, fx, fy, has_last)] = True
+        flags = (s["at0"].astype(np.uint8)
+                 | (at_end.astype(np.uint8) << 1)
+                 | (s["visited"].astype(np.uint8) << 2))
+        (bdir / f"polycls_{poly['geom_key']}.bin").write_bytes(
+            flags.tobytes() + s["first"].astype("<u2").tobytes())
+    _classify_progress.pop(bundle_id, None)
+    _log(f"classify: {len(missing)} new polygon(s), {T}x{N} in {time.time() - t0:.1f} s")
+
+
+def classify(bundle_id, polygons):
+    """Per-particle polygon attributes for the given polygon list.
+
+    Combines per-polygon cached results into (polygon ids = list indices):
+      origin_id u8  — first polygon containing the first position
+      final_id  u8  — first polygon containing the last finite position
+      first     u16 — timestep of first counted polygon entry (65535 never)
+      visited   u32 — bit j: ever inside polygon j (re-entry rule applied)
+      at0       u32 — bit j: inside polygon j at the first position
+      at_end    u32 — bit j: inside polygon j at the last finite position
+    """
+    sim = registry_find(bundle_id)
+    if sim is None:
+        raise ValueError(f"unknown bundle: {bundle_id}")
+    bdir = Path(sim["bundle_dir"])
+    meta = _read_json(bdir / "meta.json", None)
+    if meta is None:
+        raise ValueError(f"bundle has no meta.json: {bdir}")
+
+    polys = _poly_paths(polygons)
+    if len(polys) > 32:
+        raise ValueError(f"at most 32 polygons supported ({len(polys)} given)")
+
+    missing = [p for p in polys if not (bdir / f"polycls_{p['geom_key']}.bin").exists()]
+    if missing:
+        _classify_missing(bdir, meta, missing, bundle_id)
+
+    N = meta["n_particles"]
+    origin_id = np.full(N, 255, np.uint8)
+    final_id = np.full(N, 255, np.uint8)
+    first = np.full(N, SENTINEL, np.uint16)
+    visited = np.zeros(N, np.uint32)
+    at0_m = np.zeros(N, np.uint32)
+    at_end_m = np.zeros(N, np.uint32)
+
+    for j, poly in enumerate(polys):
+        raw = (bdir / f"polycls_{poly['geom_key']}.bin").read_bytes()
+        flags = np.frombuffer(raw, np.uint8, N)
+        pfirst = np.frombuffer(raw, "<u2", N, N)
+        at0 = (flags & 1) != 0
+        at_end = (flags & 2) != 0
+        vis = (flags & 4) != 0
+        bit = np.uint32(1 << j)
+        np.copyto(origin_id, j, where=at0 & (origin_id == 255))
+        np.copyto(final_id, j, where=at_end & (final_id == 255))
+        visited |= np.where(vis, bit, np.uint32(0))
+        at0_m |= np.where(at0, bit, np.uint32(0))
+        at_end_m |= np.where(at_end, bit, np.uint32(0))
+        first = np.where(vis, np.minimum(first, pfirst), first)
+
+    header = json.dumps({
+        "n": N,
+        "arrays": ["origin_id:u1", "final_id:u1", "first:u2",
+                   "visited:u4", "at0:u4", "at_end:u4"],
+        "origin_counts": np.bincount(origin_id, minlength=256).tolist()[:len(polys)],
+        "final_counts": np.bincount(final_id, minlength=256).tolist()[:len(polys)],
+        "visited_counts": [int(((visited >> j) & 1).sum()) for j in range(len(polys))],
+    }).encode("utf-8")
+    return (header + b"\n" + origin_id.tobytes() + final_id.tobytes()
+            + first.astype("<u2").tobytes() + visited.astype("<u4").tobytes()
+            + at0_m.astype("<u4").tobytes() + at_end_m.astype("<u4").tobytes())
+
+
+# ── Polygon txt import (westerschelde format) ──────────────────────────────────
+def load_poly_txt(path):
+    """Parse a polygon txt: latin-1, '#' comments, comma/space separated x y."""
+    verts = []
+    with open(path, "r", encoding="latin-1") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.replace(",", " ").split()
+            if len(parts) >= 2:
+                try:
+                    verts.append([float(parts[0]), float(parts[1])])
+                except ValueError:
+                    continue
+    return verts
+
+
+def import_polygon_dir(directory, pattern="*.txt"):
+    directory = Path(directory)
+    polys = []
+    for f in sorted(directory.glob(pattern)):
+        verts = load_poly_txt(f)
+        if len(verts) >= 3:
+            stem = f.stem
+            label = stem.split("_", 1)[1].replace("_", " ") if "_" in stem else stem
+            polys.append({"name": label, "verts": verts})
+    return polys

--- a/sedtrails-gui/backend/bundle.py
+++ b/sedtrails-gui/backend/bundle.py
@@ -620,7 +620,8 @@ def _classify_missing(bdir, meta, missing, bundle_id=""):
 
     def qbox(poly):
         bx0, bx1, by0, by1 = poly["bbox"]
-        c = lambda v, vmin, s: np.uint16(min(max((v - vmin) / s, 0), QMAX))
+        def c(v, vmin, s):
+            return np.uint16(min(max((v - vmin) / s, 0), QMAX))
         return (c(bx0, q["xmin"], q["sx"]), c(bx1, q["xmin"], q["sx"]) + 1,
                 c(by0, q["ymin"], q["sy"]), c(by1, q["ymin"], q["sy"]) + 1)
 
@@ -642,7 +643,7 @@ def _classify_missing(bdir, meta, missing, bundle_id=""):
         last_qx[valid] = qx[valid]
         last_qy[valid] = qy[valid]
 
-        for poly, s in zip(missing, st):
+        for poly, s in zip(missing, st, strict=False):
             bx0, bx1, by0, by1 = s["qbox"]
             inbox = (qx >= bx0) & (qx < bx1) & (qy >= by0) & (qy < by1)
             track = s["at0"] & ~s["left"]
@@ -672,7 +673,7 @@ def _classify_missing(bdir, meta, missing, bundle_id=""):
     fx = last_qx.astype(np.float64) * q["sx"] + q["xmin"]
     fy = last_qy.astype(np.float64) * q["sy"] + q["ymin"]
     has_last = np.flatnonzero(last_qx != SENTINEL)
-    for poly, s in zip(missing, st):
+    for poly, s in zip(missing, st, strict=False):
         at_end = np.zeros(N, bool)
         at_end[_contains(poly, fx, fy, has_last)] = True
         flags = (s["at0"].astype(np.uint8)

--- a/sedtrails-gui/backend/config_api.py
+++ b/sedtrails-gui/backend/config_api.py
@@ -167,8 +167,6 @@ def load_config(path):
 def _patch(node, new, yml):
     """Recursively apply `new` (plain dict/list) into a ruamel node in place,
     keeping comments/order of everything that did not change."""
-    from ruamel.yaml.comments import CommentedMap, CommentedSeq
-
     if isinstance(node, dict) and isinstance(new, dict):
         for k in [k for k in node.keys() if k not in new]:
             del node[k]

--- a/sedtrails-gui/backend/config_api.py
+++ b/sedtrails-gui/backend/config_api.py
@@ -1,0 +1,411 @@
+"""Settings tab backend: schemas, yaml load/save (comment-preserving), validation,
+template creation and output-size estimation.
+
+Mirrors sedtrails' own machinery where possible:
+- schemas come from the installed sedtrails package (fallback: the repo checkout),
+- validation replicates YAMLConfigValidator's Draft 2020-12 registry,
+- the size estimate mirrors Simulation._estimate_netcdf_payload_bytes /
+  _estimate_output_timesteps (5 coordinate + 6 status fields per particle-slot),
+- duration parsing mirrors particle_tracer/timer.py convert_duration_string_to_seconds.
+"""
+
+import json
+import math
+import re
+import threading
+from pathlib import Path
+
+from .settings import TOOL_DIR
+from .util import _log
+
+SCHEMA_FILES = {
+    "main": "main.schema.json",
+    "population": "population.schema.json",
+    "visualization": "visualization.schema.json",
+}
+_URN = "urn:sedtrails:config:{}"
+
+_lock = threading.RLock()   # RLock: _get_validator holds it while calling get_schemas
+_schemas = None          # name -> dict
+_validator = None        # jsonschema Draft202012Validator
+_ruamel = None           # ruamel.yaml.YAML round-trip instance, or False if unavailable
+_open_docs = {}          # abs path -> (mtime, ruamel CommentedMap)
+
+_DTYPE_BYTES = {"float32": 4, "f4": 4, "float64": 8, "f8": 8, "uint8": 1, "u1": 1,
+                "int32": 4, "i4": 4}
+_COORD_FIELDS = 5        # x, y, z, burial_depth, mixing_depth
+_STATUS_FIELDS = 6       # alive, buried, domain, transported, released, mobile
+_DUR_RE = re.compile(r"(?:(\d+)D)?\s*(?:(\d+)H)?\s*(?:(\d+)M)?\s*(?:(\d+)S)?")
+
+
+# ── schemas & validator ────────────────────────────────────────────────────────
+def _schema_dir():
+    try:
+        from importlib.resources import files
+        d = files("sedtrails") / "config"
+        if (d / SCHEMA_FILES["main"]).is_file():
+            return d
+    except Exception:
+        pass
+    d = TOOL_DIR.parent / "sedtrails" / "src" / "sedtrails" / "config"
+    if (d / SCHEMA_FILES["main"]).is_file():
+        return d
+    raise FileNotFoundError(
+        "sedtrails config schemas not found — install the sedtrails package in this "
+        "environment, or keep the sedtrails repo checkout next to sedtrails-gui")
+
+
+def get_schemas():
+    global _schemas
+    with _lock:
+        if _schemas is None:
+            d = _schema_dir()
+            _schemas = {name: json.loads((d / fn).read_text(encoding="utf-8"))
+                        for name, fn in SCHEMA_FILES.items()}
+    return _schemas
+
+
+def _get_validator():
+    """Draft 2020-12 validator with the same urn registry as YAMLConfigValidator."""
+    global _validator
+    with _lock:
+        if _validator is None:
+            import jsonschema
+            from referencing import Registry, Resource
+            from referencing.jsonschema import DRAFT202012
+
+            schemas = dict(get_schemas())
+            registry = Registry()
+            for name in ("population", "visualization"):
+                registry = registry.with_resource(
+                    uri=_URN.format(SCHEMA_FILES[name]),
+                    resource=Resource(contents=schemas[name], specification=DRAFT202012))
+            _validator = jsonschema.Draft202012Validator(
+                schema=schemas["main"], registry=registry)
+    return _validator
+
+
+def _error_entry(err):
+    pointer = "/".join(str(p) for p in err.absolute_path)
+    msg = err.message
+    if err.context:  # oneOf/anyOf: pick the most relevant sub-error
+        from jsonschema.exceptions import best_match
+        best = best_match(err.context)
+        if best is not None:
+            sub = "/".join(str(p) for p in best.absolute_path)
+            msg = best.message + (f" (at {sub})" if sub and sub != pointer else "")
+            if sub:
+                pointer = sub
+    if len(msg) > 300:
+        msg = msg[:300] + "…"
+    return {"pointer": pointer, "message": msg}
+
+
+def validate_config(cfg):
+    errors = [_error_entry(e) for e in _get_validator().iter_errors(cfg)]
+    return {"valid": not errors, "errors": errors[:50]}
+
+
+# ── yaml load / save ───────────────────────────────────────────────────────────
+def _get_ruamel():
+    global _ruamel
+    if _ruamel is None:
+        try:
+            from ruamel.yaml import YAML
+            from ruamel.yaml.constructor import RoundTripConstructor
+
+            # keep timestamps as plain strings (same intent as SedtrailsYamlLoader)
+            RoundTripConstructor.add_constructor(
+                "tag:yaml.org,2002:timestamp",
+                lambda self, node: self.construct_scalar(node))
+            yml = YAML()  # round-trip mode: preserves comments, order, quoting
+            yml.preserve_quotes = True
+            yml.width = 4096
+            yml.indent(mapping=2, sequence=4, offset=2)   # matches the example configs
+            _ruamel = yml
+        except ImportError:
+            _ruamel = False
+    return _ruamel
+
+
+def _plain(obj):
+    """ruamel/pyyaml containers -> plain JSON-able python."""
+    if isinstance(obj, dict):
+        return {str(k): _plain(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_plain(v) for v in obj]
+    if isinstance(obj, (str, int, float, bool)) or obj is None:
+        return obj
+    return str(obj)
+
+
+def _pyyaml_load(text):
+    import yaml
+
+    class _Loader(yaml.SafeLoader):
+        pass
+
+    _Loader.add_constructor("tag:yaml.org,2002:timestamp",
+                            lambda loader, node: loader.construct_scalar(node))
+    return yaml.load(text, Loader=_Loader)
+
+
+def load_config(path):
+    p = Path(path)
+    if not p.is_file():
+        raise FileNotFoundError(f"file not found: {path}")
+    text = p.read_text(encoding="utf-8")
+    yml = _get_ruamel()
+    if yml:
+        doc = yml.load(text)
+        _open_docs[str(p.resolve())] = doc
+        return {"config": _plain(doc) or {}, "roundtrip": "ruamel", "path": str(p.resolve())}
+    data = _pyyaml_load(text)
+    return {"config": _plain(data) or {}, "roundtrip": "pyyaml", "path": str(p.resolve())}
+
+
+def _patch(node, new, yml):
+    """Recursively apply `new` (plain dict/list) into a ruamel node in place,
+    keeping comments/order of everything that did not change."""
+    from ruamel.yaml.comments import CommentedMap, CommentedSeq
+
+    if isinstance(node, dict) and isinstance(new, dict):
+        for k in [k for k in node.keys() if k not in new]:
+            del node[k]
+        for k, v in new.items():
+            if k in node and isinstance(node[k], dict) and isinstance(v, dict):
+                _patch(node[k], v, yml)
+            elif k in node and isinstance(node[k], list) and isinstance(v, list):
+                _patch(node[k], v, yml)
+            elif k in node and not isinstance(node[k], (dict, list)) and not isinstance(v, (dict, list)):
+                if node[k] != v or type(node[k]) is not type(v):
+                    node[k] = v
+            else:
+                node[k] = _to_ruamel(v, yml)
+        return
+    if isinstance(node, list) and isinstance(new, list):
+        common = min(len(node), len(new))
+        for i in range(common):
+            if isinstance(node[i], (dict, list)) and isinstance(new[i], (dict, list)) \
+                    and isinstance(node[i], dict) == isinstance(new[i], dict):
+                _patch(node[i], new[i], yml)
+            elif node[i] != new[i]:
+                node[i] = _to_ruamel(new[i], yml)
+        del node[common:len(node)]
+        for v in new[common:]:
+            node.append(_to_ruamel(v, yml))
+
+
+def _to_ruamel(v, yml):
+    from ruamel.yaml.comments import CommentedMap, CommentedSeq
+
+    if isinstance(v, dict):
+        m = CommentedMap()
+        for k, x in v.items():
+            m[k] = _to_ruamel(x, yml)
+        return m
+    if isinstance(v, list):
+        s = CommentedSeq()
+        for x in v:
+            s.append(_to_ruamel(x, yml))
+        return s
+    return v
+
+
+def _schema_key_order(schema, root):
+    """Property order of an object schema (resolving one $ref level)."""
+    if "$ref" in schema:
+        ref = schema["$ref"]
+        if ref.startswith("#/"):
+            target = root
+            for part in ref[2:].split("/"):
+                target = target.get(part, {})
+            schema = target
+        else:
+            for name, fn in SCHEMA_FILES.items():
+                if ref == _URN.format(fn):
+                    schema = get_schemas()[name]
+    return schema
+
+
+def _order_by_schema(data, schema, root):
+    """Recursively order dict keys by schema property order (pyyaml fallback path)."""
+    schema = _schema_key_order(schema, root)
+    if schema.get("$id"):
+        root = schema
+    props = schema.get("properties", {})
+    if isinstance(data, dict):
+        ordered = {}
+        for k in list(props.keys()) + [k for k in data if k not in props]:
+            if k in data:
+                ordered[k] = _order_by_schema(data[k], props.get(k, {}), root)
+        return ordered
+    if isinstance(data, list):
+        item_schema = schema.get("items", {})
+        return [_order_by_schema(v, item_schema, root) for v in data]
+    return data
+
+
+def save_config(path, cfg):
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    validation = validate_config(cfg)
+    yml = _get_ruamel()
+    if yml:
+        key = str(p.resolve())
+        doc = _open_docs.get(key)
+        if doc is None and p.is_file():
+            doc = yml.load(p.read_text(encoding="utf-8"))
+        if doc is None:
+            doc = _to_ruamel(cfg, yml)
+        else:
+            _patch(doc, cfg, yml)
+        with open(p, "w", encoding="utf-8") as f:
+            yml.dump(doc, f)
+        _open_docs[key] = doc
+        mode = "ruamel"
+    else:
+        import yaml as pyyaml
+        main = get_schemas()["main"]
+        ordered = _order_by_schema(cfg, main, main)
+        with open(p, "w", encoding="utf-8") as f:
+            pyyaml.safe_dump(ordered, f, default_flow_style=False, sort_keys=False,
+                             indent=2, allow_unicode=True)
+        mode = "pyyaml"
+    _log(f"config saved ({mode}) -> {p}")
+    return {"ok": True, "path": str(p.resolve()), "roundtrip": mode,
+            "validation": validation}
+
+
+def create_template():
+    """Defaults-applied starter config with one population (uses sedtrails' own
+    defaults applier when importable, else a static minimal template)."""
+    skeleton = {
+        "general": {},
+        "inputs": {"data": ""},
+        "domain": {"subset_x": "0:100000", "subset_y": "0:100000"},
+        "time": {"timestep": "30S"},
+        "physics": {},
+        "particles": {"populations": [{}]},
+        "outputs": {},
+        "compute": {},
+    }
+    try:
+        from sedtrails.application_interfaces.validator import YAMLConfigValidator
+        v = YAMLConfigValidator()
+        skeleton = v._apply_defaults(v.schema_content, skeleton)
+    except Exception as e:
+        _log(f"template: sedtrails defaults applier unavailable ({e}); using skeleton")
+    pop = skeleton["particles"]["populations"][0]
+    pop.setdefault("name", "population_1")
+    pop.setdefault("particle_type", "passive")
+    if not pop.get("characteristics"):
+        pop["characteristics"] = {"diffusion_coefficient": 0.0}
+    seeding = pop.setdefault("seeding", {})
+    seeding.setdefault("quantity", 1)
+    if not seeding.get("strategy"):   # defaults applier leaves an empty {} here
+        seeding["strategy"] = {"random": {"bbox": "0,0 1000,1000",
+                                          "nlocations": 100, "seed": 42}}
+    if not pop.get("barriers"):
+        pop.pop("barriers", None)
+    return {"config": skeleton}
+
+
+# ── size estimate ──────────────────────────────────────────────────────────────
+def duration_seconds(s):
+    """'3D 2H1M3S' -> seconds; None if unparsable/empty."""
+    if s is None:
+        return None
+    if isinstance(s, (int, float)):
+        return float(s)
+    m = _DUR_RE.fullmatch(str(s).strip())
+    if not m or not any(m.groups()):
+        return None
+    d, h, mi, sec = (int(g) if g else 0 for g in m.groups())
+    return d * 86400 + h * 3600 + mi * 60 + sec
+
+
+def _population_count(pop):
+    """(n_particles, exact) best-effort mirror of ParticleFactory semantics:
+    total = quantity x number of seed locations."""
+    seeding = pop.get("seeding", {}) or {}
+    q = seeding.get("quantity", 1) or 1
+    strat = seeding.get("strategy", {}) or {}
+    if "point" in strat:
+        locs = strat["point"].get("locations")
+        return (q * len(locs), True) if locs else (None, False)
+    if "transect" in strat:
+        t = strat["transect"]
+        segs = t.get("segments")
+        k = t.get("k", 100.0)
+        return (int(q * k * len(segs)), True) if segs else (None, False)
+    if "random" in strat:
+        n = strat["random"].get("nlocations", 1)
+        return (int(q * n), True)
+    if "grid" in strat:
+        g = strat["grid"]
+        sep = g.get("separation", {}) or {}
+        dx, dy = sep.get("dx", 100.0) or 100.0, sep.get("dy", 100.0) or 100.0
+        bbox = g.get("bbox")
+        if bbox:
+            try:
+                parts = [float(v) for v in str(bbox).replace(",", " ").split()]
+                nx = max(1, int((parts[2] - parts[0]) / dx) + 1)
+                ny = max(1, int((parts[3] - parts[1]) / dy) + 1)
+                return (int(q * nx * ny), False)   # poly mask may trim this
+            except Exception:
+                return (None, False)
+        return (None, False)
+    if "file_points" in strat:
+        path = strat["file_points"].get("path")
+        if path and Path(path).is_file():
+            try:
+                n = sum(1 for _ in open(path, "r", encoding="latin-1"))
+                if strat["file_points"].get("has_header", True):
+                    n -= 1
+                stride = strat["file_points"].get("stride", 1) or 1
+                return (int(q * max(0, n) / stride), False)
+            except OSError:
+                return (None, False)
+        return (None, False)
+    return (None, False)
+
+
+def estimate(cfg):
+    """Mirror of Simulation._estimate_netcdf_payload_bytes/_estimate_output_timesteps."""
+    outputs = cfg.get("outputs", {}) or {}
+    ncopt = outputs.get("netcdf", {}) or {}
+    coord_b = _DTYPE_BYTES.get(str(ncopt.get("coordinate_dtype", "float32")), 4)
+    stat_b = _DTYPE_BYTES.get(str(ncopt.get("status_dtype", "uint8")), 1)
+    per_slot = _COORD_FIELDS * coord_b + _STATUS_FIELDS * stat_b
+
+    dur = duration_seconds((cfg.get("time", {}) or {}).get("duration"))
+    si = duration_seconds(outputs.get("save_interval", "1H")) or 3600
+    if outputs.get("store_tracks", True) is False:
+        slots = 1
+    elif dur is None or si <= 0:
+        slots = None
+    else:
+        n = int(math.floor(dur / si))
+        slots = 1 + n + (1 if n * si < dur - 1e-9 else 0)
+
+    pops, total, exact = [], 0, True
+    for pop in (cfg.get("particles", {}) or {}).get("populations", []) or []:
+        n, ex = _population_count(pop or {})
+        pops.append({"name": (pop or {}).get("name", "?"), "n": n, "exact": ex})
+        if n is None:
+            exact = False
+        else:
+            total += n
+            exact = exact and ex
+
+    payload = total * slots * per_slot if (slots and total) else None
+    threshold = int(ncopt.get("compression_auto_threshold_mb", 1024)) * 1024 * 1024
+    compressed = None
+    comp = ncopt.get("compression", "auto")
+    if payload is not None:
+        compressed = bool(comp) if isinstance(comp, bool) else payload >= threshold
+    return {"particles": total or None, "particles_exact": exact, "populations": pops,
+            "slots": slots, "duration_s": dur, "save_interval_s": si,
+            "bytes_per_particle_slot": per_slot, "bytes": payload,
+            "compression": compressed}

--- a/sedtrails-gui/backend/connectivity.py
+++ b/sedtrails-gui/backend/connectivity.py
@@ -1,0 +1,132 @@
+"""Connectivity tab backend (v0): polygon-to-polygon connectivity matrix.
+
+Builds on the viewer's cached per-polygon classification (bundle.classify
+machinery): M[i][j] = number (or fraction) of particles starting in polygon i
+that end in / ever visit polygon j. New metrics later = new `mode` values here.
+"""
+
+from pathlib import Path
+
+import numpy as np
+
+from .bundle import _classify_missing, _poly_paths, registry_find
+from .util import _read_json
+
+
+def compute(bundle_id, polygons, mode="start_end", normalize="count"):
+    sim = registry_find(bundle_id)
+    if sim is None:
+        raise ValueError(f"unknown bundle: {bundle_id} (import it in the Viewer tab first)")
+    bdir = Path(sim["bundle_dir"])
+    meta = _read_json(bdir / "meta.json", None)
+    if meta is None:
+        raise ValueError(f"bundle has no meta.json: {bdir}")
+
+    polys = _poly_paths(polygons)
+    if len(polys) < 2:
+        raise ValueError("connectivity needs at least 2 polygons")
+    if len(polys) > 200:
+        # uint8 origin/final ids allow up to 254 polygons (255 = unassigned)
+        raise ValueError("at most 200 polygons supported")
+
+    missing = [p for p in polys if not (bdir / f"polycls_{p['geom_key']}.bin").exists()]
+    if missing:
+        _classify_missing(bdir, meta, missing, bundle_id)
+
+    N = meta["n_particles"]
+    n = len(polys)
+    origin = np.full(N, 255, np.uint8)
+    at_end = np.zeros((n, N), bool)
+    visited = np.zeros((n, N), bool)
+    for j, poly in enumerate(polys):
+        raw = (bdir / f"polycls_{poly['geom_key']}.bin").read_bytes()
+        flags = np.frombuffer(raw, np.uint8, N)
+        at0 = (flags & 1) != 0
+        at_end[j] = (flags & 2) != 0
+        visited[j] = (flags & 4) != 0
+        np.copyto(origin, j, where=at0 & (origin == 255))
+
+    target = at_end if mode == "start_end" else visited
+    matrix = np.zeros((n, n), np.float64)
+    row_counts = []
+    for i in range(n):
+        src = origin == i
+        row_counts.append(int(src.sum()))
+        for j in range(n):
+            matrix[i, j] = int((src & target[j]).sum())
+    if normalize == "fraction":
+        for i in range(n):
+            if row_counts[i]:
+                matrix[i] /= row_counts[i]
+
+    return {
+        "labels": [p["key"] for p in polys],
+        "matrix": [[round(float(v), 4) for v in row] for row in matrix],
+        "row_counts": row_counts,
+        "n_unassigned": int((origin == 255).sum()),
+        "n_particles": N,
+        "mode": mode,
+        "normalize": normalize,
+    }
+
+
+def auto_polygons(forcing_id, n=12, var=None):
+    """Geomorphic cells à la Pearson et al. (2021): k-means clustering of the
+    forcing node cloud on (x, y, bed level) — each feature min-max normalized so
+    position and bathymetry weigh equally — then the Voronoi cells of the
+    cluster centroids, closed against the domain bounding box (mirror trick):
+    n simple polygons covering the domain, ready for connectivity analysis."""
+    from scipy.cluster.vq import kmeans2
+    from scipy.spatial import Voronoi
+
+    from .forcing import NC_LOCK, _open_ds, _slab, get_store
+
+    n = int(n)
+    if not 2 <= n <= 200:
+        raise ValueError("number of cells must be between 2 and 200")
+    s = get_store(forcing_id)
+    with NC_LOCK:
+        ds = _open_ds(s["path"])
+        try:
+            x = np.asarray(ds.variables["net_xcc"][:], float).ravel()
+            y = np.asarray(ds.variables["net_ycc"][:], float).ravel()
+            z = np.asarray(_slab(ds, var, 0), float).ravel() if var else np.zeros_like(x)
+        finally:
+            ds.close()
+
+    ok = np.isfinite(x) & np.isfinite(y) & np.isfinite(z) & (z > -1e29)
+    if ok.sum() < n:
+        raise ValueError("not enough valid nodes for that many cells")
+    pts = np.column_stack([x[ok], y[ok]])
+    zz = z[ok]
+    if len(pts) > 200_000:                       # keep k-means quick on big grids
+        step = len(pts) // 200_000 + 1
+        pts, zz = pts[::step], zz[::step]
+
+    feats = np.column_stack([pts, zz])
+    lo, hi = feats.min(axis=0), feats.max(axis=0)
+    span = np.where(hi > lo, hi - lo, 1.0)
+    _, labels = kmeans2((feats - lo) / span, n, minit="++", seed=0)
+    cents = np.array([pts[labels == k].mean(axis=0)
+                      for k in range(n) if (labels == k).any()])
+
+    # Voronoi of the centroids; reflecting them across the four bbox edges makes
+    # every real region finite and clipped exactly at the bounding box
+    x0, x1 = pts[:, 0].min(), pts[:, 0].max()
+    y0, y1 = pts[:, 1].min(), pts[:, 1].max()
+    mirrors = np.vstack([
+        np.column_stack([2 * x0 - cents[:, 0], cents[:, 1]]),
+        np.column_stack([2 * x1 - cents[:, 0], cents[:, 1]]),
+        np.column_stack([cents[:, 0], 2 * y0 - cents[:, 1]]),
+        np.column_stack([cents[:, 0], 2 * y1 - cents[:, 1]]),
+    ])
+    vor = Voronoi(np.vstack([cents, mirrors]))
+    polygons = []
+    for k in range(len(cents)):
+        region = vor.regions[vor.point_region[k]]
+        if not region or -1 in region:
+            continue
+        verts = [[round(float(vor.vertices[i][0]), 1),
+                  round(float(vor.vertices[i][1]), 1)] for i in region]
+        polygons.append({"name": f"auto_cell_{len(polygons) + 1:02d}", "verts": verts})
+    return {"polygons": polygons, "n_nodes_used": int(len(pts))}

--- a/sedtrails-gui/backend/forcing.py
+++ b/sedtrails-gui/backend/forcing.py
@@ -1,0 +1,343 @@
+"""Forcing tab backend: open a sedtrails-compatible forcing netCDF (D-Flow FM
+"sedtrails_nc" node-cloud layout), discover its variables and vector pairs,
+build a Voronoi cell mesh with a per-vertex node index (cached on disk next to
+the file), and stream per-timestep float32 value slabs to the frontend.
+
+The Voronoi construction mirrors bundle._voronoi_cells_geometry, but instead of
+baking values per vertex it emits the ORIGINAL node index per vertex, so any
+variable/timestep can be gathered client-side onto the same static geometry.
+"""
+
+import datetime
+import hashlib
+import json
+import re
+import threading
+import time
+import traceback
+import uuid
+from pathlib import Path
+
+import numpy as np
+
+from .util import (NC_LOCK, _jobs, _jobs_lock, _log, _nanfilled, _read_json,
+                   _write_json, resolve_input_path)
+
+MESH_FORMAT_VERSION = 4          # v4: cell cutoff vs 8th neighbor (anisotropic grids)
+_store = {}          # id -> {"path": str, "meta": dict, "cache_dir": Path}
+_store_lock = threading.Lock()
+_range_cache = {}    # (id, var) -> [lo, hi] global 2-98 percentile of first/mid/last frame
+
+# variable-name pairs known from transport_converter fm_netcdf conventions
+KNOWN_PAIRS = [
+    ("sea_water_x_velocity", "sea_water_y_velocity", "flow velocity"),
+    ("bedload_x_comp", "bedload_y_comp", "bedload transport"),
+    ("susload_x_comp", "susload_y_comp", "suspended load transport"),
+]
+
+
+def forcing_id(path):
+    p = Path(path).resolve()
+    return "f" + hashlib.sha1(str(p).lower().encode("utf-8")).hexdigest()[:10]
+
+
+def cache_dir_for(path):
+    p = Path(path)
+    return p.parent / (p.stem + ".forcing_cache")
+
+
+def _open_ds(path):
+    import netCDF4 as nc
+    return nc.Dataset(path, "r")
+
+
+def _reference_datetime(t_var):
+    units = getattr(t_var, "units", "") or ""
+    m = re.search(r"since\s+(\d{4}-\d{2}-\d{2})[T ]?(\d{2}:\d{2}:\d{2})?", units)
+    if not m:
+        return datetime.datetime(1970, 1, 1)
+    d = datetime.datetime.strptime(m.group(1), "%Y-%m-%d")
+    if m.group(2):
+        h, mi, s = (int(x) for x in m.group(2).split(":"))
+        d = d.replace(hour=h, minute=mi, second=s)
+    return d
+
+
+def open_forcing(path, base=None):
+    """Register a forcing file; return its id + meta (times, variables, pairs)."""
+    p = resolve_input_path(path, base)
+    if not p.is_file():
+        extra = f" (resolved to {p})" if str(p) != str(path) else ""
+        raise FileNotFoundError(f"file not found: {path}{extra}")
+    fid = forcing_id(p)
+
+    with NC_LOCK:
+        ds = _open_ds(p)
+        return _open_forcing_locked(ds, p, fid)
+
+
+def _open_forcing_locked(ds, p, fid):
+    try:
+        if "net_xcc" not in ds.variables:
+            raise ValueError("not a sedtrails forcing file (net_xcc/net_ycc missing) — "
+                             "convert the model output first")
+        x = _nanfilled(ds.variables["net_xcc"][:])
+        y = _nanfilled(ds.variables["net_ycc"][:])
+        node_dim = ds.variables["net_xcc"].dimensions[0]
+        n_nodes = len(x)
+        ok = np.isfinite(x) & np.isfinite(y)
+        extent = [float(np.min(x[ok])), float(np.max(x[ok])),
+                  float(np.min(y[ok])), float(np.max(y[ok]))]
+
+        t_var = ds.variables.get("time")
+        times, ref = [], None
+        if t_var is not None:
+            ref = _reference_datetime(t_var)
+            tsec = _nanfilled(t_var[:]).ravel()
+            times = [(ref + datetime.timedelta(seconds=float(s))).strftime("%Y-%m-%d %H:%M")
+                     if np.isfinite(s) else "?" for s in tsec]
+
+        vector_names = set()
+        pairs = []
+        for xn, yn, label in KNOWN_PAIRS:
+            if xn in ds.variables and yn in ds.variables:
+                pairs.append({"label": label, "x": xn, "y": yn})
+                vector_names |= {xn, yn}
+        for name, v in ds.variables.items():          # generic *_x_* / x_comp fallback
+            if name in vector_names or node_dim not in v.dimensions:
+                continue
+            partner = None
+            if "_x_" in name:
+                partner = name.replace("_x_", "_y_")
+            elif name.endswith("x_comp"):
+                partner = name[:-6] + "y_comp"
+            if partner and partner in ds.variables and partner not in vector_names:
+                pairs.append({"label": name.replace("_x_", " ").replace("x_comp", "").strip("_"),
+                              "x": name, "y": partner})
+                vector_names |= {name, partner}
+
+        variables = []
+        for name, v in ds.variables.items():
+            if name in ("net_xcc", "net_ycc", "time") or node_dim not in v.dimensions:
+                continue
+            variables.append({
+                "name": name,
+                "time_varying": "time" in v.dimensions,
+                "units": getattr(v, "units", ""),
+                "long_name": getattr(v, "long_name", name),
+                "is_vector_comp": name in vector_names,
+            })
+
+        meta = {"id": fid, "path": str(p), "n_nodes": n_nodes, "extent": extent,
+                "n_timesteps": len(times), "times": times,
+                "reference_date": ref.strftime("%Y-%m-%d %H:%M") if ref else None,
+                "variables": variables, "vector_pairs": pairs}
+    finally:
+        ds.close()
+
+    cdir = cache_dir_for(p)
+    with _store_lock:
+        _store[fid] = {"path": str(p), "meta": meta, "cache_dir": cdir}
+
+    result = {"id": fid, "meta": meta}
+    mesh_meta = _read_json(cdir / "mesh.json", None)
+    if mesh_meta and mesh_meta.get("format_version") == MESH_FORMAT_VERSION \
+            and (cdir / "mesh.bin").exists():
+        result["mesh"] = mesh_meta
+    else:
+        job_id = uuid.uuid4().hex[:12]
+        job = {"id": job_id, "status": "running", "progress": 0.0,
+               "message": "building forcing mesh", "bundle": None}
+        with _jobs_lock:
+            _jobs[job_id] = job
+
+        def work():
+            try:
+                mm = build_mesh(str(p), cdir, job)
+                job["status"] = "done"
+                job["mesh"] = mm
+            except Exception as e:
+                traceback.print_exc()
+                job["status"] = "error"
+                job["message"] = f"{type(e).__name__}: {e}"
+
+        threading.Thread(target=work, daemon=True).start()
+        result["mesh_job"] = job_id
+    return result
+
+
+def build_mesh(path, cdir, job=None):
+    """Voronoi cells of the node cloud; per-vertex ORIGINAL node index.
+
+    mesh.bin layout: xy f4 (Nv,2) ABSOLUTE coords | nodeIndex u4 (Nv,) |
+    tris u4 (Nt,3) | node xy f4 (n_nodes, 2).
+    """
+    from scipy.spatial import Voronoi, cKDTree
+
+    def prog(f, msg):
+        if job is not None:
+            job["progress"] = round(f, 3)
+            job["message"] = msg
+
+    t0 = time.time()
+    with NC_LOCK:
+        ds = _open_ds(path)
+        try:
+            xn = _nanfilled(ds.variables["net_xcc"][:])
+            yn = _nanfilled(ds.variables["net_ycc"][:])
+        finally:
+            ds.close()
+
+    ok = np.isfinite(xn) & np.isfinite(yn)
+    orig_idx = np.flatnonzero(ok)
+    pts = np.column_stack([xn[ok], yn[ok]])
+    n_real = len(pts)
+    prog(0.1, f"Voronoi tessellation of {n_real} nodes")
+
+    x0, x1 = pts[:, 0].min(), pts[:, 0].max()
+    y0, y1 = pts[:, 1].min(), pts[:, 1].max()
+    mx, my = (x1 - x0) * 0.2 + 1.0, (y1 - y0) * 0.2 + 1.0
+    ts = np.linspace(0.0, 1.0, 100, endpoint=False)
+    ring = np.concatenate([
+        np.column_stack([x0 - mx + ts * (x1 - x0 + 2*mx), np.full(100, y0 - my)]),
+        np.column_stack([x0 - mx + ts * (x1 - x0 + 2*mx), np.full(100, y1 + my)]),
+        np.column_stack([np.full(100, x0 - mx), y0 - my + ts * (y1 - y0 + 2*my)]),
+        np.column_stack([np.full(100, x1 + mx), y0 - my + ts * (y1 - y0 + 2*my)]),
+    ])
+    vor = Voronoi(np.vstack([pts, ring]))
+    tree = cKDTree(pts)
+    nn = tree.query(pts, k=2)[0][:, 1]
+    # cutoff radius from the 8th neighbor, not the 1st: on strongly anisotropic
+    # grids (alongshore spacing >> cross-shore) the 1st neighbor is the short
+    # axis and whole rows of valid cells would be cut (sandengine grid)
+    k8 = min(9, n_real)
+    loc = tree.query(pts, k=k8)[0][:, k8 - 1] if k8 >= 2 else nn
+    r_cut2 = (3.0 * np.maximum(loc, 1e-3)) ** 2
+    prog(0.5, "assembling cells")
+
+    verts_l, nidx_l, tris_l = [], [], []
+    vo = 0
+    vv = vor.vertices
+    for i in range(n_real):
+        region = vor.regions[vor.point_region[i]]
+        c = len(region)
+        if c < 3 or -1 in region:
+            continue
+        cell = vv[region]
+        d2 = (cell[:, 0] - pts[i, 0])**2 + (cell[:, 1] - pts[i, 1])**2
+        if d2.max() > r_cut2[i]:
+            continue
+        verts_l.append(cell)
+        nidx_l.append(np.full(c, orig_idx[i], np.uint32))
+        fan = np.empty((c - 2, 3), np.int64)
+        fan[:, 0] = vo
+        fan[:, 1] = vo + np.arange(1, c - 1)
+        fan[:, 2] = vo + np.arange(2, c)
+        tris_l.append(fan)
+        vo += c
+
+    xy = np.concatenate(verts_l).astype("<f4")
+    nidx = np.concatenate(nidx_l).astype("<u4")
+    tris = np.concatenate(tris_l).astype("<u4")
+    nodes = np.column_stack([xn, yn]).astype("<f4")
+    nodes[~np.isfinite(nodes)] = -1e30
+
+    prog(0.9, "writing mesh cache")
+    cdir.mkdir(parents=True, exist_ok=True)
+    with open(cdir / "mesh.bin", "wb") as f:
+        f.write(np.ascontiguousarray(xy).tobytes())
+        f.write(np.ascontiguousarray(nidx).tobytes())
+        f.write(np.ascontiguousarray(tris).tobytes())
+        f.write(np.ascontiguousarray(nodes).tobytes())
+    mesh_meta = {"format_version": MESH_FORMAT_VERSION, "n_verts": int(len(xy)),
+                 "n_tris": int(len(tris)), "n_nodes": int(len(nodes)),
+                 # spacing of the finest cells (1st pctl nearest-neighbor
+                 # distance) — the frontend's world-based arrow-scale anchor
+                 "cell_p01": float(np.percentile(nn, 1)),
+                 "file": "mesh.bin"}
+    _write_json(cdir / "mesh.json", mesh_meta)
+    _log(f"forcing mesh: {len(xy)} vertices, {len(tris)} triangles "
+         f"in {time.time() - t0:.1f} s -> {cdir / 'mesh.bin'}")
+    return mesh_meta
+
+
+def get_store(fid):
+    with _store_lock:
+        s = _store.get(fid)
+    if s is None:
+        raise ValueError(f"unknown forcing id: {fid} (open it first)")
+    return s
+
+
+def mesh_payload(fid):
+    """mesh.json header + mesh.bin bytes, as one JSON-line + binary payload."""
+    s = get_store(fid)
+    mesh_meta = _read_json(s["cache_dir"] / "mesh.json", None)
+    if mesh_meta is None:
+        raise ValueError("mesh not built yet")
+    header = json.dumps(mesh_meta).encode("utf-8")
+    return header + b"\n" + (s["cache_dir"] / "mesh.bin").read_bytes()
+
+
+def _slab(ds, name, t):
+    """float32[n_nodes] for one variable/timestep. Robust to extra dimensions
+    (sediment fractions, layers): selects the requested time along the time
+    axis and index 0 along any remaining non-node axis."""
+    v = ds.variables[name]
+    if "time" in v.dimensions and v.ndim >= 2:
+        idx = [slice(None)] * v.ndim
+        idx[v.dimensions.index("time")] = int(t)
+        arr = v[tuple(idx)]
+    else:
+        arr = v[:]
+    arr = np.asarray(_nanfilled(arr)).squeeze()
+    while arr.ndim > 1:            # e.g. (n_fractions, n_nodes) → first fraction
+        arr = arr[0]
+    return arr.astype("<f4")
+
+
+def field_payload(fid, var, t):
+    """float32[n_nodes] for one variable/timestep + a stable global color range."""
+    s = get_store(fid)
+    with NC_LOCK:
+        ds = _open_ds(s["path"])
+        try:
+            arr = _slab(ds, var, t)
+            key = (fid, var)
+            if key not in _range_cache:
+                nt = s["meta"]["n_timesteps"]
+                probes = [arr] if "time" not in ds.variables[var].dimensions else \
+                    [_slab(ds, var, k) for k in {0, nt // 2, nt - 1}]
+                allv = np.concatenate(probes)
+                fin = allv[np.isfinite(allv)]
+                _range_cache[key] = ([float(np.percentile(fin, 2)), float(np.percentile(fin, 98))]
+                                     if fin.size else [0.0, 1.0])
+            lo, hi = _range_cache[key]
+        finally:
+            ds.close()
+    arr[~np.isfinite(arr)] = -1e30
+    return arr.tobytes(), f"{lo:.6g},{hi:.6g}"
+
+
+def vector_payload(fid, xvar, yvar, t):
+    """interleaved float32[n_nodes, 2] (u, v) + 98th-percentile magnitude."""
+    s = get_store(fid)
+    with NC_LOCK:
+        ds = _open_ds(s["path"])
+        try:
+            u = _slab(ds, xvar, t)
+            v = _slab(ds, yvar, t)
+        finally:
+            ds.close()
+    mag = np.hypot(u, v)
+    fin = mag[np.isfinite(mag)]
+    p98 = float(np.percentile(fin, 98)) if fin.size else 1.0
+    # same -1e30 sentinel as field_payload: lets the client discard dry/masked
+    # nodes in vector-derived maps and skip them in the arrow shader
+    bad = ~(np.isfinite(u) & np.isfinite(v))
+    u[bad] = -1e30
+    v[bad] = -1e30
+    out = np.empty((len(u), 2), "<f4")
+    out[:, 0] = u
+    out[:, 1] = v
+    return out.tobytes(), f"{p98:.6g}"

--- a/sedtrails-gui/backend/httpd.py
+++ b/sedtrails-gui/backend/httpd.py
@@ -1,0 +1,366 @@
+"""HTTP server: static frontend files + JSON/binary API routes.
+
+Extracted verbatim from sedtrails-viewer/sedtrails_viewer.py (Phase 0 split).
+"""
+
+import json
+import os
+import sys
+import threading
+import traceback
+import urllib.parse
+import uuid
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+from . import config_api, connectivity, forcing, seeding_api
+from .run_manager import MANAGER as run_manager
+from .bundle import (_classify_progress, _polygons_lock, _polygons_path,
+                     _registry_lock, classify, import_polygon_dir, import_run,
+                     load_poly_txt, load_registry, registry_find, save_registry)
+from .settings import WEB_DIR
+from .util import (_browse, _jobs, _jobs_lock, _log, _read_json, _video_jobs,
+                   _write_json, native_pick, native_save)
+
+
+class GuiHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, fmt, *args):  # quiet: only log errors
+        if args and str(args[1] if len(args) > 1 else "").startswith(("4", "5")):
+            _log(f"http: {fmt % args}")
+
+    # -- helpers --
+    def _send(self, code, body, ctype="application/json", cache=False, headers=None):
+        if isinstance(body, (dict, list)):
+            body = json.dumps(body).encode("utf-8")
+        elif isinstance(body, str):
+            body = body.encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(body)))
+        for k, v in (headers or {}).items():
+            self.send_header(k, v)
+        if not cache:
+            self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        try:
+            self.wfile.write(body)
+        except (ConnectionAbortedError, BrokenPipeError):
+            pass
+
+    def _send_file(self, path, ctype, cache=True):
+        try:
+            size = os.path.getsize(path)
+        except OSError:
+            return self._send(404, {"error": "not found"})
+        self.send_response(200)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(size))
+        self.send_header("Cache-Control", "max-age=60" if cache else "no-store")
+        self.end_headers()
+        try:
+            with open(path, "rb") as f:
+                while True:
+                    chunk = f.read(1024 * 1024)
+                    if not chunk:
+                        break
+                    self.wfile.write(chunk)
+        except (ConnectionAbortedError, BrokenPipeError):
+            pass
+
+    def _json_body(self):
+        length = int(self.headers.get("Content-Length", 0))
+        return json.loads(self.rfile.read(length) or b"{}")
+
+    # -- routing --
+    def do_GET(self):
+        try:
+            parsed = urllib.parse.urlparse(self.path)
+            route = parsed.path
+            qs = urllib.parse.parse_qs(parsed.query)
+
+            if route in ("/", "/index.html"):
+                return self._send_file(WEB_DIR / "index.html", "text/html; charset=utf-8", cache=False)
+            if route.startswith(("/css/", "/js/")):
+                fpath = (WEB_DIR / route.lstrip("/")).resolve()
+                if WEB_DIR.resolve() not in fpath.parents or not fpath.is_file():
+                    return self._send(404, {"error": "not found"})
+                ctype = ("text/css; charset=utf-8" if fpath.suffix == ".css"
+                         else "text/javascript; charset=utf-8")
+                return self._send_file(fpath, ctype, cache=False)
+            if route == "/api/registry":
+                return self._send(200, load_registry())
+            if route == "/api/schema":
+                return self._send(200, config_api.get_schemas())
+            if route == "/api/run/status":
+                return self._send(200, run_manager.status())
+            if route == "/api/run/log":
+                return self._send(200, run_manager.get_log(qs.get("offset", ["0"])[0]))
+            if route.startswith("/api/forcing/"):
+                parts = route.split("/")          # /api/forcing/<id>/<what>
+                if len(parts) == 5:
+                    fid, what = parts[3], parts[4]
+                    if what == "mesh":
+                        return self._send(200, forcing.mesh_payload(fid),
+                                          ctype="application/octet-stream")
+                    if what == "field":
+                        data, rng = forcing.field_payload(
+                            fid, qs.get("var", [""])[0], qs.get("t", ["0"])[0])
+                        return self._send(200, data, ctype="application/octet-stream",
+                                          headers={"X-Data-Range": rng})
+                    if what == "vector":
+                        data, p98 = forcing.vector_payload(
+                            fid, qs.get("x", [""])[0], qs.get("y", [""])[0],
+                            qs.get("t", ["0"])[0])
+                        return self._send(200, data, ctype="application/octet-stream",
+                                          headers={"X-Mag-P98": p98})
+                return self._send(404, {"error": "not found"})
+            if route == "/api/browse":
+                return self._send(200, _browse(qs.get("dir", [""])[0]))
+            if route == "/api/pickfile":
+                try:
+                    paths = native_pick(qs.get("kind", ["nc"])[0],
+                                        qs.get("dir", [""])[0] or None)
+                    return self._send(200, {"paths": paths})
+                except Exception as e:
+                    return self._send(200, {"paths": None, "error": str(e)})
+            if route == "/api/picksave":
+                try:
+                    path = native_save(qs.get("ext", [".png"])[0],
+                                       qs.get("name", [""])[0] or None,
+                                       qs.get("dir", [""])[0] or None)
+                    return self._send(200, {"path": path})
+                except Exception as e:
+                    return self._send(200, {"path": None, "error": str(e)})
+            if route.startswith("/api/job/"):
+                with _jobs_lock:
+                    job = _jobs.get(route.rsplit("/", 1)[1])
+                return self._send(200, job or {"status": "unknown"})
+            if route == "/api/polygons":
+                with _polygons_lock:
+                    data = _read_json(_polygons_path(), {"polygons": []})
+                    if "groups" in data:   # migrate the old grouped format
+                        flat = []
+                        for g in data.get("groups", []):
+                            for p in g.get("polygons", []):
+                                if not any(q["name"] == p["name"] for q in flat):
+                                    flat.append({k: p[k] for k in ("name", "verts", "color") if k in p})
+                        data = {"polygons": flat}
+                        _write_json(_polygons_path(), data)
+                    return self._send(200, data)
+            if route == "/api/classify/progress":
+                return self._send(200, _classify_progress.get(qs.get("bundle", [""])[0], {}))
+            if route.startswith("/data/"):
+                parts = route.split("/")
+                if len(parts) == 4:
+                    sim = registry_find(urllib.parse.unquote(parts[2]))
+                    fname = os.path.basename(urllib.parse.unquote(parts[3]))
+                    if sim:
+                        fpath = Path(sim["bundle_dir"]) / fname
+                        ctype = ("application/json" if fname.endswith(".json")
+                                 else "image/png" if fname.endswith(".png")
+                                 else "application/octet-stream")
+                        return self._send_file(fpath, ctype, cache=not fname.endswith(".json"))
+                return self._send(404, {"error": "not found"})
+            return self._send(404, {"error": "not found"})
+        except Exception as e:
+            traceback.print_exc()
+            return self._send(500, {"error": str(e)})
+
+    def _raw_body(self):
+        length = int(self.headers.get("Content-Length", 0))
+        return self.rfile.read(length)
+
+    def do_POST(self):
+        try:
+            parsed = urllib.parse.urlparse(self.path)
+            route = parsed.path
+            qs = urllib.parse.parse_qs(parsed.query)
+
+            # raw-binary routes (no JSON body)
+            if route == "/api/savefile":
+                path = qs.get("path", [""])[0]
+                if not path or Path(path).suffix.lower() not in (".png", ".mp4", ".webm", ".txt", ".json"):
+                    return self._send(400, {"error": "invalid save path"})
+                data = self._raw_body()
+                Path(path).parent.mkdir(parents=True, exist_ok=True)
+                Path(path).write_bytes(data)
+                _log(f"saved {len(data)/1e6:.1f} MB -> {path}")
+                return self._send(200, {"ok": True, "bytes": len(data)})
+            if route == "/api/video/frame":
+                job = _video_jobs.get(qs.get("job", [""])[0])
+                if not job:
+                    return self._send(400, {"error": "unknown video job"})
+                i = int(qs.get("i", ["0"])[0])
+                (Path(job["dir"]) / f"{i:06d}.png").write_bytes(self._raw_body())
+                job["frames"] = max(job["frames"], i + 1)
+                return self._send(200, {"ok": True})
+
+            body = self._json_body()
+
+            if route == "/api/connectivity/compute":
+                return self._send(200, connectivity.compute(
+                    body["bundle_id"], body.get("polygons", []),
+                    body.get("mode", "start_end"), body.get("normalize", "count")))
+            if route == "/api/polygons/auto":
+                return self._send(200, connectivity.auto_polygons(
+                    body["forcing_id"], body.get("n", 12), body.get("var")))
+            if route == "/api/run/start":
+                try:
+                    return self._send(200, run_manager.start(body["config_path"]))
+                except RuntimeError as e:
+                    return self._send(409, {"error": str(e)})
+            if route == "/api/run/stop":
+                return self._send(200, run_manager.stop())
+            if route == "/api/seeding/preview":
+                return self._send(200, seeding_api.preview(
+                    body.get("population", {}), body.get("base"),
+                    bool(body.get("count_only"))))
+            if route == "/api/forcing/open":
+                return self._send(200, forcing.open_forcing(body["path"],
+                                                            body.get("base")))
+            if route == "/api/config/load":
+                return self._send(200, config_api.load_config(body["path"]))
+            if route == "/api/config/save":
+                return self._send(200, config_api.save_config(body["path"], body["config"]))
+            if route == "/api/config/validate":
+                return self._send(200, config_api.validate_config(body.get("config", {})))
+            if route == "/api/config/template":
+                return self._send(200, config_api.create_template())
+            if route == "/api/config/estimate":
+                return self._send(200, config_api.estimate(body.get("config", {})))
+            if route == "/api/config/result":
+                # where a run of this config writes its output (mirrors run_manager.start)
+                cfg_path = Path(body.get("config_path", "")).resolve()
+                if not cfg_path.is_file():
+                    return self._send(400, {"error": f"config not found: {cfg_path}"})
+                loaded = config_api.load_config(str(cfg_path))
+                out_dir = (loaded["config"].get("outputs", {}) or {}).get("directory", "./output")
+                rp = (cfg_path.parent / out_dir).resolve() / "sedtrails_results.nc"
+                out = {"path": str(rp), "exists": rp.is_file()}
+                if out["exists"]:
+                    st = rp.stat()          # matches bundle source_signature
+                    out["size"] = int(st.st_size)
+                    out["mtime"] = int(st.st_mtime)
+                return self._send(200, out)
+
+            if route == "/api/import":
+                nc_path = body.get("nc_path", "")
+                if not os.path.isfile(nc_path):
+                    return self._send(400, {"error": f"file not found: {nc_path}"})
+                job_id = uuid.uuid4().hex[:12]
+                job = {"id": job_id, "status": "running", "progress": 0.0,
+                       "message": "starting", "bundle": None}
+                with _jobs_lock:
+                    _jobs[job_id] = job
+
+                def work():
+                    try:
+                        meta = import_run(nc_path, body.get("forcing_path") or None,
+                                          body.get("name") or None, job,
+                                          body.get("grid_path") or None)
+                        job["bundle"] = meta["id"]
+                        job["status"] = "done"
+                    except MemoryError:
+                        traceback.print_exc()
+                        job["status"] = "error"
+                        job["message"] = ("not enough free memory for the import — close "
+                                          "other applications and retry, or lower SLAB_STEPS "
+                                          "in backend/settings.py")
+                    except Exception as e:
+                        traceback.print_exc()
+                        job["status"] = "error"
+                        job["message"] = f"{type(e).__name__}: {e}"
+
+                threading.Thread(target=work, daemon=True).start()
+                return self._send(200, {"job_id": job_id})
+
+            if route == "/api/polygons":
+                with _polygons_lock:
+                    _write_json(_polygons_path(), {"polygons": body.get("polygons", [])})
+                return self._send(200, {"ok": True})
+
+            if route == "/api/polygons/import":
+                path = body.get("path", "")
+                if os.path.isdir(path):
+                    polys = import_polygon_dir(path, body.get("pattern", "*.txt"))
+                elif os.path.isfile(path):
+                    verts = load_poly_txt(path)
+                    polys = ([{"name": Path(path).stem, "verts": verts}]
+                             if len(verts) >= 3 else [])
+                else:
+                    return self._send(400, {"error": f"path not found: {path}"})
+                return self._send(200, {"polygons": polys})
+
+            if route == "/api/classify":
+                payload = classify(body["bundle_id"], body.get("polygons", []))
+                return self._send(200, payload, ctype="application/octet-stream")
+
+            if route == "/api/video/start":
+                path = body.get("path", "")
+                if not path or not path.lower().endswith(".mp4"):
+                    return self._send(400, {"error": "choose an .mp4 output path first"})
+                import shutil as _sh
+                import tempfile
+                if not _sh.which("ffmpeg"):
+                    return self._send(400, {"error": "ffmpeg not found on PATH — "
+                                            "install ffmpeg to export MP4"})
+                job_id = uuid.uuid4().hex[:12]
+                _video_jobs[job_id] = {"dir": tempfile.mkdtemp(prefix="stviewer_vid_"),
+                                       "path": path, "fps": int(body.get("fps", 12)),
+                                       "frames": 0}
+                return self._send(200, {"job": job_id})
+
+            if route == "/api/video/finish":
+                import shutil as _sh
+                import subprocess
+                job = _video_jobs.pop(body.get("job", ""), None)
+                if not job:
+                    return self._send(400, {"error": "unknown video job"})
+                try:
+                    if job["frames"] == 0:
+                        raise ValueError("no frames received")
+                    cmd = ["ffmpeg", "-y", "-framerate", str(job["fps"]),
+                           "-i", str(Path(job["dir"]) / "%06d.png"),
+                           "-c:v", "libx264", "-pix_fmt", "yuv420p", "-crf", "18",
+                           job["path"]]
+                    res = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+                    if res.returncode != 0:
+                        raise RuntimeError("ffmpeg failed: " + res.stderr[-400:])
+                    _log(f"video: {job['frames']} frames @ {job['fps']} fps -> {job['path']}")
+                    return self._send(200, {"ok": True, "frames": job["frames"]})
+                except Exception as e:
+                    return self._send(500, {"error": str(e)})
+                finally:
+                    _sh.rmtree(job["dir"], ignore_errors=True)
+
+            if route == "/api/forget":
+                with _registry_lock:
+                    reg = load_registry()
+                    reg["simulations"] = [s for s in reg["simulations"]
+                                          if s["id"] != body.get("bundle_id")]
+                    hid = reg.setdefault("hidden", [])
+                    if body.get("bundle_id") and body["bundle_id"] not in hid:
+                        hid.append(body["bundle_id"])
+                    save_registry(reg)
+                return self._send(200, {"ok": True})
+
+            return self._send(404, {"error": "not found"})
+        except Exception as e:
+            traceback.print_exc()
+            return self._send(500, {"error": str(e)})
+
+
+class QuietServer(ThreadingHTTPServer):
+    # On Windows, SO_REUSEADDR lets a second instance silently share the port
+    # with a stale one (requests then hit an unpredictable server). Fail
+    # instead — main() moves to the next port.
+    allow_reuse_address = False
+
+    def handle_error(self, request, client_address):
+        # Browsers slam their keep-alive sockets on tab close/reload — routine.
+        exc = sys.exception()
+        if isinstance(exc, (ConnectionResetError, ConnectionAbortedError, BrokenPipeError)):
+            return
+        super().handle_error(request, client_address)

--- a/sedtrails-gui/backend/httpd.py
+++ b/sedtrails-gui/backend/httpd.py
@@ -18,7 +18,7 @@ from .run_manager import MANAGER as run_manager
 from .bundle import (_classify_progress, _polygons_lock, _polygons_path,
                      _registry_lock, classify, import_polygon_dir, import_run,
                      load_poly_txt, load_registry, registry_find, save_registry)
-from .settings import WEB_DIR
+from .settings import APP_DIR, VIEWER_APP_DIR, WEB_DIR
 from .util import (_browse, _jobs, _jobs_lock, _log, _read_json, _video_jobs,
                    _write_json, native_pick, native_save)
 
@@ -91,6 +91,25 @@ class GuiHandler(BaseHTTPRequestHandler):
                 return self._send_file(fpath, ctype, cache=False)
             if route == "/api/registry":
                 return self._send(200, load_registry())
+            if route == "/api/appinfo":
+                # every place the GUI writes/caches data on disk
+                locs = [{"label": "App data — simulation registry + drawn objects",
+                         "path": str(APP_DIR),
+                         "note": "registry.json (imported simulations), polygons.json (drawn objects)"}]
+                if VIEWER_APP_DIR.is_dir():
+                    locs.append({"label": "Standalone-viewer app data (merged read-only)",
+                                 "path": str(VIEWER_APP_DIR), "note": ""})
+                for s in load_registry()["simulations"]:
+                    locs.append({"label": f"Result bundle — {s.get('name') or s['id']}",
+                                 "path": s["bundle_dir"],
+                                 "note": "cached tracks / mesh / classification, next to the result file"})
+                for f in forcing._store.values():
+                    locs.append({"label": f"Forcing cache — {Path(f['path']).name}",
+                                 "path": str(f["cache_dir"]),
+                                 "note": "cached Voronoi mesh, next to the forcing file"})
+                for loc in locs:
+                    loc["exists"] = os.path.isdir(loc["path"])
+                return self._send(200, {"locations": locs})
             if route == "/api/schema":
                 return self._send(200, config_api.get_schemas())
             if route == "/api/run/status":
@@ -199,6 +218,16 @@ class GuiHandler(BaseHTTPRequestHandler):
 
             body = self._json_body()
 
+            if route == "/api/openfolder":
+                p = Path(body.get("path", ""))
+                if not p.is_dir():
+                    return self._send(400, {"error": f"folder not found: {p}"})
+                if sys.platform == "win32":
+                    os.startfile(str(p))
+                else:
+                    import subprocess
+                    subprocess.Popen(["open" if sys.platform == "darwin" else "xdg-open", str(p)])
+                return self._send(200, {"ok": True})
             if route == "/api/connectivity/compute":
                 return self._send(200, connectivity.compute(
                     body["bundle_id"], body.get("polygons", []),

--- a/sedtrails-gui/backend/run_manager.py
+++ b/sedtrails-gui/backend/run_manager.py
@@ -1,0 +1,252 @@
+"""Run tab backend: launch `sedtrails run` as a subprocess, stream its log,
+and report progress from the incrementally-written output netCDF.
+
+Progress source (in order of preference):
+1. global attrs `written_slots` / `estimated_output_slots` on sedtrails_results.nc
+   (updated per save slot by sedtrails' NetCDFWriter),
+2. the tqdm progress bar sedtrails prints to stderr (parsed live from the log
+   stream — tqdm updates with carriage returns, so the reader splits on \\r too),
+3. output file size vs. the estimated uncompressed payload,
+while the log ring buffer feeds the live log pane. HDF5 may refuse to open a
+file the writer holds (Windows locking) — every probe is try/except.
+"""
+
+import os
+import re
+import subprocess
+import sys
+import threading
+import time
+from collections import deque
+from pathlib import Path
+
+from . import config_api
+from .util import NC_LOCK, _log
+
+MAX_LOG_LINES = 8000
+_TQDM_PCT = re.compile(r"(\d+(?:\.\d+)?)%\|")
+_TQDM_ETA = re.compile(r"<((?:\d+:)?\d+:\d+)")   # [elapsed<remaining, rate]
+
+
+def _hms_to_s(txt):
+    parts = [int(x) for x in txt.split(":")]
+    s = 0
+    for p in parts:
+        s = s * 60 + p
+    return s
+
+
+class RunManager:
+    def __init__(self):
+        self._lock = threading.Lock()
+        self.proc = None
+        self.state = "idle"          # idle | running | done | error | stopped
+        self.returncode = None
+        self.started = None
+        self.ended = None
+        self.config_path = None
+        self.result_path = None
+        self.estimate = None         # config_api.estimate() result at start
+        self.lines = []              # ring buffer
+        self.base_offset = 0         # offset of lines[0]
+        self._probe = {"at": 0.0, "progress": None}
+        self._rate = deque(maxlen=24)   # (t, written_slots) for ETA
+        self._brate = deque(maxlen=24)  # (t, bytes) for the size-fallback ETA
+        self._tqdm = None               # {"pct", "eta_s", "at"} parsed from the log
+        self._cr_open = False           # last ring-buffer line is a \r-updated line
+
+    # ── lifecycle ──────────────────────────────────────────────────────────
+    def start(self, config_path):
+        with self._lock:
+            if self.proc is not None and self.proc.poll() is None:
+                raise RuntimeError("a run is already in progress")
+            cfg_path = Path(config_path).resolve()
+            if not cfg_path.is_file():
+                raise FileNotFoundError(f"config not found: {cfg_path}")
+
+            loaded = config_api.load_config(str(cfg_path))
+            cfg = loaded["config"]
+            out_dir = (cfg.get("outputs", {}) or {}).get("directory", "./output")
+            out_dir = (cfg_path.parent / out_dir).resolve()
+            self.result_path = str(out_dir / "sedtrails_results.nc")
+            self.estimate = config_api.estimate(cfg)
+
+            creationflags = subprocess.CREATE_NEW_PROCESS_GROUP if os.name == "nt" else 0
+            env = dict(os.environ)
+            env.pop("HDF5_USE_FILE_LOCKING", None)   # writer keeps default locking
+            # sedtrails disables its tqdm bar on non-TTY stderr; this opt-in
+            # keeps it printing so the GUI can parse live progress from the log
+            env["SEDTRAILS_FORCE_PROGRESS"] = "1"
+            self.proc = subprocess.Popen(
+                [sys.executable, "-u", "-c",
+                 "from sedtrails.application_interfaces.cli import app; app()",
+                 "run", "--config", str(cfg_path)],
+                cwd=str(cfg_path.parent),
+                stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                creationflags=creationflags, env=env)
+            self.state = "running"
+            self.returncode = None
+            self.started = time.time()
+            self.ended = None
+            self.config_path = str(cfg_path)
+            self.lines = []
+            self.base_offset = 0
+            self._probe = {"at": 0.0, "progress": None}
+            self._rate.clear()
+            self._brate.clear()
+            self._tqdm = None
+            self._cr_open = False
+            threading.Thread(target=self._reader, daemon=True).start()
+            _log(f"run started: {cfg_path} (pid {self.proc.pid}) -> {self.result_path}")
+            return {"ok": True, "pid": self.proc.pid, "result_path": self.result_path}
+
+    def _ingest(self, text, ends_with_cr):
+        """One log segment (split on \\n OR \\r). \\r segments (tqdm updates)
+        replace the previous \\r segment in the ring buffer instead of
+        appending, and are parsed for pct/ETA."""
+        m = _TQDM_PCT.search(text)
+        if m:
+            eta = _TQDM_ETA.search(text)
+            self._tqdm = {"pct": float(m.group(1)),
+                          "eta_s": float(_hms_to_s(eta.group(1))) if eta else None,
+                          "at": time.time()}
+        if self._cr_open and self.lines:
+            if text:
+                self.lines[-1] = text
+            self._cr_open = ends_with_cr
+            return
+        if text or not ends_with_cr:
+            self.lines.append(text)
+            if len(self.lines) > MAX_LOG_LINES:
+                drop = len(self.lines) - MAX_LOG_LINES
+                del self.lines[:drop]
+                self.base_offset += drop
+        self._cr_open = ends_with_cr
+
+    def _reader(self):
+        proc = self.proc
+        try:
+            fd = proc.stdout.fileno()
+            buf = b""
+            while True:
+                chunk = os.read(fd, 8192)
+                if not chunk:
+                    break
+                buf += chunk
+                while True:
+                    i_n = buf.find(b"\n")
+                    i_r = buf.find(b"\r")
+                    idx = min(x for x in (i_n, i_r) if x >= 0) if max(i_n, i_r) >= 0 else -1
+                    if idx < 0:
+                        break
+                    seg = buf[:idx].decode("utf-8", "replace")
+                    is_cr = buf[idx:idx + 1] == b"\r"
+                    buf = buf[idx + 1:]
+                    self._ingest(seg, is_cr)
+            if buf:
+                self._ingest(buf.decode("utf-8", "replace"), False)
+        except (ValueError, OSError):
+            pass
+        proc.wait()
+        self.returncode = proc.returncode
+        self.ended = time.time()
+        if self.state == "running":
+            self.state = "done" if proc.returncode == 0 else "error"
+        _log(f"run finished: rc={proc.returncode} ({self.state})")
+
+    def stop(self):
+        with self._lock:
+            if self.proc is None or self.proc.poll() is not None:
+                return {"ok": True, "note": "no run in progress"}
+            self.state = "stopped"
+            pid = self.proc.pid
+            if os.name == "nt":
+                # /T kills the whole tree (parallel runs fork worker processes)
+                subprocess.run(["taskkill", "/T", "/F", "/PID", str(pid)],
+                               capture_output=True)
+            else:
+                self.proc.terminate()
+            _log(f"run stopped (pid {pid})")
+            return {"ok": True}
+
+    # ── progress ───────────────────────────────────────────────────────────
+    def _probe_progress(self):
+        now = time.time()
+        if now - self._probe["at"] < 2.0:
+            return self._probe["progress"]
+        prog = {"written_slots": None, "total_slots": None, "pct": None,
+                "eta_s": None, "bytes": None, "est_bytes": None}
+        est = self.estimate or {}
+        prog["est_bytes"] = est.get("bytes")
+        prog["total_slots"] = est.get("slots")
+        rp = self.result_path
+        # ignore a result file left over from a PREVIOUS run (its attrs would
+        # show stale/complete progress until the new writer recreates it)
+        if rp and self.started and os.path.exists(rp):
+            try:
+                if os.path.getmtime(rp) < self.started - 1.0:
+                    rp = None
+            except OSError:
+                rp = None
+        if rp and os.path.exists(rp):
+            try:
+                prog["bytes"] = os.path.getsize(rp)
+            except OSError:
+                pass
+            try:
+                import netCDF4 as nc
+                with NC_LOCK, nc.Dataset(rp, "r") as ds:
+                    w = getattr(ds, "written_slots", None)
+                    t = getattr(ds, "estimated_output_slots", None)
+                    if w is not None:
+                        prog["written_slots"] = int(w)
+                    if t is not None:
+                        prog["total_slots"] = int(t)
+            except Exception:
+                pass                       # writer holds the file — size fallback
+        w, t = prog["written_slots"], prog["total_slots"]
+        if w is not None and t:
+            prog["pct"] = min(100.0, w / max(t, 1) * 100.0)
+            self._rate.append((now, w))
+            if len(self._rate) >= 2:
+                (t0, w0), (t1, w1) = self._rate[0], self._rate[-1]
+                if w1 > w0:
+                    prog["eta_s"] = max(0.0, (t - w1) * (t1 - t0) / (w1 - w0))
+        elif self._tqdm is not None:
+            # tqdm bar parsed from the live log (% of simulated time)
+            prog["pct"] = min(100.0, self._tqdm["pct"])
+            prog["eta_s"] = self._tqdm["eta_s"]
+            prog["source"] = "log"
+        elif prog["bytes"] and prog["est_bytes"]:
+            prog["pct"] = min(99.0, prog["bytes"] / prog["est_bytes"] * 100.0)
+            self._brate.append((now, prog["bytes"]))
+            if len(self._brate) >= 2:
+                (t0, b0), (t1, b1) = self._brate[0], self._brate[-1]
+                if b1 > b0:
+                    prog["eta_s"] = max(0.0, (prog["est_bytes"] - b1) * (t1 - t0) / (b1 - b0))
+        self._probe = {"at": now, "progress": prog}
+        return prog
+
+    def status(self):
+        running = self.proc is not None and self.proc.poll() is None
+        if not running and self.state == "running":
+            time.sleep(0.1)               # reader thread is finishing up
+        st = {"state": self.state, "returncode": self.returncode,
+              "config_path": self.config_path, "result_path": self.result_path,
+              "started": self.started,
+              "elapsed": (self.ended or time.time()) - self.started if self.started else None,
+              "log_length": self.base_offset + len(self.lines)}
+        st["progress"] = self._probe_progress() if self.started else None
+        if self.state in ("done", "error", "stopped") and st["progress"]:
+            st["progress"]["eta_s"] = None
+        return st
+
+    def get_log(self, offset):
+        offset = max(int(offset), self.base_offset)
+        rel = offset - self.base_offset
+        lines = self.lines[rel:]
+        return {"offset": offset + len(lines), "lines": lines,
+                "truncated": offset > 0 and rel == 0 and self.base_offset > 0}
+
+
+MANAGER = RunManager()

--- a/sedtrails-gui/backend/seeding_api.py
+++ b/sedtrails-gui/backend/seeding_api.py
@@ -1,0 +1,63 @@
+"""Seeding tab backend: WYSIWYG preview of a population's seed locations.
+
+Runs the population dict through sedtrails' own PopulationConfig + seeding
+strategies (particle_seeder.py), so the preview matches the simulation exactly
+— including numpy RNG seeds for the random strategy.
+"""
+
+import copy
+from pathlib import Path
+
+from .util import resolve_input_path
+
+MAX_POINTS = 50_000
+
+
+def _resolve_paths(strategy_settings, base):
+    """Make pol_file / poly / path entries absolute against the config dir."""
+    for key in ("pol_file", "poly", "path"):
+        v = strategy_settings.get(key)
+        if isinstance(v, str) and v:
+            cand = resolve_input_path(v, base)
+            if cand.exists():
+                strategy_settings[key] = str(cand)
+
+
+def preview(population, base=None, count_only=False):
+    """Seed locations for one population dict. Returns
+    {n_locations, n_particles, quantity, points?: [[x,y],...], capped}."""
+    from sedtrails.particle_tracer.particle_seeder import PopulationConfig
+
+    pop = copy.deepcopy(population or {})
+    pop.setdefault("particle_type", "passive")
+    seeding = pop.setdefault("seeding", {})
+    seeding.setdefault("quantity", 1)
+    if not seeding.get("burial_depth"):
+        seeding["burial_depth"] = {"constant": 0}
+    strategy = seeding.get("strategy") or {}
+    if not strategy:
+        raise ValueError("no seeding strategy set for this population")
+    name = next(iter(strategy))
+    if isinstance(strategy[name], dict):
+        _resolve_paths(strategy[name], base)
+
+    config = PopulationConfig(population_config=pop)
+    # dispatch exactly like ParticleFactory.create_particles does
+    from sedtrails.particle_tracer.particle_seeder import (
+        FilePointsStrategy, GridStrategy, PointStrategy, RandomStrategy, TransectStrategy)
+    STRATEGY_MAP = {"point": PointStrategy(), "random": RandomStrategy(),
+                    "grid": GridStrategy(), "transect": TransectStrategy(),
+                    "file_points": FilePointsStrategy()}
+    if config.strategy.lower() not in STRATEGY_MAP:
+        raise ValueError(f"unknown seeding strategy: {config.strategy}")
+
+    positions = STRATEGY_MAP[config.strategy.lower()].seed(config)
+    n_loc = len(positions)
+    n_particles = sum(int(q) for q, _, _ in positions)
+    out = {"n_locations": n_loc, "n_particles": n_particles,
+           "quantity": int(config.quantity), "strategy": config.strategy,
+           "capped": n_loc > MAX_POINTS}
+    if not count_only:
+        pts = positions[:MAX_POINTS]
+        out["points"] = [[round(float(x), 2), round(float(y), 2)] for _, x, y in pts]
+    return out

--- a/sedtrails-gui/backend/seeding_api.py
+++ b/sedtrails-gui/backend/seeding_api.py
@@ -6,7 +6,6 @@ strategies (particle_seeder.py), so the preview matches the simulation exactly
 """
 
 import copy
-from pathlib import Path
 
 from .util import resolve_input_path
 

--- a/sedtrails-gui/backend/settings.py
+++ b/sedtrails-gui/backend/settings.py
@@ -1,0 +1,25 @@
+"""Shared configuration constants for the SedTRAILS GUI backend."""
+
+from pathlib import Path
+
+DATA_ROOTS = []                  # extra browse roots (absolute paths); drives + home are added automatically
+
+BG_WIDTH_PX = 6144               # width of generated background images (height from aspect)
+BG_ELEV_PCTL = (2.0, 98.0)       # percentile color limits for the bathymetry background
+BG_DZ_PCTL = 98.0                # symmetric percentile limit for the bed-change background
+CMAP_NPY = None                  # optional path to an (N,3)/(N,4) .npy colormap for the bathymetry
+
+SLAB_STEPS = 8                   # timesteps per read slab for time-major files
+SLAB_PARTICLES = 50_000          # particles per read slab for particle-major files
+LOAD_WHOLE_LIMIT = 2 * 1024**3   # particle-major files smaller than this (per variable) load in one go
+PAD_FRAC = 0.02                  # extent padding around the data bounding box
+REFERENCE_DATE_FALLBACK = "2017-12-01"  # used when the time variable has no CF units
+
+APP_DIR = Path.home() / ".sedtrails_gui"
+VIEWER_APP_DIR = Path.home() / ".sedtrails_viewer"  # old standalone-viewer registry, merged read-only
+FORMAT_VERSION = 1
+SENTINEL = 65535
+QMAX = 65534
+
+TOOL_DIR = Path(__file__).resolve().parent.parent
+WEB_DIR = TOOL_DIR / "web"

--- a/sedtrails-gui/backend/util.py
+++ b/sedtrails-gui/backend/util.py
@@ -1,0 +1,180 @@
+"""Small shared helpers: logging, JSON files, browse, native dialogs, jobs.
+
+Extracted verbatim from sedtrails-viewer/sedtrails_viewer.py (Phase 0 split).
+"""
+
+import json
+import os
+import re
+import string
+import threading
+import time
+from pathlib import Path
+
+import numpy as np
+
+from . import settings as cfg
+
+_jobs = {}
+_video_jobs = {}
+_jobs_lock = threading.Lock()
+
+# HDF5 (and therefore netCDF4) is NOT thread-safe: concurrent reads from the
+# threaded HTTP server crash the whole process with an access violation.
+# Every netCDF4 open/read/close in this backend must hold this lock.
+NC_LOCK = threading.RLock()
+
+
+# ── Small helpers ──────────────────────────────────────────────────────────────
+def resolve_input_path(path, base=None):
+    """Resolve a user/config-supplied file path robustly.
+
+    - POSIX drive mounts from HPC configs (``/p/...``) map to the drive letter
+      on Windows (``P:\\...``) — the H7 cluster mounts network drives that way.
+    - Absolute or drive-anchored paths (``p:\\...``, ``\\\\server\\...``) are
+      NEVER joined onto ``base`` (joining used to mangle ``p:\\x`` → ``C:\\p\\x``).
+    - Only genuinely relative paths resolve against ``base`` (the config dir).
+    """
+    raw = str(path).strip()
+    p = Path(raw)
+    fwd = raw.replace("\\", "/")
+    if os.name == "nt":
+        m = re.match(r"^/([A-Za-z])(/.*)?$", fwd)
+        if m:
+            p = Path(m.group(1).upper() + ":" + (m.group(2) or "/"))
+    anchored = p.is_absolute() or re.match(r"^[A-Za-z]:", raw) or fwd.startswith("/")
+    if not anchored and base:
+        p = Path(base) / p
+    return p.resolve()
+
+
+def _log(msg):
+    print(f"[{time.strftime('%H:%M:%S')}] {msg}", flush=True)
+
+
+def _read_json(path, default):
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, ValueError):
+        return default
+
+
+def _write_json(path, obj):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(obj, f, indent=1)
+    os.replace(tmp, path)
+
+
+def _nanfilled(var_slice):
+    """netCDF4 slice → plain float array with masked/fill values as NaN.
+
+    Kept memory-lean (in-place fill-value replacement, no masked-array
+    wrappers): import slabs on big runs are hundreds of MB each and the
+    viewer must survive on low-RAM machines.
+    """
+    arr = var_slice
+    if isinstance(arr, np.ma.MaskedArray):
+        arr = arr.filled(np.nan)
+    arr = np.asarray(arr, dtype=np.float64)
+    arr[arr > 1e30] = np.nan
+    arr[arr < -1e30] = np.nan
+    return arr
+
+
+# ── Native file picker ─────────────────────────────────────────────────────────
+_picker_lock = threading.Lock()
+
+
+def native_save(ext, suggest=None, initial_dir=None):
+    """Native 'Save as…' dialog on the server machine. '' = cancelled."""
+    import tkinter as tk
+    from tkinter import filedialog
+
+    with _picker_lock:
+        root = tk.Tk()
+        root.withdraw()
+        root.attributes("-topmost", True)
+        try:
+            return filedialog.asksaveasfilename(
+                parent=root, initialdir=initial_dir or None,
+                initialfile=suggest or None, defaultextension=ext,
+                filetypes=[(ext.upper().strip('.') + " file", "*" + ext)]) or ""
+        finally:
+            root.destroy()
+
+
+def native_pick(kind, initial_dir=None):
+    """Open a native OS file dialog (the server runs on the user's machine).
+
+    kind: 'nc' (single netCDF), 'txt' (multiple polygon txts), 'yaml' (single
+    yaml config), 'dir' (folder). Returns a list of paths (empty = cancelled).
+    Raises if tkinter unavailable (headless session) — the viewer then falls
+    back to its built-in browser.
+    """
+    import tkinter as tk
+    from tkinter import filedialog
+
+    with _picker_lock:
+        root = tk.Tk()
+        root.withdraw()
+        root.attributes("-topmost", True)
+        try:
+            if kind == "dir":
+                p = filedialog.askdirectory(initialdir=initial_dir or None, parent=root)
+                return [p] if p else []
+            if kind == "yaml":
+                p = filedialog.askopenfilename(
+                    initialdir=initial_dir or None, parent=root,
+                    title="Select SedTRAILS config",
+                    filetypes=[("YAML files", "*.yaml *.yml"), ("All files", "*.*")])
+                return [p] if p else []
+            if kind == "txt":
+                ps = filedialog.askopenfilenames(
+                    initialdir=initial_dir or None, parent=root,
+                    title="Select polygon file(s)",
+                    filetypes=[("Polygon text files", "*.txt"), ("All files", "*.*")])
+                return list(ps)
+            p = filedialog.askopenfilename(
+                initialdir=initial_dir or None, parent=root,
+                title="Select netCDF file",
+                filetypes=[("netCDF files", "*.nc"), ("All files", "*.*")])
+            return [p] if p else []
+        finally:
+            root.destroy()
+
+
+def _browse(dir_param):
+    if not dir_param:
+        roots = []
+        for d in string.ascii_uppercase:
+            drive = f"{d}:\\"
+            if os.path.exists(drive):
+                roots.append(drive)
+        roots.append(str(Path.home()))
+        roots.extend(str(Path(r)) for r in cfg.DATA_ROOTS if os.path.exists(r))
+        return {"dir": "", "parent": None,
+                "dirs": [{"name": r, "path": r} for r in dict.fromkeys(roots)],
+                "files": []}
+    d = Path(dir_param)
+    if not d.is_dir():
+        raise ValueError(f"not a directory: {dir_param}")
+    dirs, files = [], []
+    try:
+        entries = sorted(os.scandir(d), key=lambda e: e.name.lower())
+    except PermissionError:
+        entries = []
+    for e in entries:
+        try:
+            if e.is_dir():
+                if not e.name.startswith("."):
+                    dirs.append({"name": e.name, "path": str(Path(d) / e.name)})
+            elif e.name.lower().endswith((".nc", ".txt", ".yaml", ".yml")):
+                files.append({"name": e.name, "path": str(Path(d) / e.name),
+                              "size": e.stat().st_size})
+        except OSError:
+            continue
+    parent = str(d.parent) if d.parent != d else ""
+    return {"dir": str(d), "parent": parent, "dirs": dirs, "files": files}

--- a/sedtrails-gui/sedtrails_gui.py
+++ b/sedtrails-gui/sedtrails_gui.py
@@ -37,13 +37,13 @@ OPEN_BROWSER = True
 APP_WINDOW = True                # own window without address bar (Edge/Chrome); False = normal browser tab
 DATA_ROOTS = []                  # extra browse roots (absolute paths); drives + home are added automatically
 
-from backend import settings
+from backend import settings  # noqa: E402  (after the env-var setup above)
 
 settings.DATA_ROOTS = DATA_ROOTS
 
-from backend.bundle import load_registry
-from backend.httpd import GuiHandler, QuietServer
-from backend.util import _log
+from backend.bundle import load_registry  # noqa: E402
+from backend.httpd import GuiHandler, QuietServer  # noqa: E402
+from backend.util import _log  # noqa: E402
 
 
 def _open_window(url):

--- a/sedtrails-gui/sedtrails_gui.py
+++ b/sedtrails-gui/sedtrails_gui.py
@@ -1,0 +1,100 @@
+"""
+SedTRAILS GUI — configure, seed, run and inspect SedTRAILS simulations.
+
+Run directly (VS Code / terminal):
+
+    python sedtrails_gui.py
+
+Opens its own app window (Edge/Chrome, no address bar) serving
+http://127.0.0.1:8766/ — set APP_WINDOW = False for a plain browser tab.
+Tabs: Settings, Populations, Run, Viewer (particles + forcing), Connectivity.
+The Viewer tab is the full standalone sedtrails-viewer; the standalone tool
+remains untouched next to this one and both can run side by side (different
+ports, separate registries — bundles imported with the old viewer show up
+here automatically).
+
+Dependencies: numpy, netCDF4. Optional: matplotlib + scipy (model layers,
+classification), tkinter (native file dialogs), ffmpeg (MP4 export), and the
+sedtrails package + jsonschema (Settings / Seeding / Run sections).
+
+More constants (slab sizes, browse roots, app dir): backend/settings.py.
+"""
+
+import os
+import sys
+import threading
+import webbrowser
+
+# Let the GUI peek at run progress (written_slots) in the output netCDF while
+# sedtrails is still writing it — Windows HDF5 locking would refuse otherwise.
+# The launched run itself gets this stripped from its environment (run_manager).
+os.environ.setdefault("HDF5_USE_FILE_LOCKING", "FALSE")
+
+# ── Configuration ──────────────────────────────────────────────────────────────
+HOST = "127.0.0.1"
+PORT = 8766                      # auto-increments if taken
+OPEN_BROWSER = True
+APP_WINDOW = True                # own window without address bar (Edge/Chrome); False = normal browser tab
+DATA_ROOTS = []                  # extra browse roots (absolute paths); drives + home are added automatically
+
+from backend import settings
+
+settings.DATA_ROOTS = DATA_ROOTS
+
+from backend.bundle import load_registry
+from backend.httpd import GuiHandler, QuietServer
+from backend.util import _log
+
+
+def _open_window(url):
+    """Open the GUI in its own app window (no tabs / address bar) via a
+    Chromium browser's --app mode; falls back to a normal browser tab."""
+    import shutil
+    import subprocess
+    candidates = [
+        shutil.which("msedge"),
+        shutil.which("chrome"),
+        r"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe",
+        r"C:\Program Files\Microsoft\Edge\Application\msedge.exe",
+        r"C:\Program Files\Google\Chrome\Application\chrome.exe",
+        r"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe",
+    ]
+    for exe in candidates:
+        if exe and os.path.exists(exe):
+            subprocess.Popen([exe, f"--app={url}"])
+            return
+    webbrowser.open(url)
+
+
+def main():
+    import faulthandler
+    faulthandler.enable()  # a hard crash (e.g. in the netCDF C library) prints a trace
+    settings.APP_DIR.mkdir(parents=True, exist_ok=True)
+    port = PORT
+    for _ in range(21):
+        try:
+            server = QuietServer((HOST, port), GuiHandler)
+            break
+        except OSError:
+            port += 1
+    else:
+        _log("no free port found")
+        sys.exit(1)
+
+    url = f"http://{HOST}:{port}/"
+    reg = load_registry()
+    _log("SedTRAILS GUI")
+    _log(f"  serving {settings.WEB_DIR / 'index.html'}")
+    _log(f"  {len(reg['simulations'])} simulation(s) in registry")
+    _log(f"  open {url}")
+    if OPEN_BROWSER:
+        opener = _open_window if APP_WINDOW else webbrowser.open
+        threading.Timer(0.4, lambda: opener(url)).start()
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        _log("stopped")
+
+
+if __name__ == "__main__":
+    main()

--- a/sedtrails-gui/web/css/app.css
+++ b/sedtrails-gui/web/css/app.css
@@ -281,18 +281,18 @@
 /* save buttons: clean monochrome icons right of the logo; a small accent dot
    marks unsaved changes (class .attn, set in settings.js updateChip) */
 #tb-actions { display: flex; gap: 5px; align-items: center; }
-#tb-actions button {
+#tb-actions button, #tb-appdata {
   display: flex; align-items: center; gap: 2px; position: relative;
   background: none; border: 1px solid var(--border); border-radius: 6px;
   height: 26px; padding: 0 7px; color: var(--text);
 }
-#tb-actions button:hover { border-color: var(--text); color: var(--text); background: var(--panel2); }
+#tb-actions button:hover, #tb-appdata:hover { border-color: var(--text); color: var(--text); background: var(--panel2); }
 #tb-actions button:disabled { opacity: .4; }
 #tb-actions button.attn::after {
   content: ""; position: absolute; top: -3px; right: -3px; width: 8px; height: 8px;
   border-radius: 50%; background: var(--accent); border: 1px solid var(--panel);
 }
-#tb-actions svg { display: block; }
+#tb-actions svg, #tb-appdata svg { display: block; }
 #tb-actions .tb-ellipsis { font-size: 11px; line-height: 1; font-weight: 700; }
 
 /* timeline coverage bands (which span is forcing / particles) */

--- a/sedtrails-gui/web/css/app.css
+++ b/sedtrails-gui/web/css/app.css
@@ -1,0 +1,438 @@
+  :root {
+    --bg: #e9ecf0; --panel: #ffffff; --panel2: #f2f4f7; --border: #d6dbe2;
+    --text: #1e2833; --dim: #5f6b78; --accent: #1f6fd6; --accent2: #17509e;
+    --ok: #2f9e57; --warn: #c07f22; --err: #cc4444;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  html, body { height: 100%; overflow: hidden; }
+  body {
+    background: var(--bg); color: var(--text);
+    font: 13px/1.45 "Segoe UI", system-ui, -apple-system, sans-serif;
+    user-select: none;
+  }
+  #glcanvas { position: absolute; inset: 0; width: 100%; height: 100%; display: block; cursor: grab; }
+  #glcanvas.drawing { cursor: crosshair; }
+  #glcanvas.panning { cursor: grabbing; }
+  #glcanvas.vtx { cursor: move; }          /* hovering a movable point (edit tool) */
+
+  #sidebar {
+    position: absolute; top: 0; left: 0; bottom: 58px; width: var(--sidebar-w, 560px);
+    background: color-mix(in srgb, var(--panel) 96%, transparent);
+    border-right: 1px solid var(--border);
+    overflow-y: auto; overflow-x: hidden; z-index: 5;
+    backdrop-filter: blur(3px);
+    box-shadow: 2px 0 10px rgba(30,45,60,.06);
+  }
+  #sidebar.hidden { display: none !important; }
+  #sidebar::-webkit-scrollbar { width: 8px; }
+  #sidebar::-webkit-scrollbar-thumb { background: var(--border); border-radius: 4px; }
+  #brand {
+    padding: 12px 14px 10px; border-bottom: 1px solid var(--border);
+    display: flex; align-items: baseline; gap: 8px;
+  }
+  #brand b { font-size: 14px; letter-spacing: .3px; color: var(--accent2); }
+  #brand span { color: var(--dim); font-size: 11px; }
+  #sidebar details { border-bottom: 1px solid var(--border); }
+  #sidebar summary {
+    padding: 9px 14px; cursor: pointer; list-style: none;
+    font-size: 11px; font-weight: 600; letter-spacing: .8px; text-transform: uppercase;
+    color: var(--dim); display: flex; align-items: center; gap: 6px;
+  }
+  #sidebar summary:hover { color: var(--text); background: var(--panel2); }
+  #sidebar summary::before { content: "▸"; font-size: 9px; transition: transform .12s; }
+  #sidebar details[open] > summary::before { transform: rotate(90deg); }
+  .sec { padding: 4px 14px 12px; }
+  .row { display: flex; align-items: center; gap: 8px; margin: 5px 0; flex-wrap: wrap; }
+  .grow { flex: 1; }
+  .dim { color: var(--dim); font-size: 12px; }
+  .small { font-size: 11px; }
+
+  button, select, input[type=text], input[type=number], input[type=date] {
+    background: var(--panel); color: var(--text);
+    border: 1px solid var(--border); border-radius: 5px;
+    padding: 4px 8px; font: inherit; font-size: 12px;
+  }
+  button { cursor: pointer; background: var(--panel2); }
+  button:hover { border-color: var(--accent); color: var(--accent2); }
+  button.primary { background: var(--accent); border-color: var(--accent); color: #fff; }
+  button.primary:hover { background: var(--accent2); color: #fff; }
+  button.mini { padding: 1px 7px; font-size: 11px; }
+  button:disabled { opacity: .55; cursor: default; pointer-events: none; }
+  button.danger:hover { border-color: var(--err); color: var(--err); }
+  button.okbtn { background: var(--ok); border-color: var(--ok); color: #fff; }
+  button.okbtn:hover { background: #268a4b; border-color: #268a4b; color: #fff; }
+  button.active { background: var(--accent); border-color: var(--accent); color: #fff; }
+  select { max-width: 100%; }
+  input[type=checkbox], input[type=radio] { accent-color: var(--accent); cursor: pointer; }
+  input[type=range] { accent-color: var(--accent); flex: 1; min-width: 50px; }
+  input[type=number] { width: 62px; }
+
+  /* eye show/hide toggles + greyed-out (disabled-looking) blocks */
+  button.eye {
+    padding: 0 5px; font-size: 13px; line-height: 17px; border-radius: 5px;
+    position: relative; background: var(--panel2); flex: none;
+  }
+  button.eye.off { color: var(--dim); background: var(--panel); }
+  button.eye.off::after {
+    content: ""; position: absolute; left: 3px; right: 3px; top: 50%;
+    border-top: 2px solid var(--err); transform: rotate(-22deg);
+  }
+  #sidebar summary button.eye { margin-left: auto; text-transform: none; }
+  .grey { opacity: .45; pointer-events: none; }
+
+  /* swatch color picker */
+  .colorbtn {
+    display: inline-block; width: 22px; height: 16px; border-radius: 4px;
+    border: 1px solid rgba(0,0,0,.25); cursor: pointer; flex: none; vertical-align: -3px;
+  }
+  .colorbtn:hover { outline: 2px solid var(--accent); }
+  #swatchpop {
+    position: fixed; z-index: 40; background: var(--panel); border: 1px solid var(--border);
+    border-radius: 8px; padding: 8px; box-shadow: 0 8px 26px rgba(20,35,50,.25);
+    display: none; width: 176px;
+  }
+  #swatchpop .grid { display: grid; grid-template-columns: repeat(8, 18px); gap: 3px; }
+  #swatchpop .sw { width: 18px; height: 18px; border-radius: 4px; cursor: pointer;
+    border: 1px solid rgba(0,0,0,.18); }
+  #swatchpop .sw:hover { outline: 2px solid var(--accent); }
+  #swatchpop .more { margin-top: 6px; font-size: 11px; color: var(--accent2); cursor: pointer; }
+
+  .simcard {
+    background: var(--panel2); border: 1px solid var(--border); border-radius: 7px;
+    padding: 7px 9px; margin: 6px 0;
+  }
+  .simcard .name { font-weight: 600; display: flex; align-items: center; gap: 7px; }
+  .simcard .meta { color: var(--dim); font-size: 11px; margin-top: 2px; }
+  .simcard .loadbar { height: 3px; background: var(--border); border-radius: 2px; margin-top: 6px; overflow: hidden; }
+  .simcard .loadbar > div { height: 100%; background: var(--accent); width: 0%; transition: width .3s; }
+  .swatch { display: inline-block; width: 12px; height: 12px; border-radius: 3px; border: 1px solid rgba(0,0,0,.2); flex: none; }
+
+  .pillwrap { display: flex; flex-wrap: wrap; gap: 4px; margin: 5px 0 2px; }
+  .pill {
+    display: inline-flex; align-items: center; gap: 4px;
+    border: 1px solid var(--border); border-radius: 999px;
+    padding: 1px 4px 1px 5px; font-size: 11px; background: var(--panel2); cursor: pointer;
+    max-width: 100%;
+  }
+  .pill:hover { border-color: var(--accent); }
+  .pill.selected { border-color: var(--accent); background: color-mix(in srgb, var(--accent) 12%, var(--panel)); }
+  .pill .dot { width: 10px; height: 10px; border-radius: 50%; border: 1px solid rgba(0,0,0,.25); flex: none; }
+  .pill b { font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .pill button { border: none; background: none; padding: 0 3px; font-size: 10px; color: var(--dim); visibility: hidden; }
+  .pill:hover button { visibility: visible; }
+  .pill button:hover { color: var(--err); }
+
+  .rule {
+    background: var(--panel2); border: 1px solid var(--border); border-radius: 7px;
+    padding: 6px 8px; margin: 6px 0; font-size: 12px;
+    display: flex; flex-wrap: wrap; align-items: center; gap: 4px; row-gap: 5px;
+  }
+  .rule select, .rule input[type=number] { padding: 2px 4px; font-size: 11.5px; }
+  .rule .word { color: var(--dim); }
+  .rule .tools { margin-left: auto; display: flex; gap: 2px; }
+  .rule.default { background: color-mix(in srgb, var(--accent) 7%, var(--panel2)); }
+  .scalerow { background: var(--panel2); border: 1px dashed var(--border); border-radius: 7px;
+    padding: 5px 8px; margin: 6px 0; font-size: 11px; display: flex; align-items: center;
+    gap: 5px; flex-wrap: wrap; }
+  .scalerow input[type=number] { width: 58px; padding: 2px 4px; font-size: 11px; }
+  .scalerow select { padding: 2px 4px; font-size: 11px; }
+
+  #playbar {
+    position: absolute; left: 0; right: 0; bottom: 0; height: 58px;
+    background: var(--panel); border-top: 1px solid var(--border);
+    display: flex; align-items: center; gap: 10px; padding: 0 12px; z-index: 6;
+  }
+  #playbar button {
+    min-width: 32px; background: none; border-color: transparent;
+  }
+  #playbar button:hover { background: var(--panel2); border-color: var(--border); color: var(--text); }
+  #timeline { flex: 1; height: 20px; -webkit-appearance: none; appearance: none;
+    background: transparent; cursor: pointer; }
+  #timeline::-webkit-slider-runnable-track { height: 8px; border-radius: 4px; background: var(--tl-bg, var(--border)); }
+  #timeline::-webkit-slider-thumb {
+    -webkit-appearance: none; width: 16px; height: 16px; border-radius: 50%;
+    background: #fff; margin-top: -4px; border: 2px solid var(--accent);
+    box-shadow: 0 1px 4px rgba(20,35,50,.35); cursor: pointer;
+    transition: transform .1s;
+  }
+  #timeline:hover::-webkit-slider-thumb, #timeline:active::-webkit-slider-thumb { transform: scale(1.18); }
+  #timeline::-moz-range-track { height: 8px; border-radius: 4px; background: var(--tl-bg, var(--border)); }
+  #timeline::-moz-range-thumb { width: 12px; height: 12px; border-radius: 50%;
+    background: #fff; border: 2px solid var(--accent);
+    box-shadow: 0 1px 4px rgba(20,35,50,.35); }
+  #datelabel { min-width: 175px; text-align: right; font-variant-numeric: tabular-nums; }
+  #speedwrap { display: flex; align-items: center; gap: 6px; width: 150px; }
+
+  #statusbar {
+    position: absolute; right: 10px; top: 8px; z-index: 5;
+    background: color-mix(in srgb, var(--panel) 92%, transparent);
+    border: 1px solid var(--border); border-radius: 7px;
+    padding: 5px 11px; font-size: 12px; color: var(--dim);
+    display: flex; gap: 14px; align-items: center; backdrop-filter: blur(3px);
+  }
+  #statusbar b { color: var(--text); font-variant-numeric: tabular-nums; }
+  #coords { position: absolute; right: 10px; bottom: 68px; z-index: 5; color: var(--dim);
+    font-size: 11px; font-variant-numeric: tabular-nums;
+    background: color-mix(in srgb, var(--panel) 85%, transparent); padding: 2px 8px; border-radius: 5px; }
+  #attribution { position: absolute; left: calc(var(--sidebar-w, 560px) + 10px);
+    bottom: 62px; z-index: 4; color: var(--dim);
+    font-size: 10px; background: color-mix(in srgb, var(--panel) 70%, transparent);
+    padding: 1px 6px; border-radius: 4px; }
+  #colorbars { position: absolute; right: 10px; bottom: 96px; z-index: 5;
+    display: flex; flex-direction: column; gap: 6px; }
+  .cbar { background: color-mix(in srgb, var(--panel) 94%, transparent);
+    border: 1px solid var(--border); border-radius: 7px; padding: 6px 10px; width: 200px; }
+  .cbar .title { font-size: 11px; color: var(--dim); margin-bottom: 3px; }
+  .cbar .ramp { height: 9px; border-radius: 3px; }
+  .cbar .lbl { display: flex; justify-content: space-between; font-size: 10px;
+    color: var(--dim); font-variant-numeric: tabular-nums; margin-top: 2px; }
+  #sidebtn { position: absolute; left: 10px; top: 48px; z-index: 13; display: none; }
+  /* draggable divider on the sidebar's right edge (all tabs) */
+  #sideresize { position: absolute; top: 40px; bottom: 58px;
+    left: calc(var(--sidebar-w, 560px) - 3px); width: 7px;
+    cursor: ew-resize; z-index: 7; }
+  #sideresize:hover, #sideresize.dragging {
+    background: color-mix(in srgb, var(--accent) 35%, transparent); }
+  #drawhint {
+    position: absolute; left: 50%; transform: translateX(-50%); top: 10px; z-index: 6;
+    background: var(--panel); border: 1px solid var(--warn); border-radius: 7px;
+    padding: 5px 12px; font-size: 12px; display: none;
+    align-items: center; gap: 10px;
+  }
+  #btn-edit-done {
+    background: var(--ok); border-color: var(--ok); color: #fff;
+    padding: 2px 12px; font-weight: 600; border-radius: 999px; flex: none;
+  }
+  #btn-edit-done:hover { background: #268a4b; border-color: #268a4b; color: #fff; }
+
+  /* export-viewport framing overlay */
+  #vpselect { position: absolute; inset: 0; z-index: 15; pointer-events: none; overflow: hidden; }
+  #vpselect-rect { position: absolute; border: 2px solid var(--accent); border-radius: 2px;
+    box-shadow: 0 0 0 200vmax rgba(25, 36, 48, .35); }
+  #vpselect-bar { position: absolute; left: 50%; transform: translateX(-50%); bottom: 76px;
+    background: var(--panel); border: 1px solid var(--border); border-radius: 8px;
+    padding: 8px 12px; display: flex; gap: 10px; align-items: center;
+    pointer-events: auto; box-shadow: 0 8px 26px rgba(20, 35, 50, .25); }
+  #vpselect-ok { background: var(--ok); border-color: var(--ok); color: #fff; font-weight: 600; }
+  #vpselect-ok:hover { background: #268a4b; border-color: #268a4b; color: #fff; }
+
+  .modal-back {
+    position: absolute; inset: 0; background: rgba(25, 36, 48, .38); z-index: 20;
+    display: flex; align-items: center; justify-content: center;
+  }
+  .modal {
+    background: var(--panel); border: 1px solid var(--border); border-radius: 10px;
+    width: min(620px, 92vw); max-height: 84vh; display: flex; flex-direction: column;
+    box-shadow: 0 12px 40px rgba(20, 35, 50, .25);
+  }
+  .modal header { padding: 13px 16px; border-bottom: 1px solid var(--border); display: flex; align-items: center; }
+  .modal header b { font-size: 14px; }
+  .modal header .x { margin-left: auto; }
+  .modal .body { padding: 12px 16px; overflow-y: auto; }
+  .modal footer { padding: 10px 16px; border-top: 1px solid var(--border); display: flex; gap: 8px; justify-content: flex-end; }
+  .filelist { border: 1px solid var(--border); border-radius: 6px; max-height: 300px; overflow-y: auto; margin-top: 8px; }
+  .filelist .fe { padding: 5px 10px; cursor: pointer; display: flex; gap: 8px; align-items: center; }
+  .filelist .fe:hover { background: var(--panel2); }
+  .filelist .fe .sz { margin-left: auto; color: var(--dim); font-size: 11px; }
+  .field { margin: 9px 0; }
+  .field .lbl { color: var(--dim); font-size: 11px; margin-bottom: 3px; }
+  .pathbox { display: flex; gap: 6px; }
+  .pathbox input { flex: 1; font-size: 11px; }
+  .progress { height: 6px; background: var(--border); border-radius: 3px; overflow: hidden; margin: 8px 0 2px; }
+  .progress > div { height: 100%; background: var(--accent); width: 0%; transition: width .25s; }
+  .hint { color: var(--dim); font-size: 11px; margin-top: 4px; }
+  .toast {
+    position: absolute; left: 50%; transform: translateX(-50%); bottom: 60px; z-index: 30;
+    background: var(--panel); border: 1px solid var(--border); border-left: 3px solid var(--accent);
+    border-radius: 7px; padding: 8px 14px; font-size: 12px; box-shadow: 0 6px 20px rgba(20,35,50,.18);
+  }
+  .toast.err { border-left-color: var(--err); }
+
+/* ═════════════════════════ GUI additions (sedtrails-gui) ═════════════════════════ */
+#topbar {
+  position: absolute; top: 0; left: 0; right: 0; height: 40px; z-index: 12;
+  background: var(--panel); border-bottom: 1px solid var(--border);
+  display: flex; align-items: center; gap: 16px; padding: 0 14px;
+}
+#topbrand b { font-size: 14px; letter-spacing: .3px; color: var(--accent2); }
+#topbrand span { color: var(--dim); font-size: 11px; margin-left: 6px; }
+#tabbar { display: flex; gap: 6px; align-items: center; }
+.tabbtn {
+  border: 1px solid transparent; background: none; border-radius: 999px;
+  padding: 5px 15px; font-size: 12.5px; color: var(--dim);
+  transition: background .12s, color .12s;
+}
+.tabbtn:hover { background: var(--panel2); color: var(--text); border-color: var(--border); }
+.tabbtn.active {
+  background: var(--accent); border-color: var(--accent);
+  color: #fff; font-weight: 600;
+  box-shadow: 0 2px 8px color-mix(in srgb, var(--accent) 40%, transparent);
+}
+.tabbtn.active:hover { background: var(--accent2); border-color: var(--accent2); color: #fff; }
+#sidebar { top: 40px; }
+#statusbar { top: 48px; }
+#drawhint { top: 50px; }
+.tabpanel { display: none; }
+.tabpanel.active { display: block; }
+.placeholder { color: var(--dim); padding: 20px 16px; font-size: 12px; line-height: 1.7; }
+/* playbar + Objects panel are global chrome: visible on every tab */
+#cfgchip { margin-left: auto; color: var(--dim); font-size: 11.5px; max-width: 320px;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+/* save buttons: clean monochrome icons right of the logo; a small accent dot
+   marks unsaved changes (class .attn, set in settings.js updateChip) */
+#tb-actions { display: flex; gap: 5px; align-items: center; }
+#tb-actions button {
+  display: flex; align-items: center; gap: 2px; position: relative;
+  background: none; border: 1px solid var(--border); border-radius: 6px;
+  height: 26px; padding: 0 7px; color: var(--text);
+}
+#tb-actions button:hover { border-color: var(--text); color: var(--text); background: var(--panel2); }
+#tb-actions button:disabled { opacity: .4; }
+#tb-actions button.attn::after {
+  content: ""; position: absolute; top: -3px; right: -3px; width: 8px; height: 8px;
+  border-radius: 50%; background: var(--accent); border: 1px solid var(--panel);
+}
+#tb-actions svg { display: block; }
+#tb-actions .tb-ellipsis { font-size: 11px; line-height: 1; font-weight: 700; }
+
+/* timeline coverage bands (which span is forcing / particles) */
+#tlwrap { flex: 1; display: flex; flex-direction: column; gap: 1px; justify-content: center; }
+#tl-cover { position: relative; height: 22px; margin: 0 7px; }
+#tl-cover > div {
+  position: absolute; left: 0; right: 0; height: 10px; border-radius: 3px;
+  cursor: help; display: none;
+}
+#tl-cover > div.on { display: block; }
+#tl-cov-frc { top: 0; }
+#tl-cov-par { bottom: 0; }
+#tl-cover > div > span {
+  position: absolute; left: 6px; top: 50%; transform: translateY(-50%);
+  font-size: 9px; line-height: 1; font-weight: 600; letter-spacing: .4px;
+  color: var(--text); text-shadow: 0 0 3px var(--panel), 0 0 3px var(--panel);
+  pointer-events: none;
+}
+#tlwrap #timeline { flex: none; }
+
+/* ── floating panels: Layers (what is drawn) + Objects (central shape store) ── */
+#floatpanels {
+  position: absolute; right: 10px; top: 84px; z-index: 5; width: 252px;
+  display: flex; flex-direction: column; gap: 8px;
+  max-height: calc(100vh - 200px);
+  pointer-events: none;              /* empty space below the panels stays map */
+}
+#layerspanel, #objectspanel {
+  pointer-events: auto;
+  background: color-mix(in srgb, var(--panel) 94%, transparent);
+  border: 1px solid var(--border); border-radius: 7px;
+  backdrop-filter: blur(3px);
+  overflow-y: auto; flex: 0 1 auto; min-height: 27px;
+}
+#layerspanel > summary, #objectspanel > summary {
+  padding: 6px 12px; cursor: pointer; list-style: none;
+  font-size: 11px; font-weight: 600; letter-spacing: .8px; text-transform: uppercase;
+  color: var(--dim); display: flex; align-items: center; gap: 6px;
+}
+#layerspanel > summary:hover, #objectspanel > summary:hover { color: var(--text); }
+/* ONE look for every panel collapse/hide button: small round chevron, left of
+   the floating panels' titles and (as #btn-hide-side) right in the sidebar
+   header; group-level collapse inside keeps the small ▸ triangle */
+.panel-toggle {
+  border-radius: 999px; min-width: 22px; height: 20px; line-height: 1;
+  padding: 0 5px; background: var(--panel2); border: 1px solid var(--border);
+  flex: none;
+}
+.panel-toggle:hover { border-color: var(--accent); color: var(--accent2); }
+#lp-body, #op-body { padding: 2px 0 8px; }
+.op-toolbar { display: flex; flex-wrap: wrap; gap: 3px; padding: 2px 10px 6px; }
+.lp-ramp { width: 34px; height: 8px; border-radius: 3px; flex: none;
+  border: 1px solid rgba(0,0,0,.12); font-size: 11px; line-height: 8px; }
+.lp-group {
+  padding: 6px 12px 2px; font-size: 10px; font-weight: 600; letter-spacing: .6px;
+  text-transform: uppercase; color: var(--dim);
+  display: flex; align-items: center; gap: 6px;
+}
+.lp-group .lp-tools { margin-left: auto; display: flex; gap: 4px; align-items: center; }
+.lp-group button.eye { margin-left: auto; }        /* legacy headers without .lp-tools */
+.lp-row { display: flex; align-items: center; gap: 6px; padding: 2px 12px; font-size: 12px; }
+.lp-row .mini { padding: 0 4px; font-size: 10px; }
+.lp-row input.lp-name { border: none; background: none; font: inherit; font-size: 12px;
+  flex: 1; min-width: 0; padding: 0; color: var(--text); }
+.lp-row input.lp-name:focus { outline: 1px solid var(--accent); border-radius: 3px; }
+#layerspanel details { border: none; }
+#layerspanel details > summary.lp-group { list-style: none; cursor: pointer; }
+#layerspanel details > summary.lp-group::before { content: "▸"; font-size: 8px; transition: transform .12s; }
+#layerspanel details[open] > summary.lp-group::before { transform: rotate(90deg); }
+.swatch.hollow { background: transparent !important; border-width: 2px; border-radius: 50%; }
+/* editable coordinate table (Objects panel, draw/edit mode) */
+.op-coords { margin: 2px 12px 6px 24px; display: flex; flex-direction: column; gap: 2px; }
+.op-crow { display: flex; gap: 4px; align-items: center; }
+.op-crow > span { width: 16px; text-align: right; font-size: 10px; color: var(--dim); flex: none; }
+.op-crow > i { flex: 1; font-style: normal; font-size: 10px; color: var(--dim); padding-left: 4px; }
+.op-crow input { flex: 1; min-width: 0; font-size: 11px; padding: 1px 4px;
+  font-variant-numeric: tabular-nums; }
+.op-crow .mini { flex: none; }
+
+/* ── Settings tab: schema-driven form ── */
+.sf-field { display: flex; align-items: center; gap: 6px; margin: 4px 0; }
+.sf-label { width: 158px; flex: none; font-size: 11.5px; overflow: hidden;
+  text-overflow: ellipsis; white-space: nowrap; }
+.sf-label .req { color: var(--err); }
+.sf-input { flex: 1; min-width: 0; font-size: 12px; }
+textarea.sf-input { font: inherit; font-size: 11.5px; background: var(--panel);
+  color: var(--text); border: 1px solid var(--border); border-radius: 5px;
+  padding: 4px 8px; resize: vertical; }
+button.info { border: none; background: none; color: var(--accent2);
+  padding: 0 2px; font-size: 12px; flex: none; }
+button.info:hover { color: var(--accent); border: none; }
+#infopop { position: fixed; z-index: 50; display: none; max-width: 330px;
+  background: var(--panel); border: 1px solid var(--border);
+  border-left: 3px solid var(--accent); border-radius: 7px; padding: 8px 12px;
+  font-size: 11.5px; white-space: pre-wrap; color: var(--text);
+  box-shadow: 0 8px 26px rgba(20,35,50,.25); }
+.sf-branch { margin: 2px 0 6px 10px; border-left: 2px solid var(--border); padding-left: 8px; }
+.sf-chooser { margin: 4px 0; }
+.sf-chooser label { font-size: 11.5px; margin-right: 4px; }
+.sf-pop { margin: 6px 10px; border: 1px solid var(--border); border-radius: 7px;
+  background: var(--panel2); }
+/* pinned (non-collapsible) group: the seeding block inside a population card */
+.sf-pinned { border-bottom: 1px solid var(--border); }
+.sf-pinnedhead { padding: 9px 14px 2px; font-size: 11px; font-weight: 600;
+  letter-spacing: .8px; text-transform: uppercase; color: var(--dim);
+  display: flex; align-items: center; gap: 6px; }
+.sf-pop > summary { text-transform: none !important; letter-spacing: 0 !important;
+  font-size: 12px !important; }
+.sf-pop .poptools { margin-left: auto; display: flex; gap: 4px; }
+.sf-err { outline: 1px solid var(--err); outline-offset: 2px; border-radius: 4px; }
+#set-errors { margin-top: 6px; }
+#set-errors .errline { color: var(--err); font-size: 11px; cursor: pointer; margin: 2px 0; }
+#set-errors .errline:hover { text-decoration: underline; }
+#set-errors .ok { color: var(--ok); font-size: 11px; }
+
+/* ── Run tab: panel is a flex column so ONLY the log pane scrolls. The log
+   lives in a plain div (#run-logsec) — inside <details> Chrome's internal
+   ::details-content box would break the flex chain and kill the scroll ── */
+body.tab-run #sidebar { display: flex; flex-direction: column; overflow-y: hidden; }
+.tabpanel[data-tab="run"].active { display: flex; flex-direction: column; flex: 1; min-height: 0; }
+#run-logsec { flex: 1; display: flex; flex-direction: column; min-height: 0; gap: 4px; }
+#run-log { background: #10161d; color: #cdd6e0; font: 11px/1.5 Consolas, monospace;
+  border-radius: 7px; padding: 8px 10px; flex: 1; min-height: 0;
+  overflow-y: scroll; overscroll-behavior: contain;
+  white-space: pre-wrap; word-break: break-all; user-select: text; }
+/* an always-visible scrollbar inside the black log window */
+#run-log::-webkit-scrollbar { width: 10px; }
+#run-log::-webkit-scrollbar-track { background: #10161d; border-radius: 7px; }
+#run-log::-webkit-scrollbar-thumb { background: #3a4656; border-radius: 5px;
+  border: 2px solid #10161d; }
+#run-log::-webkit-scrollbar-thumb:hover { background: var(--accent); }
+/* the Simulation section must not force the panel taller than the viewport —
+   the log pane below absorbs all remaining height */
+.tabpanel[data-tab="run"] details { flex: none; }
+#run-summary .row span:last-child { font-size: 11.5px; }
+
+/* ── Connectivity tab ── */
+.conmat { border-collapse: collapse; font-size: 11px; font-variant-numeric: tabular-nums; }
+.conmat th, .conmat td { border: 1px solid var(--border); padding: 4px 7px; text-align: right; }
+.conmat th { color: var(--dim); font-weight: 600; text-align: left; max-width: 110px;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.conmat th.corner { font-weight: 400; font-style: italic; }
+.conmat tr:first-child th { text-align: right; }

--- a/sedtrails-gui/web/index.html
+++ b/sedtrails-gui/web/index.html
@@ -1,0 +1,447 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>SedTRAILS GUI</title>
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><circle cx='5' cy='6' r='3' fill='%231f6fd6'/><circle cx='11' cy='10' r='2.4' fill='%23ff8a3d'/></svg>">
+<link rel="stylesheet" href="css/app.css">
+</head>
+<body>
+<canvas id="glcanvas"></canvas>
+
+<div id="topbar">
+  <div id="topbrand"><b>SedTRAILS</b></div>
+  <span id="tb-actions">
+    <button id="tb-save" title="Save config">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+           stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/>
+        <polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></svg>
+    </button>
+    <button id="tb-saveas" title="Save config as…">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+           stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/>
+        <polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></svg>
+      <span class="tb-ellipsis">…</span>
+    </button>
+  </span>
+  <nav id="tabbar">
+    <button class="tabbtn" data-tab="settings">Settings</button>
+    <button class="tabbtn" data-tab="seeding">Populations</button>
+    <button class="tabbtn" data-tab="run">Run</button>
+    <button class="tabbtn" data-tab="viewer">Viewer</button>
+    <button class="tabbtn" data-tab="connectivity">Connectivity</button>
+  </nav>
+  <span id="cfgchip" title=""></span>
+</div>
+<div id="infopop"></div>
+<div id="sidebar">
+  <div id="brand"><b id="paneltitle">Result viewer</b>
+    <button class="mini panel-toggle" style="margin-left:auto" id="btn-hide-side" title="Hide panel">⟨</button>
+  </div>
+  <div class="tabpanel active" data-tab="viewer">
+
+  <details>
+    <summary>Simulations</summary>
+    <div class="sec">
+      <div id="simlist"></div>
+      <div class="hint" id="sim-import-status" style="display:none"></div>
+      <div class="row"><button class="primary" id="btn-add-sim">＋ Add simulation…</button></div>
+    </div>
+  </details>
+
+  <!-- base map controls moved to the Background section below; the model-layer
+       rows stay hidden (dropped from the GUI, wiring kept) -->
+  <div style="display:none">
+      <div class="row small"><span class="dim" style="width:78px">Model layer</span>
+        <button class="eye" id="eye-model" title="show/hide model layer">👁</button>
+        <select id="sel-model" class="grow"><option value="bed">bathymetry</option></select></div>
+      <div class="row small" id="row-mesh-alpha"><span class="dim" style="width:78px">Layer opacity</span>
+        <input type="range" id="rng-mesh-alpha" min="0.15" max="1" step="0.05" value="1"></div>
+  </div>
+
+  <!-- polygons are managed in the floating Objects panel; the legacy controls
+       stay in the DOM (hidden) because the panel reuses their handlers -->
+  <div style="display:none">
+    <div id="poly-opts">
+      <div id="polylist"></div>
+      <button class="eye" id="eye-poly">👁</button>
+      <button id="btn-poly-import">Import…</button>
+      <button id="btn-poly-draw">✏ Draw new</button>
+    </div>
+  </div>
+
+  <details>
+    <summary>Filter &amp; color</summary>
+    <div class="sec">
+      <div id="rulelist"></div>
+      <div class="row"><button id="btn-add-rule">＋ Add rule</button></div>
+      <div id="pointscale"></div>
+      <div class="row small dim" id="classify-status"></div>
+    </div>
+  </details>
+
+  <details>
+    <summary>Particle display <button class="eye" id="eye-points" title="show/hide particles">👁</button></summary>
+    <div class="sec" id="points-opts">
+      <div class="row small"><span class="dim" style="width:72px">Point size</span>
+        <input type="range" id="rng-size" min="1" max="8" step="0.5" value="3"></div>
+      <div class="row small"><span class="dim" style="width:72px">Opacity</span>
+        <input type="range" id="rng-alpha" min="0.05" max="1" step="0.05" value="0.85"></div>
+      <div class="row small"><span class="dim" style="width:72px">Particles</span>
+        <select id="sel-decim">
+          <option value="1">all</option><option value="4">1 / 4</option>
+          <option value="16">1 / 16</option><option value="64">1 / 64</option>
+        </select></div>
+      <!-- fade-buried / fade-immobile hidden for now (wiring kept intact) -->
+      <div style="display:none">
+        <div class="row small"><label><input type="checkbox" id="chk-fade-bur"> Fade buried, fully at ≥</label>
+          <input type="number" id="inp-fade-depth" value="0.05" step="0.01" min="0" style="width:56px">
+          <span class="dim">m</span></div>
+        <div class="row small"><label><input type="checkbox" id="chk-fade-imm"> Fade immobile (inactive) particles</label></div>
+        <div class="row small" id="row-fade-alpha"><span class="dim" style="width:72px">Faded opacity</span>
+          <input type="range" id="rng-fade-alpha" min="0" max="0.6" step="0.05" value="0.1"></div>
+      </div>
+    </div>
+  </details>
+
+  <details>
+    <summary>Paths display <button class="eye" id="eye-paths" title="show/hide paths of the filtered particles">👁</button></summary>
+    <div class="sec" id="paths-opts">
+      <div class="row small"><span class="dim" style="width:72px">Width</span>
+        <input type="range" id="rng-pwidth" min="0.5" max="6" step="0.5" value="1.5"></div>
+      <div class="row small"><span class="dim" style="width:72px">Opacity</span>
+        <input type="range" id="rng-palpha" min="0.05" max="1" step="0.05" value="0.6"></div>
+      <div class="row small"><span class="dim" style="width:72px">Color</span>
+        <select id="sel-pathcolor">
+          <option value="age">by age</option>
+          <option value="dist">by distance travelled</option>
+          <option value="burial">by burial depth</option>
+          <option value="solid">solid color</option>
+        </select>
+        <span id="pathcolor-swatch"></span></div>
+      <div id="pathscale"></div>
+      <div class="row small dim" id="paths-note"></div>
+    </div>
+  </details>
+
+  <details>
+    <summary>Forcing layers <button class="eye" id="eye-frc" title="show/hide all forcing layers">👁</button></summary>
+    <div class="sec">
+      <!-- single source of truth: the forcing file comes from the config's
+           inputs.data (Settings tab); the manual pathbox stays hidden -->
+      <div class="pathbox" style="display:none"><input type="text" id="frc-path" placeholder="…\forcing_sedtrails.nc">
+        <button id="frc-open">Browse…</button>
+        <button id="frc-load">Open</button></div>
+      <div class="hint" id="frc-src">no config loaded — set the forcing file in Settings → inputs → data</div>
+      <div class="hint" id="frc-info"></div>
+      <div id="frc-layers"></div>
+      <div class="row"><select id="frc-add-var" class="grow"></select>
+        <button class="primary mini" id="frc-add">＋ Add layer</button></div>
+      <div class="hint">Layers draw bottom-up; the top card draws on top. Use ▲▼ to reorder.</div>
+    </div>
+  </details>
+  <!-- fine-step time slider removed: ONE main time slider (play bar) drives
+       everything; the elements stay hidden because forcing.js still syncs them -->
+  <div style="display:none">
+    <button id="frc-step-b" class="mini">⏮</button>
+    <button id="frc-step-f" class="mini">⏭</button>
+    <span class="dim small" id="frc-tlabel">–</span>
+    <input type="range" id="frc-time" min="0" max="0" step="1" value="0">
+  </div>
+
+  <details>
+    <summary>Overlays</summary>
+    <!-- seeding previews / objects / connectivity network — eyes + legends,
+         rendered by LayersPanel.refresh() (which replaced the floating panel) -->
+    <div class="sec" id="ov-body"></div>
+  </details>
+
+  <details>
+    <summary>Background <button class="eye" id="eye-basemap" title="show/hide base map">👁</button></summary>
+    <div class="sec">
+      <div class="row small"><span class="dim" style="width:78px">Base map</span>
+        <select id="sel-basemap" class="grow">
+          <option value="sat" selected>satellite</option>
+          <option value="gray">gray map</option>
+        </select></div>
+    </div>
+  </details>
+  </div>
+  <div class="tabpanel" data-tab="settings">
+    <div class="sec">
+      <div class="field"><div class="lbl">Configuration yaml</div>
+        <div class="pathbox"><input type="text" id="set-path" placeholder="…\sedtrails-config.yaml"
+            title="type a path and press Enter to load">
+          <button id="set-open" title="Native file dialog">Open…</button></div></div>
+      <div id="set-estimate" class="hint"></div>
+      <div id="set-errors"></div>
+    </div>
+    <div id="settings-form"></div>
+  </div>
+  <!-- the Forcing viewer tab was merged into the Viewer tab: its sections
+       (Forcing layers + hidden fine-step slider) live in the viewer panel -->
+  <div class="tabpanel" data-tab="seeding">
+    <div class="sec">
+      <div class="row">
+        <button id="seed-goto-settings">All settings…</button>
+      </div>
+    </div>
+    <div id="seeding-pops"></div>
+  </div>
+  <div class="tabpanel" data-tab="run">
+    <details>
+      <summary>Simulation</summary>
+      <div class="sec">
+        <div id="run-summary"></div>
+        <div class="row">
+          <button class="primary" id="run-start">▶ Start run</button>
+          <button class="danger" id="run-stop" style="display:none">■ Stop</button>
+          <button id="run-import" style="display:none">Import &amp; view result</button>
+        </div>
+        <div class="row small" id="run-state"></div>
+        <div class="progress" id="run-prog" style="display:none"><div></div></div>
+        <div class="hint" id="run-progtxt"></div>
+      </div>
+    </details>
+    <!-- plain div, not <details>: Chrome's internal ::details-content box
+         breaks the flex chain that lets the log scroll inside itself -->
+    <div class="sec" id="run-logsec">
+      <div class="dim small">Log</div>
+      <pre id="run-log"></pre>
+    </div>
+  </div>
+  <div class="tabpanel" data-tab="connectivity">
+    <details>
+      <summary>Connectivity matrix</summary>
+      <div class="sec">
+        <div class="row small"><span class="dim" style="width:72px">Simulation</span>
+          <select id="con-sim" class="grow"></select></div>
+        <div class="row small"><span class="dim" style="width:72px">Mode</span>
+          <select id="con-mode" class="grow">
+            <option value="start_end">start → end position</option>
+            <option value="start_ever" title="re-entry rule: the start polygon itself only counts after leaving and returning">start → ever visited (re-entry rule)</option>
+          </select></div>
+        <div class="row small"><span class="dim" style="width:72px">Values</span>
+          <select id="con-norm" class="grow">
+            <option value="count">particle counts</option>
+            <option value="fraction">fraction of source</option>
+          </select></div>
+        <div class="row small"><span class="dim" style="width:72px">Auto cells</span>
+          <input type="number" id="con-ncells" min="2" max="200" value="12" style="width:58px">
+          <button id="con-gencells" class="grow"
+            title="k-means clustering of the forcing bathymetry (geomorphic cells, Pearson et al. 2021); replaces previous auto_cell_* objects">⚙ Generate polygons</button>
+          <button id="con-delcells" class="mini" title="Remove all auto-generated cells">✕</button></div>
+        <div class="hint" id="con-info"></div>
+        <div class="row">
+          <button class="primary" id="con-compute">Compute</button>
+          <button id="con-csv" style="display:none">⬇ CSV</button>
+        </div>
+        <div class="hint" id="con-status"></div>
+      </div>
+    </details>
+    <details id="con-resultsec">
+      <summary>Result</summary>
+      <div class="sec" style="overflow-x:auto">
+        <div id="con-result" class="hint">No result yet.</div>
+      </div>
+    </details>
+  </div>
+</div>
+<button id="sidebtn" class="mini panel-toggle" title="Show panel">⟩</button>
+<div id="sideresize" title="drag to resize the panel"></div>
+
+<div id="statusbar">
+  <span id="st-sel"><b>0</b> selected</span>
+  <span id="st-fps"><b>–</b> fps</span>
+  <span id="st-load" style="display:none">loading <b>0%</b></span>
+  <span id="st-frc" style="display:none">⏳ forcing…</span>
+</div>
+<div id="floatpanels">
+  <!-- the floating Layers panel was replaced by the Viewer tab's sidebar
+       (Overlays/Background sections); it stays hidden, not deleted -->
+  <details id="layerspanel" style="display:none">
+    <summary><button class="mini panel-toggle" tabindex="-1"
+      title="collapse / expand">▾</button>Layers</summary>
+    <div id="lp-body"></div>
+  </details>
+  <details id="objectspanel">
+    <summary><button class="mini panel-toggle" tabindex="-1"
+      title="collapse / expand">▾</button>Objects</summary>
+    <div id="op-body"></div>
+  </details>
+</div>
+<!-- export-viewport framing overlay: aspect-locked frame; the map underneath
+     stays interactive (pan/zoom), only the bottom bar catches clicks -->
+<div id="vpselect" style="display:none">
+  <div id="vpselect-rect"></div>
+  <div id="vpselect-bar">
+    <span class="dim small">Pan &amp; zoom the map until the frame is right</span>
+    <button id="vpselect-ok">✓ Save viewport</button>
+    <button id="vpselect-cancel">Cancel</button>
+  </div>
+</div>
+<div id="coords"></div>
+<div id="attribution"></div>
+<div id="colorbars"></div>
+<div id="drawhint"><span id="drawhint-text">Click to add vertices · <b>Enter</b>/double-click to finish · <b>Esc</b> to cancel</span><button id="btn-edit-done" style="display:none">✓ Done</button></div>
+<div id="swatchpop"><div class="grid"></div><div class="more">custom…</div>
+  <input type="color" id="swatch-custom" style="position:absolute;visibility:hidden"></div>
+
+<div id="playbar">
+  <button id="btn-play" title="Space">▶</button>
+  <button id="btn-step-b" title="1 day back">⏮</button>
+  <button id="btn-step-f" title="1 day forward">⏭</button>
+  <div id="tlwrap">
+    <div id="tl-cover">
+      <div id="tl-cov-frc"><span>forcing</span></div>
+      <div id="tl-cov-par"><span>particles</span></div>
+    </div>
+    <input type="range" id="timeline" min="0" max="1000" step="1" value="0">
+  </div>
+  <span id="datelabel" class="dim">–</span>
+  <span id="speedwrap"><span class="dim small">speed</span>
+    <input type="range" id="rng-speed" min="0" max="1" step="0.005" value="0.167">
+    <span class="dim small" id="lbl-speed">3.0 h/s</span></span>
+  <button id="btn-export" title="Export PNG / MP4">⬇ Export</button>
+</div>
+
+<div class="modal-back" id="modal-open" style="display:none">
+  <div class="modal">
+    <header><b>Open simulation</b><button class="x mini" data-close="modal-open">✕</button></header>
+    <div class="body">
+      <div class="field">
+        <div class="lbl">Recent</div>
+        <select id="sel-recent" style="width:100%">
+          <option value="">— pick a recent simulation to reopen —</option>
+        </select>
+      </div>
+      <div class="field">
+        <div class="lbl">SedTRAILS results netCDF</div>
+        <div class="pathbox"><input type="text" id="inp-nc" placeholder="…\03_output\run\sedtrails_results.nc">
+          <button data-browse="inp-nc" data-ext=".nc">Browse…</button></div>
+      </div>
+      <div class="field">
+        <div class="lbl">Forcing / DFM netCDF — optional, enables the bathymetry &amp; bed-change model layers</div>
+        <div class="pathbox"><input type="text" id="inp-forcing" placeholder="(optional)">
+          <button data-browse="inp-forcing" data-ext=".nc">Browse…</button></div>
+      </div>
+      <div class="field" style="display:flex;gap:14px">
+        <div class="grow"><div class="lbl">Display name</div><input type="text" id="inp-name" style="width:100%"></div>
+        <div><div class="lbl">Load every n-th particle</div>
+          <select id="inp-stride"><option value="1">1 (all)</option><option value="2">2</option>
+            <option value="4">4</option><option value="10">10</option></select></div>
+      </div>
+      <div class="progress" id="import-prog" style="display:none"><div></div></div>
+      <div class="hint" id="import-msg"></div>
+    </div>
+    <footer><button data-close="modal-open">Cancel</button>
+      <button class="primary" id="btn-import">Open</button></footer>
+  </div>
+</div>
+
+<div class="modal-back" id="modal-browse" style="display:none">
+  <div class="modal">
+    <header><b id="browse-title">Select file</b><button class="x mini" data-close="modal-browse">✕</button></header>
+    <div class="body">
+      <div class="pathbox"><input type="text" id="browse-path"><button id="browse-go">Go</button></div>
+      <div class="filelist" id="browse-list"></div>
+      <div class="hint" id="browse-hint"></div>
+    </div>
+    <footer><button data-close="modal-browse">Cancel</button>
+      <button class="primary" id="browse-usedir" style="display:none">Use this folder</button></footer>
+  </div>
+</div>
+
+<div class="modal-back" id="modal-poly" style="display:none">
+  <div class="modal" style="width:min(420px,92vw)">
+    <header><b id="modal-poly-title">New polygon</b><button class="x mini" data-close="modal-poly">✕</button></header>
+    <div class="body">
+      <div class="field"><div class="lbl">Name</div><input type="text" id="poly-name" style="width:100%"></div>
+    </div>
+    <footer><button data-close="modal-poly">Cancel</button>
+      <button class="primary" id="poly-save">Save</button></footer>
+  </div>
+</div>
+
+<!-- Modify-seeding dialog: the ONLY place where particle release positions are
+     changed (object, distribution, coordinates, seed, counts). Body is built by
+     SeedingTab.openSeedingModal(); Apply commits, Cancel discards the draft. -->
+<div class="modal-back" id="modal-seeding" style="display:none">
+  <div class="modal" style="width:min(440px,92vw)">
+    <header><b id="modal-seeding-title">Modify seeding</b><button class="x mini" data-close="modal-seeding">✕</button></header>
+    <div class="body" id="modal-seeding-body"></div>
+    <footer><span class="dim small" id="modal-seeding-count" style="margin-right:auto"></span>
+      <button data-close="modal-seeding">Cancel</button>
+      <button class="primary" id="modal-seeding-apply">Apply</button></footer>
+  </div>
+</div>
+
+<div class="modal-back" id="modal-export" style="display:none">
+  <div class="modal" style="width:min(460px,92vw)">
+    <header><b>Export</b><button class="x mini" data-close="modal-export">✕</button></header>
+    <div class="body">
+      <div class="row"><label><input type="radio" name="expfmt" value="png" checked> PNG image</label>
+        <label><input type="radio" name="expfmt" value="mp4"> MP4 animation</label></div>
+      <div class="field"><div class="lbl">Resolution</div>
+        <select id="exp-res">
+          <option value="current">current window</option>
+          <option value="1920x1080" selected>1920 × 1080</option>
+          <option value="2560x1440">2560 × 1440</option>
+          <option value="3840x2160">3840 × 2160</option>
+        </select></div>
+      <div class="field"><div class="lbl">Viewport</div>
+        <div class="row">
+          <select id="exp-vp" class="grow"><option value="">current map view</option></select>
+          <button id="exp-vp-new" class="mini" title="frame a fixed viewport on the map">＋ define…</button>
+          <button id="exp-vp-del" class="mini danger" title="delete this saved viewport" style="display:none">✕</button>
+        </div>
+        <div class="hint">"Current map view" exports what you see (cropped to the chosen aspect
+          ratio). A saved viewport pins the exact framing, so the export can be reproduced
+          later — with different layers/particles if you like.</div>
+      </div>
+      <div id="exp-mp4opts" style="display:none">
+        <div class="field" style="display:flex;gap:12px">
+          <div><div class="lbl">Frame rate (fps)</div><input type="number" id="exp-fps" value="12" min="1" max="60"></div>
+          <div><div class="lbl">Days per frame</div><input type="number" id="exp-dpf" value="1" min="0.25" step="0.25"></div>
+        </div>
+        <div class="field" style="display:flex;gap:12px">
+          <div><div class="lbl">From</div><input type="date" id="exp-t0"></div>
+          <div><div class="lbl">To</div><input type="date" id="exp-t1"></div>
+        </div>
+        <div class="hint" id="exp-duration"></div>
+      </div>
+      <div class="progress" id="exp-prog" style="display:none"><div></div></div>
+      <div class="hint" id="exp-msg"></div>
+    </div>
+    <footer><button data-close="modal-export">Cancel</button>
+      <button class="primary" id="btn-do-export">Save as…</button></footer>
+  </div>
+</div>
+
+<script src="js/core/util.js"></script>
+<script src="js/core/state.js"></script>
+<script src="js/core/gl.js"></script>
+<script src="js/core/tiles.js"></script>
+<script src="js/core/mesh.js"></script>
+<script src="js/tabs/viewer.js"></script>
+<script src="js/core/playbar.js"></script>
+<script src="js/core/render.js"></script>
+<script src="js/tabs/viewer-export.js"></script>
+<script src="js/tabs/viewer-ui.js"></script>
+<script src="js/core/interact.js"></script>
+<script src="js/tabs/viewer-wiring.js"></script>
+<script src="js/tabs/schema-form.js"></script>
+<script src="js/core/tabs.js"></script>
+<script src="js/tabs/settings.js"></script>
+<script src="js/tabs/forcing.js"></script>
+<script src="js/tabs/seeding.js"></script>
+<script src="js/tabs/run.js"></script>
+<script src="js/tabs/connectivity.js"></script>
+<script src="js/core/layers-panel.js"></script>
+<script src="js/core/objects-panel.js"></script>
+<script src="js/core/app.js"></script>
+</body>
+</html>

--- a/sedtrails-gui/web/index.html
+++ b/sedtrails-gui/web/index.html
@@ -35,6 +35,11 @@
     <button class="tabbtn" data-tab="connectivity">Connectivity</button>
   </nav>
   <span id="cfgchip" title=""></span>
+  <button id="tb-appdata" title="Data locations — where the GUI stores its files">
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+         stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+  </button>
 </div>
 <div id="infopop"></div>
 <div id="sidebar">
@@ -363,6 +368,16 @@
     </div>
     <footer><button data-close="modal-poly">Cancel</button>
       <button class="primary" id="poly-save">Save</button></footer>
+  </div>
+</div>
+
+<!-- Data locations: every folder the GUI writes to (registry + drawn objects,
+     result bundles, forcing caches). Body built by showAppData() in app.js. -->
+<div class="modal-back" id="modal-appdata" style="display:none">
+  <div class="modal" style="width:min(560px,92vw)">
+    <header><b>Data locations</b><button class="x mini" data-close="modal-appdata">✕</button></header>
+    <div class="body" id="appdata-body"></div>
+    <footer><button data-close="modal-appdata">Close</button></footer>
   </div>
 </div>
 

--- a/sedtrails-gui/web/js/core/app.js
+++ b/sedtrails-gui/web/js/core/app.js
@@ -1,4 +1,57 @@
 "use strict";
+/* ── Data locations popup (📁 top right): every folder the GUI writes to ── */
+async function showAppData() {
+  const body = $('appdata-body');
+  body.innerHTML = '<div class="dim small">loading…</div>';
+  $('modal-appdata').style.display = 'flex';
+  let locs;
+  try {
+    locs = (await apiJson('/api/appinfo')).locations;
+  } catch (e) {
+    body.textContent = 'failed: ' + e.message;
+    return;
+  }
+  body.innerHTML = '';
+  for (const l of locs) {
+    const d = document.createElement('div');
+    d.className = 'field';
+    const lbl = document.createElement('div');
+    lbl.className = 'lbl';
+    lbl.textContent = l.label;
+    const row = document.createElement('div');
+    row.style.cssText = 'display:flex;gap:6px;align-items:center';
+    const p = document.createElement('code');
+    p.style.cssText = 'flex:1;font-size:11px;overflow:hidden;text-overflow:ellipsis;' +
+                      'white-space:nowrap' + (l.exists ? '' : ';opacity:.5');
+    p.textContent = l.path + (l.exists ? '' : '  (not created yet)');
+    p.title = l.path;
+    row.append(p);
+    if (l.exists) {
+      const b = document.createElement('button');
+      b.className = 'mini';
+      b.textContent = '📂';
+      b.title = 'open in file explorer';
+      b.onclick = () => api('/api/openfolder', {path: l.path})
+        .catch(e => toast('could not open folder: ' + e.message, true));
+      row.append(b);
+    }
+    d.append(lbl, row);
+    if (l.note) {
+      const n = document.createElement('div');
+      n.className = 'dim small';
+      n.textContent = l.note;
+      d.append(n);
+    }
+    body.append(d);
+  }
+  const note = document.createElement('div');
+  note.className = 'dim small';
+  note.style.marginTop = '8px';
+  note.textContent = 'View settings (colors, collapsed sections, last opened files) live in ' +
+                     'the browser’s localStorage for this address, not in a file.';
+  body.append(note);
+}
+
 /* ═════════════════════════ init ═════════════════════════ */
 async function init() {
   // entering the Viewer re-checks the config's result file: loads it if new,
@@ -8,6 +61,7 @@ async function init() {
     if (typeof autoImportResult === 'function') autoImportResult();
     if (typeof ForcingTab !== 'undefined') ForcingTab.enter();
   }});
+  $('tb-appdata').onclick = showAppData;
   refreshToolButtons();
   refreshRules();
   refreshModelLayers();

--- a/sedtrails-gui/web/js/core/app.js
+++ b/sedtrails-gui/web/js/core/app.js
@@ -1,0 +1,34 @@
+"use strict";
+/* ═════════════════════════ init ═════════════════════════ */
+async function init() {
+  // entering the Viewer re-checks the config's result file: loads it if new,
+  // replaces the loaded run if the file on disk changed since the import.
+  // The forcing layers live here too (merged tab) — re-sync them as well.
+  Tabs.register('viewer', {enter() {
+    if (typeof autoImportResult === 'function') autoImportResult();
+    if (typeof ForcingTab !== 'undefined') ForcingTab.enter();
+  }});
+  refreshToolButtons();
+  refreshRules();
+  refreshModelLayers();
+  rebuildPaletteTex();
+  if (softwareGL) {
+    $('sel-decim').value = '16';
+    state.decim = 16;
+    toast('Software GPU detected — particle decimation set to 1/16');
+  }
+  try {
+    const pol = await apiJson('/api/polygons');
+    state.polygons = pol.polygons || [];
+    ensurePolyColors();
+    refreshPolyList(); refreshRules();
+    LayersPanel.refresh();           // panels were built before the store arrived
+  } catch (e) {}
+  syncVis();
+  // load the last config right away (any tab): it brings the forcing file and
+  // an existing result file along — no "Open simulation" popup anymore
+  if (typeof SettingsTab !== 'undefined') SettingsTab.init().catch(() => {});
+  updateTimelineUI();
+  requestAnimationFrame(render);
+}
+init();

--- a/sedtrails-gui/web/js/core/gl.js
+++ b/sedtrails-gui/web/js/core/gl.js
@@ -1,0 +1,355 @@
+"use strict";
+/* ═════════════════════════ WebGL setup ═════════════════════════ */
+const canvas = $('glcanvas');
+const gl = canvas.getContext('webgl2', {antialias: false, alpha: false, depth: false,
+                                        stencil: true, preserveDrawingBuffer: true});
+if (!gl) document.body.innerHTML = '<p style="padding:40px">WebGL2 is not available in this browser.</p>';
+
+let softwareGL = false;
+try {
+  const dbg = gl.getExtension('WEBGL_debug_renderer_info');
+  const renderer = dbg ? gl.getParameter(dbg.UNMASKED_RENDERER_WEBGL) : '';
+  softwareGL = /swiftshader|llvmpipe|software/i.test(renderer);
+} catch (e) {}
+
+function compile(vsSrc, fsSrc) {
+  const mk = (type, src) => {
+    const s = gl.createShader(type);
+    gl.shaderSource(s, src);
+    gl.compileShader(s);
+    if (!gl.getShaderParameter(s, gl.COMPILE_STATUS))
+      throw new Error(gl.getShaderInfoLog(s) + '\n' + src);
+    return s;
+  };
+  const p = gl.createProgram();
+  gl.attachShader(p, mk(gl.VERTEX_SHADER, vsSrc));
+  gl.attachShader(p, mk(gl.FRAGMENT_SHADER, fsSrc));
+  gl.linkProgram(p);
+  if (!gl.getProgramParameter(p, gl.LINK_STATUS)) throw new Error(gl.getProgramInfoLog(p));
+  const u = {};
+  const n = gl.getProgramParameter(p, gl.ACTIVE_UNIFORMS);
+  for (let i = 0; i < n; i++) {
+    const info = gl.getActiveUniform(p, i);
+    u[info.name.replace('[0]', '')] = gl.getUniformLocation(p, info.name);
+  }
+  return {prog: p, u};
+}
+
+// Rule encoding:
+// cond: 0 always/none, 1 start-in, 2 end-in, 3 ever-in, 4 burial>=, 5 burial<
+// arg:  polygon index, -1 = any polygon, -2 = no polygon
+// action: 0 hide, 1 solid, 2 by-burial, 3 by-age, 4 by-first (+defaults 5/6/7)
+const PT_VS = `#version 300 es
+precision highp float; precision highp int;
+layout(location=0) in uvec2 aPos;
+layout(location=1) in uvec2 aPosNext;
+layout(location=2) in uvec2 aIds;
+layout(location=3) in uint aFirst;
+layout(location=4) in uint aBur0;
+layout(location=5) in uint aBur1;
+layout(location=6) in uint aMaskV;   // ever visited
+layout(location=7) in uint aMask0;   // inside at start
+layout(location=8) in uint aMaskE;   // inside at end
+layout(location=9) in uint aFlg;     // 1 mobile, 0 immobile, 255 unknown
+uniform vec4 uQuant, uView;
+uniform float uFrac, uPointSize, uAlpha, uNowDays, uBurMax;
+uniform vec3 uFade;                  // x: fade-depth (quantized, <=0 off), y: fade-immobile, z: faded alpha
+uniform vec2 uVRbur, uVRage, uVRfirst;
+uniform int uNRules;
+uniform ivec4 uRuleI[${MAX_RULES}];
+uniform vec4 uRuleC[${MAX_RULES}];
+uniform vec2 uRuleT[${MAX_RULES}];
+uniform int uDefAction;
+uniform vec3 uDefColor, uTint;
+uniform sampler2D uCmap, uPalette;
+out vec4 vColor;
+void cull() { gl_Position = vec4(2.0, 2.0, 2.0, 1.0); gl_PointSize = 0.0; vColor = vec4(0.0); }
+bool maskHit(uint mask, int arg) {
+  if (arg == -1) return mask != 0u;
+  if (arg == -2) return mask == 0u;
+  return (mask & (1u << uint(arg))) != 0u;
+}
+bool condHit(int cond, int arg, float th, float bur) {
+  if (cond == 0) return true;
+  if (cond == 4) return bur >= th;
+  if (cond == 5) return bur < th;
+  return maskHit(cond == 1 ? aMask0 : cond == 2 ? aMaskE : aMaskV, arg);
+}
+vec3 valueColor(int action, float bur, float first) {
+  float v, lo, hi;
+  if (action == 2) { v = bur / 65534.0 * uBurMax; lo = uVRbur.x; hi = uVRbur.y; }
+  else if (action == 3) { v = uNowDays; lo = uVRage.x; hi = uVRage.y; }
+  else {
+    if (first >= 65535.0) return vec3(0.545, 0.576, 0.62);
+    v = first; lo = uVRfirst.x; hi = uVRfirst.y;
+  }
+  return texture(uCmap, vec2(clamp((v - lo) / max(hi - lo, 1e-9), 0.0, 1.0), 0.5)).rgb;
+}
+vec3 paletteColor(int id) {
+  if (id == 255) return vec3(0.545, 0.576, 0.62);
+  return texelFetch(uPalette, ivec2(id & 31, 0), 0).rgb;
+}
+void main() {
+  if (aPos.x == 65535u) { cull(); return; }
+  vec2 p = vec2(aPos) * uQuant.xy + uQuant.zw;
+  if (aPosNext.x != 65535u)
+    p = mix(p, vec2(aPosNext) * uQuant.xy + uQuant.zw, uFrac);
+  float bur = (aBur0 == 65535u) ? 0.0
+            : (aBur1 == 65535u) ? float(aBur0)
+            : mix(float(aBur0), float(aBur1), uFrac);
+  int act = -1;
+  vec3 col = vec3(0.0);
+  for (int i = 0; i < ${MAX_RULES}; i++) {
+    if (i >= uNRules) break;
+    if (condHit(uRuleI[i].x, uRuleI[i].y, uRuleT[i].x, bur)
+        && condHit(uRuleI[i].z, uRuleI[i].w, uRuleT[i].y, bur)) {
+      act = int(uRuleC[i].w); col = uRuleC[i].rgb; break;
+    }
+  }
+  if (act < 0) {
+    act = uDefAction;
+    col = (act == 5) ? paletteColor(int(aIds.x))
+        : (act == 6) ? paletteColor(int(aIds.y))
+        : (act == 7) ? uTint : uDefColor;
+    if (act >= 5) act = 1;
+  }
+  if (act == 0) { cull(); return; }
+  if (act >= 2) col = valueColor(act, bur, float(aFirst));
+  gl_Position = vec4(p * uView.xy + uView.zw, 0.0, 1.0);
+  gl_PointSize = uPointSize;
+  float a = uAlpha;
+  if (uFade.x > 0.0) a *= mix(1.0, uFade.z, clamp(bur / uFade.x, 0.0, 1.0));
+  if (uFade.y > 0.5 && aFlg == 0u) a *= uFade.z;
+  vColor = vec4(col, a);
+}`;
+const PT_FS = `#version 300 es
+precision mediump float;
+in vec4 vColor;
+uniform float uRound;
+out vec4 frag;
+void main() {
+  vec3 col = vColor.rgb;
+  if (uRound > 0.5) {
+    vec2 c = gl_PointCoord - 0.5;
+    float r2 = dot(c, c);
+    if (r2 > 0.25) discard;
+    col *= 1.0 - 0.3 * smoothstep(0.15, 0.25, r2);   // darker rim → particle look
+  }
+  frag = vec4(col * vColor.a, vColor.a);
+}`;
+
+const SEG_VS = `#version 300 es
+precision highp float; precision highp int;
+layout(location=1) in uvec4 aSeg;
+layout(location=2) in uvec2 aTV;
+uniform vec4 uQuant, uView;
+uniform vec2 uCanvas, uVR;
+uniform float uWidthPx, uNow, uPmax;
+uniform int uSolid;
+uniform vec3 uSolidColor;
+uniform sampler2D uCmap;
+out vec4 vColor;
+void main() {
+  if (float(aTV.x) > uNow || aSeg.x == 65535u || aSeg.z == 65535u) {
+    gl_Position = vec4(2.0, 2.0, 2.0, 1.0); vColor = vec4(0.0); return;
+  }
+  vec2 p0 = vec2(aSeg.xy) * uQuant.xy + uQuant.zw;
+  vec2 p1 = vec2(aSeg.zw) * uQuant.xy + uQuant.zw;
+  vec2 c0 = p0 * uView.xy + uView.zw;
+  vec2 c1 = p1 * uView.xy + uView.zw;
+  vec2 dpx = (c1 - c0) * uCanvas * 0.5;
+  float len = max(length(dpx), 1e-4);
+  vec2 dir = dpx / len;
+  vec2 nrm = vec2(-dir.y, dir.x);
+  float along = float(gl_VertexID >> 1);
+  float side = float((gl_VertexID & 1) * 2 - 1);
+  vec2 px = mix(vec2(0.0), dpx, along)
+          + dir * (along * 2.0 - 1.0) * uWidthPx * 0.5
+          + nrm * side * uWidthPx * 0.5;
+  gl_Position = vec4(c0 + px / (uCanvas * 0.5), 0.0, 1.0);
+  vec3 col;
+  if (uSolid == 1) col = uSolidColor;
+  else {
+    float v = float(aTV.y) / 65534.0 * uPmax;
+    col = texture(uCmap, vec2(clamp((v - uVR.x) / max(uVR.y - uVR.x, 1e-9), 0.0, 1.0), 0.5)).rgb;
+  }
+  vColor = vec4(col, 1.0);
+}`;
+const SEG_FS = `#version 300 es
+precision mediump float;
+in vec4 vColor; out vec4 frag;
+void main() { frag = vec4(vColor.rgb * vColor.a, vColor.a); }`;
+
+const MESH_VS = `#version 300 es
+precision highp float;
+layout(location=0) in vec2 aPos;
+layout(location=1) in float aVal;
+uniform vec4 uView;
+uniform vec2 uOff;
+out float vVal;
+void main() {
+  vVal = aVal;
+  gl_Position = vec4((aPos + uOff) * uView.xy + uView.zw, 0.0, 1.0);
+}`;
+const MESH_FS = `#version 300 es
+precision mediump float;
+in float vVal;
+uniform vec2 uClim;
+uniform float uAlpha;
+uniform sampler2D uRamp;
+out vec4 frag;
+void main() {
+  if (vVal < -9000.0) discard;
+  float f = clamp((vVal - uClim.x) / (uClim.y - uClim.x), 0.0, 1.0);
+  vec4 c = texture(uRamp, vec2(f, 0.5));
+  frag = vec4(c.rgb * uAlpha, uAlpha);
+}`;
+
+const FLAT_VS = `#version 300 es
+layout(location=0) in vec2 aPos;
+uniform vec4 uView;
+uniform float uPtSize;   // px; only POINTS draws care — set it before every POINTS draw
+void main() { gl_Position = vec4(aPos * uView.xy + uView.zw, 0.0, 1.0); gl_PointSize = uPtSize; }`;
+const FLAT_FS = `#version 300 es
+precision mediump float;
+uniform vec4 uColor;
+uniform float uRound;    // 1 = round point with darker rim, 2 = hollow ring (seeding previews)
+out vec4 frag;
+void main() {
+  vec3 col = uColor.rgb;
+  float a = uColor.a;
+  if (uRound > 0.5) {
+    vec2 c = gl_PointCoord - 0.5;
+    float r2 = dot(c, c);
+    if (r2 > 0.25) discard;
+    if (uRound > 1.5) a *= smoothstep(0.07, 0.11, r2);   // hollow center
+    col *= 1.0 - 0.35 * smoothstep(0.14, 0.25, r2);
+  }
+  frag = vec4(col * a, a);
+}`;
+
+const TEX_VS = `#version 300 es
+layout(location=0) in vec2 aPos;
+layout(location=1) in vec2 aUV;
+uniform vec4 uView;
+out vec2 vUV;
+void main() { vUV = aUV; gl_Position = vec4(aPos * uView.xy + uView.zw, 0.0, 1.0); }`;
+const TEX_FS = `#version 300 es
+precision mediump float;
+in vec2 vUV; uniform sampler2D uTex; out vec4 frag;
+void main() { vec4 c = texture(uTex, vUV); frag = vec4(c.rgb, 1.0); }`;
+
+const SCREEN_VS = `#version 300 es
+layout(location=0) in vec2 aPos;
+out vec2 vUV;
+void main() { vUV = aPos * 0.5 + 0.5; gl_Position = vec4(aPos, 0.0, 1.0); }`;
+const BLIT_FS = `#version 300 es
+precision mediump float;
+in vec2 vUV; uniform sampler2D uTex; uniform float uAlpha; out vec4 frag;
+void main() { frag = texture(uTex, vUV) * uAlpha; }`;
+
+const progPt = compile(PT_VS, PT_FS);
+const progSeg = compile(SEG_VS, SEG_FS);
+const progMesh = compile(MESH_VS, MESH_FS);
+const progFlat = compile(FLAT_VS, FLAT_FS);
+const progTex = compile(TEX_VS, TEX_FS);
+const progBlit = compile(SCREEN_VS, BLIT_FS);
+
+function makeRampTexture(stops) {
+  const tex = gl.createTexture();
+  const px = new Uint8Array(256 * 4);
+  for (let i = 0; i < 256; i++) {
+    const f = i / 255 * (stops.length - 1);
+    const j = Math.min(Math.floor(f), stops.length - 2);
+    const w = f - j;
+    for (let k = 0; k < 3; k++)
+      px[i*4+k] = Math.round(stops[j][k] * (1-w) + stops[j+1][k] * w);
+    px[i*4+3] = 255;
+  }
+  gl.bindTexture(gl.TEXTURE_2D, tex);
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 256, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, px);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+  return tex;
+}
+const cmapTextures = {};
+function cmapTex(name) {
+  if (!cmapTextures[name]) cmapTextures[name] = makeRampTexture(CMAPS[name] || CMAPS.viridis);
+  return cmapTextures[name];
+}
+
+const paletteTex = gl.createTexture();
+gl.bindTexture(gl.TEXTURE_2D, paletteTex);
+gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+function rebuildPaletteTex() {
+  // palette slots = polygon colors, so palette-by-polygon coloring matches
+  // each polygon's own color
+  const polys = allPolys();
+  const px = new Uint8Array(32 * 4);
+  for (let i = 0; i < 32; i++) {
+    const rgb = hex2rgb(polys[i] && polys[i].color ? polys[i].color : PALETTE[i % PALETTE.length]);
+    px[i*4] = rgb[0]; px[i*4+1] = rgb[1]; px[i*4+2] = rgb[2]; px[i*4+3] = 255;
+  }
+  gl.bindTexture(gl.TEXTURE_2D, paletteTex);
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 32, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, px);
+}
+
+const screenQuad = gl.createBuffer();
+gl.bindBuffer(gl.ARRAY_BUFFER, screenQuad);
+gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1,-1, 3,-1, -1,3]), gl.STATIC_DRAW);
+
+const off = {fbo: gl.createFramebuffer(), tex: gl.createTexture(), w: 0, h: 0};
+function ensureOffFBO() {
+  if (off.w === canvas.width && off.h === canvas.height) return;
+  off.w = canvas.width; off.h = canvas.height;
+  gl.bindTexture(gl.TEXTURE_2D, off.tex);
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, off.w, off.h, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+  gl.bindFramebuffer(gl.FRAMEBUFFER, off.fbo);
+  gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, off.tex, 0);
+  gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+}
+
+/* ═════════════════════════ swatch color picker ═════════════════════════ */
+let swatchCb = null;
+{
+  const grid = document.querySelector('#swatchpop .grid');
+  for (const c of SWATCHES) {
+    const d = document.createElement('div');
+    d.className = 'sw';
+    d.style.background = c;
+    d.onclick = () => { if (swatchCb) swatchCb(c); closeSwatchPop(); };
+    grid.appendChild(d);
+  }
+  document.querySelector('#swatchpop .more').onclick = () => {
+    const inp = $('swatch-custom');
+    inp.oninput = () => { if (swatchCb) swatchCb(inp.value); };
+    inp.click();
+    closeSwatchPop();
+  };
+  window.addEventListener('mousedown', e => {
+    if (!$('swatchpop').contains(e.target) && !e.target.classList.contains('colorbtn'))
+      closeSwatchPop();
+  });
+}
+function closeSwatchPop() { $('swatchpop').style.display = 'none'; swatchCb = null; }
+function mkColorBtn(getColor, setColor, title) {
+  const b = document.createElement('span');
+  b.className = 'colorbtn';
+  b.style.background = getColor();
+  b.title = title || 'change color';
+  b.onclick = ev => {
+    ev.stopPropagation();
+    const pop = $('swatchpop');
+    pop.style.display = 'block';
+    const r = b.getBoundingClientRect();
+    pop.style.left = Math.min(r.left, window.innerWidth - 190) + 'px';
+    pop.style.top = Math.min(r.bottom + 4, window.innerHeight - 140) + 'px';
+    swatchCb = c => { setColor(c); b.style.background = c; };
+  };
+  return b;
+}
+

--- a/sedtrails-gui/web/js/core/interact.js
+++ b/sedtrails-gui/web/js/core/interact.js
@@ -1,0 +1,153 @@
+"use strict";
+/* ═════════════════════════ canvas interaction ═════════════════════════ */
+let drag = null;
+
+/* vertex / edge hit-testing for the edit tool (shared with the Objects panel) */
+const MIN_VERTS = {polygon: 3, bbox: 3, transect: 2, point: 1};
+function hitTol() { return 10 / state.view.ppm * (window.devicePixelRatio || 1); }
+function nearestVert(p, ax, ay, tol) {
+  let best = -1, bestD = tol * tol;
+  p.verts.forEach((v, i) => {
+    const d = (v[0] - ax) ** 2 + (v[1] - ay) ** 2;
+    if (d < bestD) { bestD = d; best = i; }
+  });
+  return best;
+}
+function nearestSegment(p, ax, ay, tol) {
+  const type = p.type || 'polygon';
+  if (type === 'point') return null;               // point sets have no edges
+  const n = p.verts.length;
+  const segs = type === 'transect' ? n - 1 : n;    // closed shapes include the closing edge
+  let best = null, bestD = tol * tol;
+  for (let i = 0; i < segs; i++) {
+    const a = p.verts[i], b = p.verts[(i + 1) % n];
+    const dx = b[0] - a[0], dy = b[1] - a[1];
+    const L2 = dx * dx + dy * dy;
+    if (!L2) continue;
+    const t = Math.max(0, Math.min(1, ((ax - a[0]) * dx + (ay - a[1]) * dy) / L2));
+    const x = a[0] + t * dx, y = a[1] + t * dy;
+    const d = (x - ax) ** 2 + (y - ay) ** 2;
+    if (d < bestD) { bestD = d; best = {i, x, y}; }
+  }
+  return best;
+}
+function editTarget() {
+  return state.tool === 'edit' && state.editSel && state.world0
+    ? state.polygons.find(x => x.name === state.editSel.name) : null;
+}
+
+canvas.addEventListener('mousedown', e => {
+  if (state.tool === 'draw') return;
+  const p = e.button === 0 ? editTarget() : null;
+  if (p) {
+    const [ax, ay] = screenToRd(e.clientX, e.clientY);
+    const tol = hitTol();
+    const best = nearestVert(p, ax, ay, tol);
+    if (best >= 0) { drag = {vert: {p, i: best}}; return; }
+    if (e.altKey && (p.type || 'polygon') === 'point') {   // Alt-click: add a point
+      p.verts.push([ax, ay]);
+      drag = {vert: {p, i: p.verts.length - 1}};
+      state.dirty = true;
+      return;
+    }
+    const seg = nearestSegment(p, ax, ay, tol);
+    if (seg) {   // click near an edge: insert a vertex there and drag it right away
+      p.verts.splice(seg.i + 1, 0, [seg.x, seg.y]);
+      drag = {vert: {p, i: seg.i + 1}};
+      state.dirty = true;
+      return;
+    }
+  }
+  drag = {pan: {x: e.clientX, y: e.clientY, cx: state.view.cx, cy: state.view.cy}};
+  canvas.classList.add('panning');
+});
+window.addEventListener('mousemove', e => {
+  if (state.world0) {
+    const [ax, ay] = screenToRd(e.clientX, e.clientY);
+    $('coords').textContent = `${Math.round(ax)}, ${Math.round(ay)} RD`;
+  }
+  if (!drag) {
+    const p = editTarget();   // hover feedback over a movable point
+    if (p) {
+      const [ax, ay] = screenToRd(e.clientX, e.clientY);
+      canvas.classList.toggle('vtx', nearestVert(p, ax, ay, hitTol()) >= 0);
+    } else if (canvas.classList.contains('vtx')) canvas.classList.remove('vtx');
+    return;
+  }
+  if (drag.pan) {
+    const dpr = window.devicePixelRatio || 1;
+    state.view.cx = drag.pan.cx - (e.clientX - drag.pan.x) * dpr / state.view.ppm;
+    state.view.cy = drag.pan.cy + (e.clientY - drag.pan.y) * dpr / state.view.ppm;
+    state.dirty = true;
+  } else if (drag.vert) {
+    drag.vert.p.verts[drag.vert.i] = screenToRd(e.clientX, e.clientY);
+    state.dirty = true;
+  }
+});
+window.addEventListener('mouseup', () => {
+  if (drag && drag.vert) onPolygonsChanged();
+  drag = null;
+  canvas.classList.remove('panning');
+});
+canvas.addEventListener('contextmenu', e => {
+  const p = editTarget();
+  if (!p) return;                            // not editing — normal context menu
+  e.preventDefault();
+  const [ax, ay] = screenToRd(e.clientX, e.clientY);
+  const i = nearestVert(p, ax, ay, hitTol());
+  if (i < 0) return;
+  const type = p.type || 'polygon';
+  if (p.verts.length <= (MIN_VERTS[type] || 3)) {
+    toast(`a ${type} needs at least ${MIN_VERTS[type]} point(s)`, true);
+    return;
+  }
+  p.verts.splice(i, 1);
+  onPolygonsChanged();
+});
+canvas.addEventListener('wheel', e => {
+  e.preventDefault();
+  const f = Math.exp(-e.deltaY * 0.0013);
+  const [wx, wy] = screenToWorld(e.clientX, e.clientY);
+  state.view.ppm *= f;
+  const [wx2, wy2] = screenToWorld(e.clientX, e.clientY);
+  state.view.cx += wx - wx2;
+  state.view.cy += wy - wy2;
+  state.dirty = true;
+}, {passive: false});
+canvas.addEventListener('click', e => {
+  if (state.tool !== 'draw' || !state.world0) return;
+  state.draft.push(screenToRd(e.clientX, e.clientY));
+  // two-click shapes finish themselves; others keep the coord table live
+  const m = state.drawMode || 'polygon';
+  if ((m === 'transect' || m === 'bbox') && state.draft.length === 2) finishDraft();
+  else if (typeof ObjectsPanel !== 'undefined') ObjectsPanel.refresh();
+  state.dirty = true;
+});
+canvas.addEventListener('dblclick', e => {
+  if (state.tool === 'draw') {
+    e.preventDefault();
+    if (state.draft.length > 1) state.draft.pop();   // drop the dblclick's extra vertex
+    finishDraft();
+  }
+});
+window.addEventListener('keydown', e => {
+  if (e.target.tagName === 'INPUT' || e.target.tagName === 'SELECT' || e.target.tagName === 'TEXTAREA') return;
+  if (e.key === 'Escape') {
+    if (state.tool === 'draw') {
+      state.draft = []; state.tool = 'pan'; refreshToolButtons(); state.dirty = true;
+      if (typeof ObjectsPanel !== 'undefined') ObjectsPanel.refresh();
+    } else if (state.tool === 'edit') {
+      state.editSel = null; state.tool = 'pan'; refreshToolButtons(); state.dirty = true;
+      if (typeof ObjectsPanel !== 'undefined') ObjectsPanel.refresh();
+    }
+    closeSwatchPop();
+    document.querySelectorAll('.modal-back').forEach(m => m.style.display = 'none');
+    return;
+  }
+  // playback shortcuts work everywhere (the playbar is global); polygon-draw
+  // finish works wherever the draw tool is armed
+  if (e.code === 'Space') { e.preventDefault(); togglePlay(); }
+  else if (e.key === 'Enter' && state.tool === 'draw') finishDraft();
+  else if (e.key === 'ArrowRight') stepDays(1);
+  else if (e.key === 'ArrowLeft') stepDays(-1);
+});

--- a/sedtrails-gui/web/js/core/layers-panel.js
+++ b/sedtrails-gui/web/js/core/layers-panel.js
@@ -1,0 +1,176 @@
+"use strict";
+/* ═════════════════════════ Overlays section (ex Layers panel) ═════════════
+   The floating Layers panel was merged into the Viewer tab's sidebar: this
+   module now renders the Overlays section (#ov-body) — seeding previews,
+   objects master eye and the connectivity network, the drawn things that have
+   no other native controls in the sidebar. Particles/forcing/background got
+   native sidebar controls in the merge. Still a VIEW over the existing
+   globals (state.*, SeedingTab.previews) — it owns no state of its own.
+   The module keeps its name because refresh() is called from everywhere and
+   the Objects panel reuses its ui helpers + wirePanel. */
+
+const LayersPanel = (() => {
+  const el = () => $('ov-body');
+
+  function eyeBtn(shown, onClick) {
+    const b = document.createElement('button');
+    b.className = 'eye' + (shown ? '' : ' off');
+    b.textContent = '👁';
+    b.onclick = ev => { ev.preventDefault(); ev.stopPropagation(); onClick(); };
+    return b;
+  }
+
+  function row(...els) {
+    const r = document.createElement('div');
+    r.className = 'lp-row';
+    for (const e of els) r.appendChild(e);
+    return r;
+  }
+
+  function label(txt, dimmed) {
+    const s = document.createElement('span');
+    s.className = 'grow' + (dimmed ? ' dim' : '');
+    s.style.cssText = 'overflow:hidden;text-overflow:ellipsis;white-space:nowrap';
+    s.textContent = txt;
+    return s;
+  }
+
+  function groupHead(txt, ...extras) {
+    const s = document.createElement('div');
+    s.className = 'lp-group';
+    s.appendChild(document.createTextNode(txt));
+    const tools = document.createElement('span');
+    tools.className = 'lp-tools';
+    for (const e of extras) e && tools.appendChild(e);
+    s.appendChild(tools);
+    return s;
+  }
+
+  /* collapsible group: <details> whose summary is the group header.
+     Extras (↗ link, group eye) sit right-aligned in a .lp-tools span so every
+     group header reads the same: ▸ NAME … [link][eye] */
+  function groupBox(key, txt, ...extras) {
+    const d = document.createElement('details');
+    d.open = localStorage.getItem('stgui_obj_' + key) !== '0';
+    d.addEventListener('toggle', () =>
+      localStorage.setItem('stgui_obj_' + key, d.open ? '1' : '0'));
+    const s = document.createElement('summary');
+    s.className = 'lp-group';
+    s.appendChild(document.createTextNode(txt));
+    const tools = document.createElement('span');
+    tools.className = 'lp-tools';
+    for (const e of extras) e && tools.appendChild(e);
+    s.appendChild(tools);
+    d.appendChild(s);
+    return d;
+  }
+
+  function swatch(color, hollow) {
+    const s = document.createElement('span');
+    s.className = 'swatch' + (hollow ? ' hollow' : '');
+    if (hollow) s.style.borderColor = color;
+    else s.style.background = color;
+    return s;
+  }
+
+  function mini(txt, title, fn) {
+    const b = document.createElement('button');
+    b.className = 'mini';
+    b.textContent = txt;
+    b.title = title;
+    b.onclick = ev => { ev.preventDefault(); ev.stopPropagation(); fn(); };
+    return b;
+  }
+
+  function link(tab, title) {
+    return mini('↗', title, () => Tabs.activate(tab));
+  }
+
+  const OBJ_GLYPH = {polygon: '⬠', point: '•', transect: '╱', bbox: '▭'};
+  const sync = () => { if (typeof syncVis === 'function') syncVis(); };
+
+  function refresh() {
+    const body = el();
+    if (body) {
+      body.innerHTML = '';
+
+      /* ── seeding previews: ONE eye + per-population legend ── */
+      if (typeof SeedingTab !== 'undefined') {
+        const names = SeedingTab.popNames();
+        if (names.length) {
+          const shown = SeedingTab.showPreviews();
+          body.appendChild(groupHead('Seeding previews',
+            link('seeding', 'open the Populations tab'),
+            eyeBtn(shown, () => {
+              SeedingTab.setShowPreviews(!shown);
+              refresh();
+            })));
+          const previews = SeedingTab.previews();
+          names.forEach((nm, i) => {
+            const pv = previews[i];
+            body.appendChild(row(
+              swatch(PALETTE[i % PALETTE.length], true),
+              label(nm + (pv && pv.n ? '' : ' (no preview)'), !shown || !(pv && pv.n))));
+          });
+        }
+      }
+
+      /* ── objects: master eye + a one-line summary (per-object visibility
+         and management live in the floating Objects panel, top right) ── */
+      body.appendChild(groupHead('Objects',
+        eyeBtn(state.showOutlines, () => {
+          state.showOutlines = !state.showOutlines;
+          sync(); state.dirty = true; refresh();
+        })));
+      body.appendChild(row(label(state.polygons.length
+        ? `${state.polygons.length} object(s) — manage in the Objects panel (top right)`
+        : 'none drawn yet — see the Objects panel (top right)', true)));
+
+      /* ── connectivity network: nodes at cell centroids + directed edges from
+         the last computed matrix (Connectivity tab); drawn by drawConnectivity */
+      if (state.connectivity) {
+        body.appendChild(groupHead('Connectivity',
+          link('connectivity', 'open the Connectivity tab'),
+          eyeBtn(state.showConnectivity, () => {
+            state.showConnectivity = !state.showConnectivity;
+            state.dirty = true; refresh();
+          })));
+        const con = state.connectivity;
+        body.appendChild(row(label(
+          `${con.labels.length} cells · ` +
+          (con.mode === 'start_end' ? 'start → end' : 'start → ever visited') +
+          (con.normalize === 'fraction' ? ' · fractions' : ' · counts'),
+          !state.showConnectivity)));
+        body.appendChild(row(label('edge width ∝ value · node size ∝ departures', true)));
+      }
+    }
+
+    if (typeof ObjectsPanel !== 'undefined') ObjectsPanel.refresh();
+  }
+
+  /* collapse persistence + header chevron button for a floating panel —
+     the chevron matches the sidebar's hide button so panel-level collapse
+     reads differently from the small group triangles inside */
+  function wirePanel(id, lsKey) {
+    const panel = $(id);
+    if (!panel) return;
+    const tgl = panel.querySelector('summary .panel-toggle');
+    const syncTgl = () => { if (tgl) tgl.textContent = panel.open ? '▾' : '▸'; };
+    if (tgl) tgl.onclick = ev => {     // buttons swallow the summary click
+      ev.preventDefault(); ev.stopPropagation();
+      panel.open = !panel.open;
+    };
+    panel.open = localStorage.getItem(lsKey) === '1';   // collapsed by default
+    panel.addEventListener('toggle', () => {
+      localStorage.setItem(lsKey, panel.open ? '1' : '0');
+      syncTgl();
+    });
+    syncTgl();
+  }
+  // (the floating #layerspanel is hidden — no wirePanel for it anymore)
+
+  /* small shared UI helpers, reused by the Objects panel */
+  return {refresh, wirePanel,
+          ui: {eyeBtn, row, label, groupHead, groupBox, swatch, mini, link}};
+})();
+LayersPanel.refresh();

--- a/sedtrails-gui/web/js/core/mesh.js
+++ b/sedtrails-gui/web/js/core/mesh.js
@@ -1,0 +1,84 @@
+"use strict";
+/* ═════════════════════════ model-layer mesh ═════════════════════════ */
+async function loadMesh(run) {
+  const m = run.meta.mesh;
+  if (!m || state.mesh) return;
+  try {
+    const buf = await (await fetch(`/data/${run.id}/${m.file}`)).arrayBuffer();
+    const N = m.n_nodes, M = m.n_tris;
+    let o = 0;
+    const xy = new Float32Array(buf, o, N * 2); o += N * 8;
+    const bed = new Float32Array(buf, o, N);    o += N * 4;
+    const dz = new Float32Array(buf, o, N);     o += N * 4;
+    const tris = new Uint32Array(buf, o, M * 3);
+
+    const posB = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, posB);
+    gl.bufferData(gl.ARRAY_BUFFER, xy, gl.STATIC_DRAW);
+    const idxB = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, idxB);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, tris, gl.STATIC_DRAW);
+
+    const mkVao = vals => {
+      const vb = gl.createBuffer();
+      gl.bindBuffer(gl.ARRAY_BUFFER, vb);
+      gl.bufferData(gl.ARRAY_BUFFER, vals, gl.STATIC_DRAW);
+      const vao = gl.createVertexArray();
+      gl.bindVertexArray(vao);
+      gl.bindBuffer(gl.ARRAY_BUFFER, posB);
+      gl.enableVertexAttribArray(0); gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 8, 0);
+      gl.bindBuffer(gl.ARRAY_BUFFER, vb);
+      gl.enableVertexAttribArray(1); gl.vertexAttribPointer(1, 1, gl.FLOAT, false, 4, 0);
+      gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, idxB);
+      gl.bindVertexArray(null);
+      return vao;
+    };
+    state.mesh = {
+      runId: run.id,
+      off: [run.quantU[2], run.quantU[3]],
+      nIdx: M * 3,
+      vaoBed: mkVao(bed),
+      vaoDz: mkVao(dz),
+      climBed: m.clim_bed,
+      climDz: m.clim_dz,
+      hasDz: m.has_dz,
+      rampBed: makeRampTexture(m.cmap_bed.filter((_, i) => i % 16 === 0)),
+      rampDz: makeRampTexture(m.cmap_dz.filter((_, i) => i % 16 === 0)),
+    };
+    // model layer stays OFF by default — the Background group only carries the
+    // base map now; bathymetry is shown through the Forcing layers instead
+    refreshModelLayers();
+    state.dirty = true;
+  } catch (e) {
+    toast('Model layer failed to load: ' + e.message, true);
+  }
+}
+
+function refreshModelLayers() {
+  const sel = $('sel-model');
+  const cur = state.modelLayer;
+  sel.innerHTML = '<option value="bed">bathymetry</option>' +
+    (state.mesh && state.mesh.hasDz ? '<option value="dz">bed-level change</option>' : '');
+  sel.value = cur;
+  if (sel.value !== cur) { sel.value = 'bed'; state.modelLayer = 'bed'; }
+  syncVis();
+  if (typeof LayersPanel !== 'undefined') LayersPanel.refresh();
+}
+
+function drawMeshLayer() {
+  const m = state.mesh;
+  if (!m || !state.showModel) return;
+  const useDz = state.modelLayer === 'dz';
+  gl.useProgram(progMesh.prog);
+  gl.uniform4fv(progMesh.u.uView, viewUniform());
+  gl.uniform2fv(progMesh.u.uOff, m.off);
+  gl.uniform2fv(progMesh.u.uClim, useDz ? m.climDz : m.climBed);
+  gl.uniform1f(progMesh.u.uAlpha, state.meshAlpha);
+  gl.activeTexture(gl.TEXTURE0);
+  gl.bindTexture(gl.TEXTURE_2D, useDz ? m.rampDz : m.rampBed);
+  gl.uniform1i(progMesh.u.uRamp, 0);
+  gl.bindVertexArray(useDz ? m.vaoDz : m.vaoBed);
+  gl.drawElements(gl.TRIANGLES, m.nIdx, gl.UNSIGNED_INT, 0);
+  gl.bindVertexArray(null);
+}
+

--- a/sedtrails-gui/web/js/core/objects-panel.js
+++ b/sedtrails-gui/web/js/core/objects-panel.js
@@ -1,0 +1,203 @@
+"use strict";
+/* ═════════════════════════ floating Objects panel ═════════════════════════
+   THE central manager for all map shapes (polygons, boxes, transects, point
+   sets) — one shared store (state.polygons, persisted server-side). Objects
+   are created here (draw / import), renamed, re-colored, re-ordered, edited
+   and deleted here — other tabs only PICK from this store (seeding areas,
+   filter rules, connectivity). Visibility of the whole group is toggled in
+   the Layers panel; per-object eyes live here. */
+
+const ObjectsPanel = (() => {
+  const el = () => $('op-body');
+  const GLYPH = {polygon: '⬠', point: '•', transect: '╱', bbox: '▭'};
+  const fmtC = v => String(Math.round(v * 100) / 100);
+
+  /* editable coordinate table over a live [[x,y],…] array (object verts or
+     the current draft) — commit on change, so typing keeps focus */
+  function coordTable(verts, {onChange, minVerts, addLabel}) {
+    const {mini} = LayersPanel.ui;
+    const t = document.createElement('div');
+    t.className = 'op-coords';
+    const head = document.createElement('div');
+    head.className = 'op-crow dim';
+    head.innerHTML = '<span></span><i>x [m]</i><i>y [m]</i>';
+    t.appendChild(head);
+    verts.forEach((v, i) => {
+      const r = document.createElement('div');
+      r.className = 'op-crow';
+      const idx = document.createElement('span');
+      idx.textContent = i + 1;
+      const num = (k) => {
+        const inp = document.createElement('input');
+        inp.value = fmtC(v[k]);
+        inp.onchange = () => {
+          const f = parseFloat(inp.value);
+          if (isFinite(f)) { v[k] = f; onChange(); }
+          else inp.value = fmtC(v[k]);
+        };
+        return inp;
+      };
+      const del = mini('✕', 'remove this point', () => {
+        if (verts.length <= minVerts) {
+          toast(`needs at least ${minVerts} point(s)`, true);
+          return;
+        }
+        verts.splice(i, 1);
+        onChange();
+      });
+      r.append(idx, num(0), num(1), del);
+      t.appendChild(r);
+    });
+    const foot = document.createElement('div');
+    foot.className = 'op-crow';
+    foot.appendChild(mini('＋ point', addLabel, () => {
+      const last = verts[verts.length - 1];
+      const off = 25 / state.view.ppm * (window.devicePixelRatio || 1);
+      verts.push(last ? [last[0] + off, last[1] + off] : [0, 0]);
+      onChange();
+    }));
+    t.appendChild(foot);
+    return t;
+  }
+
+  function refresh() {
+    const body = el();
+    if (!body || typeof LayersPanel === 'undefined') return;
+    const {eyeBtn, row, label, mini} = LayersPanel.ui;
+    body.innerHTML = '';
+
+    /* ── toolbar: draw a new object / import from file ── */
+    const bar = document.createElement('div');
+    bar.className = 'op-toolbar';
+    for (const [mode, txt, title] of [
+      ['point', '• points', 'draw a set of points (click, Enter to finish)'],
+      ['transect', '╱ transect', 'draw a transect (2 clicks)'],
+      ['bbox', '▭ box', 'draw a box (2 corner clicks)'],
+      ['polygon', '⬠ polygon', 'draw a polygon (Enter/double-click to finish)'],
+    ]) {
+      const b = document.createElement('button');
+      b.className = 'mini' +
+        (state.tool === 'draw' && (state.drawMode || 'polygon') === mode ? ' active' : '');
+      b.textContent = txt;
+      b.title = title;
+      b.onclick = () => startDrawObject(mode);
+      bar.appendChild(b);
+    }
+    const imp = document.createElement('button');
+    imp.className = 'mini';
+    imp.textContent = '⇪ import';
+    imp.title = 'import polygons (.txt file or folder)';
+    imp.onclick = () => $('btn-poly-import').onclick();
+    bar.appendChild(imp);
+    // bulk-remove the auto-generated connectivity cells (only shown if any)
+    if (typeof ConnectivityTab !== 'undefined' &&
+        state.polygons.some(p => ConnectivityTab.AUTO_RE.test(p.name))) {
+      const del = document.createElement('button');
+      del.className = 'mini danger';
+      del.textContent = '✕ auto cells';
+      del.title = 'remove all auto-generated cells (auto_cell_*)';
+      del.onclick = () => ConnectivityTab.removeAutoCells();
+      bar.appendChild(del);
+    }
+    body.appendChild(bar);
+
+    /* live coordinates of the shape being drawn */
+    if (state.tool === 'draw' && state.draft.length) {
+      body.appendChild(row(label('new ' +
+        (OBJ_LABEL[state.drawMode || 'polygon'] || 'object') + ' — coordinates', true)));
+      body.appendChild(coordTable(state.draft, {
+        minVerts: 1,
+        addLabel: 'add a point (or click the map)',
+        onChange: () => { state.dirty = true; refresh(); },
+      }));
+    }
+
+    if (!state.polygons.length) {
+      body.appendChild(row(label('no objects yet — draw or import above', true)));
+      return;
+    }
+
+    state.polygons.forEach((p, i) => {
+      const type = p.type || 'polygon';
+      const editing = state.editSel && state.editSel.name === p.name;
+
+      const glyph = document.createElement('span');
+      glyph.className = 'dim';
+      glyph.style.cssText = 'width:14px;text-align:center;flex:none';
+      glyph.textContent = GLYPH[type];
+      glyph.title = type;
+
+      const nameInp = document.createElement('input');
+      nameInp.className = 'lp-name';
+      nameInp.value = p.name;
+      nameInp.title = 'click to rename';
+      nameInp.onchange = () => {
+        let nn = nameInp.value.trim() || p.name;
+        while (state.polygons.some(q => q !== p && q.name === nn)) nn += '*';
+        if (state.editSel && state.editSel.name === p.name) state.editSel = {name: nn};
+        p.name = nn;
+        onPolygonsChanged();
+        refresh();
+      };
+
+      const colorBtn = typeof mkColorBtn === 'function'
+        ? mkColorBtn(() => p.color || '#445566',
+                     c => {
+                       p.color = c;
+                       savePolygons();
+                       if (typeof rebuildPaletteTex === 'function') rebuildPaletteTex();
+                       if (typeof refreshRules === 'function') refreshRules();
+                       state.dirty = true;
+                       LayersPanel.refresh();
+                     },
+                     'object color')
+        : LayersPanel.ui.swatch(p.color || '#445566');
+
+      const edit = mini('✎', editing ? 'stop editing' : 'edit points (map + table)', () => {
+        state.editSel = editing ? null : {name: p.name};
+        state.tool = state.editSel ? 'edit' : 'pan';
+        if (typeof refreshToolButtons === 'function') refreshToolButtons();
+        state.dirty = true;
+        refresh();
+      });
+      if (editing) edit.classList.add('active');
+
+      body.appendChild(row(
+        eyeBtn(!p.hidden, () => {
+          p.hidden = !p.hidden;
+          savePolygons();
+          state.dirty = true;
+          LayersPanel.refresh();
+        }),
+        colorBtn, glyph, nameInp, edit,
+        mini('▲', 'move up', () => {
+          if (i === 0) return;
+          [state.polygons[i - 1], state.polygons[i]] =
+            [state.polygons[i], state.polygons[i - 1]];
+          onPolygonsChanged();
+          refresh();
+        }),
+        mini('✕', 'delete object', () => {
+          if (!confirm(`Delete "${p.name}"?`)) return;
+          state.polygons.splice(i, 1);
+          if (state.editSel && state.editSel.name === p.name) state.editSel = null;
+          onPolygonsChanged();
+          refresh();
+        })));
+
+      if (editing) {
+        body.appendChild(coordTable(p.verts, {
+          minVerts: MIN_VERTS[type] || 3,
+          addLabel: 'add a point (or click an edge on the map)',
+          onChange: () => { onPolygonsChanged(); refresh(); },
+        }));
+      }
+    });
+  }
+
+  /* collapse persistence + header chevron (shared with the Layers panel) */
+  LayersPanel.wirePanel('objectspanel', 'stgui_objectspanel_open');
+
+  return {refresh};
+})();
+ObjectsPanel.refresh();

--- a/sedtrails-gui/web/js/core/playbar.js
+++ b/sedtrails-gui/web/js/core/playbar.js
@@ -1,0 +1,59 @@
+"use strict";
+/* ═════════════════════════ playback / clock ═════════════════════════ */
+function forcingTimeDays() {
+  return (typeof ForcingTab !== 'undefined' && ForcingTab.state.timeDays &&
+          ForcingTab.state.timeDays.length) ? ForcingTab.state.timeDays : null;
+}
+
+function clockHasSources() {
+  return state.runs.length > 0 || !!forcingTimeDays();
+}
+
+function updateClockRange() {
+  // union of every time source: all particle runs + the open forcing file
+  let t0 = Infinity, t1 = -Infinity;
+  for (const r of state.runs) {
+    const td = r.meta.time_days;
+    t0 = Math.min(t0, r.epoch + td[0]);
+    t1 = Math.max(t1, r.epoch + td[td.length - 1]);
+  }
+  const ftd = forcingTimeDays();
+  if (ftd) {
+    t0 = Math.min(t0, ftd[0]);
+    t1 = Math.max(t1, ftd[ftd.length - 1]);
+  }
+  if (!isFinite(t0)) return;                 // no sources — keep defaults
+  state.clock.t0 = t0; state.clock.t1 = t1;
+  state.clock.t = Math.min(Math.max(state.clock.t, t0), t1);
+  if (!isFinite(state.clock.t)) state.clock.t = t0;
+}
+
+function frameAt(run, absDay) {
+  const td = run.meta.time_days;
+  const local = absDay - run.epoch;
+  let lo = 0, hi = td.length - 1;
+  if (local <= td[0]) return {k: 0, frac: 0};
+  if (local >= td[hi]) return {k: hi, frac: 0};
+  while (hi - lo > 1) {
+    const mid = (lo + hi) >> 1;
+    if (td[mid] <= local) lo = mid; else hi = mid;
+  }
+  const span = td[hi] - td[lo];
+  return {k: lo, frac: span > 0 ? (local - td[lo]) / span : 0};
+}
+
+function loadedFrontier() {
+  let front = state.clock.t1;
+  for (const r of state.runs) {
+    if (!r.visible) continue;
+    const td = r.meta.time_days;
+    const k = Math.max(0, Math.min(r.loaded - 1, td.length - 1));
+    if (r.loaded < td.length) front = Math.min(front, r.epoch + td[Math.max(0, k - 1)]);
+  }
+  return front;
+}
+
+function fmtDate(absDay) {
+  return new Date(absDay * 86400000).toISOString().slice(0, 10);
+}
+

--- a/sedtrails-gui/web/js/core/render.js
+++ b/sedtrails-gui/web/js/core/render.js
@@ -1,0 +1,428 @@
+"use strict";
+/* ═════════════════════════ rendering ═════════════════════════ */
+function resize() {
+  if (state.exporting) return;
+  const dpr = window.devicePixelRatio || 1;
+  const w = Math.round(canvas.clientWidth * dpr);
+  const h = Math.round(canvas.clientHeight * dpr);
+  if (canvas.width !== w || canvas.height !== h) {
+    canvas.width = w; canvas.height = h;
+    state.dirty = true;
+  }
+}
+
+function viewUniform() {
+  const {cx, cy, ppm} = state.view;
+  const sx = 2 * ppm / canvas.width, sy = 2 * ppm / canvas.height;
+  return [sx, sy, -cx * sx, -cy * sy];
+}
+
+function fitView(run) {
+  const e = run.meta.extent;
+  const w = e[1] - e[0], h = e[3] - e[2];
+  state.view.cx = (e[0] + e[1]) / 2 - state.world0[0];
+  state.view.cy = (e[2] + e[3]) / 2 - state.world0[1];
+  state.view.ppm = Math.min(canvas.width / w, canvas.height / h) * 0.94;
+}
+
+function screenToWorld(px, py) {
+  const dpr = window.devicePixelRatio || 1;
+  const x = (px * dpr - canvas.width / 2) / state.view.ppm + state.view.cx;
+  const y = (canvas.height / 2 - py * dpr) / state.view.ppm + state.view.cy;
+  return [x, y];
+}
+function screenToRd(px, py) {
+  const [lx, ly] = screenToWorld(px, py);
+  return state.world0 ? [lx + state.world0[0], ly + state.world0[1]] : [lx, ly];
+}
+
+function uploadFrame(run, k, slot) {
+  const fr = run.frames[k];
+  if (!fr) return false;
+  gl.bindBuffer(gl.ARRAY_BUFFER, slot === 0 ? run.posA : run.posB);
+  gl.bufferSubData(gl.ARRAY_BUFFER, 0, fr);
+  if (run.burFrames && run.burFrames[k]) {
+    gl.bindBuffer(gl.ARRAY_BUFFER, slot === 0 ? run.burA : run.burB);
+    gl.bufferSubData(gl.ARRAY_BUFFER, 0, run.burFrames[k]);
+  }
+  if (run.flagFrames && run.flagFrames[k]) {
+    gl.bindBuffer(gl.ARRAY_BUFFER, slot === 0 ? run.flgA : run.flgB);
+    gl.bufferSubData(gl.ARRAY_BUFFER, 0, run.flagFrames[k]);
+  }
+  run.bufFrame[slot] = k;
+  return true;
+}
+
+function setRuleUniforms(prog, run) {
+  const compiled = compiledRules(run);
+  const ri = new Int32Array(MAX_RULES * 4);
+  const rc = new Float32Array(MAX_RULES * 4);
+  const rt = new Float32Array(MAX_RULES * 2);
+  compiled.forEach((r, i) => {
+    ri[i*4] = r.c1.c; ri[i*4+1] = r.c1.a; ri[i*4+2] = r.c2.c; ri[i*4+3] = r.c2.a;
+    rc[i*4] = r.rgb[0]/255; rc[i*4+1] = r.rgb[1]/255; rc[i*4+2] = r.rgb[2]/255;
+    rc[i*4+3] = r.action;
+    rt[i*2] = r.c1.t; rt[i*2+1] = r.c2.t;
+  });
+  gl.uniform1i(prog.u.uNRules, compiled.length);
+  gl.uniform4iv(prog.u.uRuleI, ri);
+  gl.uniform4fv(prog.u.uRuleC, rc);
+  gl.uniform2fv(prog.u.uRuleT, rt);
+  const d = state.defaultApp;
+  const defAction = d.action === 'hide' ? 0 : d.action === 'color' ? 1
+    : d.action === 'colorby' ? (d.colorby === 'burial' ? 2 : d.colorby === 'age' ? 3 : 4)
+    : d.action === 'palette-origin' ? 5 : d.action === 'palette-final' ? 6 : 7;
+  gl.uniform1i(prog.u.uDefAction, defAction);
+  const dc = hex2rgb(d.color || NEUTRAL);
+  gl.uniform3f(prog.u.uDefColor, dc[0]/255, dc[1]/255, dc[2]/255);
+  const tc = hex2rgb(run.tint);
+  gl.uniform3f(prog.u.uTint, tc[0]/255, tc[1]/255, tc[2]/255);
+}
+
+function drawPoints(run, frac, kCur, kNext) {
+  let vaoIdx;
+  if (run.bufFrame[0] === kCur && run.bufFrame[1] === kNext) vaoIdx = 0;
+  else if (run.bufFrame[1] === kCur && run.bufFrame[0] === kNext) vaoIdx = 1;
+  else if (run.bufFrame[1] === kCur) { uploadFrame(run, kNext, 0); vaoIdx = 1; }
+  else if (run.bufFrame[0] === kNext) { uploadFrame(run, kCur, 1); vaoIdx = 1; }
+  else if (run.bufFrame[1] === kNext) { uploadFrame(run, kCur, 0); vaoIdx = 0; }
+  else { uploadFrame(run, kCur, 0); uploadFrame(run, kNext, 1); vaoIdx = 0; }
+  if (run.bufFrame[vaoIdx] !== kCur) return;
+
+  const sizePx = state.pointSize * (window.devicePixelRatio || 1);
+  gl.useProgram(progPt.prog);
+  gl.uniform4fv(progPt.u.uQuant, run.quantU);
+  gl.uniform4fv(progPt.u.uView, viewUniform());
+  gl.uniform1f(progPt.u.uFrac, kNext === kCur ? 0 : frac);
+  gl.uniform1f(progPt.u.uPointSize, sizePx);
+  gl.uniform1f(progPt.u.uRound, sizePx >= 2.0 ? 1 : 0);
+  gl.uniform1f(progPt.u.uAlpha, state.alpha);
+  gl.uniform1f(progPt.u.uBurMax, run.meta.burial_max || 0.01);
+  const fadeQ = state.fade.bur && run.meta.has_burial
+    ? Math.max(state.fade.depth, 0.001) / (run.meta.burial_max || 0.01) * 65534 : 0;
+  gl.uniform3f(progPt.u.uFade, fadeQ,
+               state.fade.imm && run.flagFrames ? 1 : 0, state.fade.alpha);
+  const td = run.meta.time_days;
+  gl.uniform1f(progPt.u.uNowDays, Math.max(0, state.clock.t - run.epoch - td[0]));
+  gl.uniform2fv(progPt.u.uVRbur, effRange('burial'));
+  gl.uniform2fv(progPt.u.uVRage, effRange('age'));
+  gl.uniform2fv(progPt.u.uVRfirst, effRange('first'));
+  setRuleUniforms(progPt, run);
+  gl.activeTexture(gl.TEXTURE0); gl.bindTexture(gl.TEXTURE_2D, cmapTex(state.pointCmap));
+  gl.uniform1i(progPt.u.uCmap, 0);
+  gl.activeTexture(gl.TEXTURE1); gl.bindTexture(gl.TEXTURE_2D, paletteTex);
+  gl.uniform1i(progPt.u.uPalette, 1);
+  gl.bindVertexArray(run.vaos[vaoIdx]);
+  gl.drawElements(gl.POINTS, Math.ceil(run.N / state.decim), gl.UNSIGNED_INT, 0);
+  gl.bindVertexArray(null);
+}
+
+function drawPolyFill(p, rgb) {
+  // stencil parity fill — works for concave polygons, no triangulation needed
+  const w0 = state.world0;
+  const n = p.verts.length;
+  const arr = new Float32Array(n * 2);
+  let bx0 = Infinity, bx1 = -Infinity, by0 = Infinity, by1 = -Infinity;
+  for (let i = 0; i < n; i++) {
+    const x = p.verts[i][0] - w0[0], y = p.verts[i][1] - w0[1];
+    arr[i*2] = x; arr[i*2+1] = y;
+    bx0 = Math.min(bx0, x); bx1 = Math.max(bx1, x);
+    by0 = Math.min(by0, y); by1 = Math.max(by1, y);
+  }
+  gl.enable(gl.STENCIL_TEST);
+  gl.clear(gl.STENCIL_BUFFER_BIT);
+  gl.colorMask(false, false, false, false);
+  gl.stencilFunc(gl.ALWAYS, 0, 0xff);
+  gl.stencilOp(gl.KEEP, gl.KEEP, gl.INVERT);
+  gl.bufferData(gl.ARRAY_BUFFER, arr, gl.DYNAMIC_DRAW);
+  gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 8, 0);
+  gl.drawArrays(gl.TRIANGLE_FAN, 0, n);
+  gl.colorMask(true, true, true, true);
+  gl.stencilFunc(gl.EQUAL, 1, 1);
+  gl.stencilOp(gl.KEEP, gl.KEEP, gl.KEEP);
+  const quad = new Float32Array([bx0, by0, bx1, by0, bx0, by1, bx1, by1]);
+  gl.bufferData(gl.ARRAY_BUFFER, quad, gl.DYNAMIC_DRAW);
+  gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 8, 0);
+  gl.uniform4f(progFlat.u.uColor, rgb[0]/255, rgb[1]/255, rgb[2]/255, 0.25);
+  gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+  gl.disable(gl.STENCIL_TEST);
+}
+
+/* WebGL lineWidth > 1 is unsupported on Windows/ANGLE — thick lines are drawn
+   as per-segment quads (screen-space width) plus round joint points that hide
+   the segment seams. Expects progFlat active, the scratch buffer bound and
+   uColor set; leaves uRound at 0. */
+function strokePath(arr, n, closed, pxWidth) {
+  const dpr = window.devicePixelRatio || 1;
+  const hw = pxWidth * dpr / state.view.ppm / 2;          // half-width, world units
+  const segs = closed ? n : n - 1;
+  const quads = new Float32Array(segs * 12);
+  let o = 0;
+  for (let i = 0; i < segs; i++) {
+    const j = (i + 1) % n;
+    const x0 = arr[i*2], y0 = arr[i*2+1], x1 = arr[j*2], y1 = arr[j*2+1];
+    let dx = x1 - x0, dy = y1 - y0;
+    const L = Math.hypot(dx, dy) || 1;
+    const nx = -dy / L * hw, ny = dx / L * hw;
+    quads[o++] = x0+nx; quads[o++] = y0+ny; quads[o++] = x0-nx; quads[o++] = y0-ny;
+    quads[o++] = x1+nx; quads[o++] = y1+ny;
+    quads[o++] = x1+nx; quads[o++] = y1+ny; quads[o++] = x0-nx; quads[o++] = y0-ny;
+    quads[o++] = x1-nx; quads[o++] = y1-ny;
+  }
+  gl.bufferData(gl.ARRAY_BUFFER, quads, gl.DYNAMIC_DRAW);
+  gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 8, 0);
+  gl.drawArrays(gl.TRIANGLES, 0, quads.length / 2);
+  gl.bufferData(gl.ARRAY_BUFFER, arr, gl.DYNAMIC_DRAW);
+  gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 8, 0);
+  gl.uniform1f(progFlat.u.uPtSize, pxWidth * dpr);
+  gl.uniform1f(progFlat.u.uRound, 1);
+  gl.drawArrays(gl.POINTS, 0, n);
+  gl.uniform1f(progFlat.u.uRound, 0);
+}
+
+function drawPolyOutlines() {
+  if (!state.world0) return;
+  gl.useProgram(progFlat.prog);
+  gl.uniform4fv(progFlat.u.uView, viewUniform());
+  gl.uniform1f(progFlat.u.uPtSize, 7);
+  if (!drawPolyOutlines.buf) drawPolyOutlines.buf = gl.createBuffer();
+  gl.bindBuffer(gl.ARRAY_BUFFER, drawPolyOutlines.buf);
+  gl.enableVertexAttribArray(0);
+  const w0 = state.world0;
+  for (const p of state.polygons) {
+    const sel = state.editSel && state.editSel.name === p.name;
+    if (!sel && (!state.showOutlines || p.hidden)) continue;
+    const type = p.type || 'polygon';
+    const rgb = hex2rgb(p.color || '#445566');
+    if (sel && type !== 'point' && type !== 'transect') drawPolyFill(p, rgb);
+    const arr = new Float32Array(p.verts.length * 2);
+    for (let i = 0; i < p.verts.length; i++) {
+      arr[i*2] = p.verts[i][0] - w0[0]; arr[i*2+1] = p.verts[i][1] - w0[1];
+    }
+    gl.bindBuffer(gl.ARRAY_BUFFER, drawPolyOutlines.buf);
+    gl.uniform4f(progFlat.u.uColor, rgb[0]/255, rgb[1]/255, rgb[2]/255, 1.0);
+    if (type !== 'point' && p.verts.length > 1)
+      strokePath(arr, p.verts.length, type !== 'transect', sel ? 3 : 2);
+    if (type === 'point' || type === 'transect') {   // endpoints / release points
+      gl.bufferData(gl.ARRAY_BUFFER, arr, gl.DYNAMIC_DRAW);
+      gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 8, 0);
+      gl.uniform1f(progFlat.u.uPtSize, 7);
+      gl.uniform1f(progFlat.u.uRound, 1);
+      gl.drawArrays(gl.POINTS, 0, p.verts.length);
+      gl.uniform1f(progFlat.u.uRound, 0);
+    }
+    if (sel) {   // edit handles: the object's own color, larger, round
+      gl.bufferData(gl.ARRAY_BUFFER, arr, gl.DYNAMIC_DRAW);
+      gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 8, 0);
+      gl.uniform1f(progFlat.u.uPtSize, 11);
+      gl.uniform1f(progFlat.u.uRound, 1);
+      gl.drawArrays(gl.POINTS, 0, p.verts.length);
+      gl.uniform1f(progFlat.u.uRound, 0);
+      gl.uniform1f(progFlat.u.uPtSize, 7);
+    }
+  }
+  if (state.draft.length) {   // always visible while drawing
+    const arr = new Float32Array(state.draft.length * 2);
+    for (let i = 0; i < state.draft.length; i++) {
+      arr[i*2] = state.draft[i][0] - w0[0]; arr[i*2+1] = state.draft[i][1] - w0[1];
+    }
+    gl.uniform4f(progFlat.u.uColor, 0.85, 0.55, 0.1, 1.0);
+    if (state.draft.length > 1) strokePath(arr, state.draft.length, false, 2);
+    gl.bufferData(gl.ARRAY_BUFFER, arr, gl.DYNAMIC_DRAW);
+    gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 8, 0);
+    gl.uniform1f(progFlat.u.uPtSize, 7);
+    gl.uniform1f(progFlat.u.uRound, 1);
+    gl.drawArrays(gl.POINTS, 0, state.draft.length);
+    gl.uniform1f(progFlat.u.uRound, 0);
+  }
+}
+
+/* ── connectivity network (Pearson et al. 2021 style): one node per polygon
+   centroid (size ∝ departures), directed edges i→j whose width scales with the
+   matrix value, colored by the SOURCE polygon. Data = state.connectivity (set
+   by the Connectivity tab); toggled from the Layers panel. ── */
+function drawConnectivity() {
+  const con = state.connectivity;
+  if (!state.showConnectivity || !con || !state.world0) return;
+  if (typeof allPolys !== 'function') return;
+  const polys = allPolys();
+  const w0 = state.world0;
+  const cents = con.labels.map(l => {
+    const p = polys.find(q => q.key === l);
+    return p ? polyCentroid(p) : null;      // deleted polygons: node/edges skipped
+  });
+  const n = con.labels.length;
+  let vmax = 0, rmax = 1;
+  for (let i = 0; i < n; i++) {
+    rmax = Math.max(rmax, con.row_counts[i] || 0);
+    for (let j = 0; j < n; j++) if (i !== j) vmax = Math.max(vmax, con.matrix[i][j]);
+  }
+  if (!vmax) return;                        // no off-diagonal transport at all
+
+  gl.useProgram(progFlat.prog);
+  gl.uniform4fv(progFlat.u.uView, viewUniform());
+  if (!drawConnectivity.buf) drawConnectivity.buf = gl.createBuffer();
+  gl.bindBuffer(gl.ARRAY_BUFFER, drawConnectivity.buf);
+  gl.enableVertexAttribArray(0);
+  const dpr = window.devicePixelRatio || 1;
+  const pxw = dpr / state.view.ppm;         // world units per CSS pixel
+
+  for (let i = 0; i < n; i++) {
+    const ci = cents[i];
+    if (!ci) continue;
+    const rgb = hex2rgb(polyColorOf(con.labels[i]));
+    gl.uniform4f(progFlat.u.uColor, rgb[0]/255, rgb[1]/255, rgb[2]/255, 0.78);
+    for (let j = 0; j < n; j++) {
+      const v = con.matrix[i][j], cj = cents[j];
+      if (i === j || !cj || !v || v / vmax < 0.02) continue;   // declutter floor
+      const wpx = 1.5 + 6.5 * v / vmax;
+      let dx = cj[0] - ci[0], dy = cj[1] - ci[1];
+      const L = Math.hypot(dx, dy) || 1;
+      dx /= L; dy /= L;
+      const nx = -dy * 3 * pxw, ny = dx * 3 * pxw;   // separate i→j from j→i
+      const ah = (5 + wpx * 1.6) * pxw;              // arrowhead length
+      const tipX = cj[0] - w0[0] + nx - dx * 10 * pxw;
+      const tipY = cj[1] - w0[1] + ny - dy * 10 * pxw;
+      const bX = tipX - dx * ah, bY = tipY - dy * ah;
+      const shaft = new Float32Array([
+        ci[0] - w0[0] + nx + dx * 8 * pxw, ci[1] - w0[1] + ny + dy * 8 * pxw, bX, bY]);
+      strokePath(shaft, 2, false, wpx);
+      const ux = -dy * ah * 0.55, uy = dx * ah * 0.55;
+      const tri = new Float32Array([tipX, tipY, bX + ux, bY + uy, bX - ux, bY - uy]);
+      gl.bufferData(gl.ARRAY_BUFFER, tri, gl.DYNAMIC_DRAW);
+      gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 8, 0);
+      gl.drawArrays(gl.TRIANGLES, 0, 3);
+    }
+  }
+  for (let i = 0; i < n; i++) {             // nodes on top of the edges
+    const ci = cents[i];
+    if (!ci) continue;
+    const rgb = hex2rgb(polyColorOf(con.labels[i]));
+    const pt = new Float32Array([ci[0] - w0[0], ci[1] - w0[1]]);
+    gl.bufferData(gl.ARRAY_BUFFER, pt, gl.DYNAMIC_DRAW);
+    gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 8, 0);
+    gl.uniform1f(progFlat.u.uPtSize,
+                 (9 + 9 * Math.sqrt((con.row_counts[i] || 0) / rmax)) * dpr);
+    gl.uniform1f(progFlat.u.uRound, 1);
+    gl.uniform4f(progFlat.u.uColor, rgb[0]/255, rgb[1]/255, rgb[2]/255, 1.0);
+    gl.drawArrays(gl.POINTS, 0, 1);
+  }
+  gl.uniform1f(progFlat.u.uRound, 0);
+}
+
+function drawPathsFBO(clock) {
+  ensureOffFBO();
+  gl.bindFramebuffer(gl.FRAMEBUFFER, off.fbo);
+  gl.viewport(0, 0, off.w, off.h);
+  gl.clearColor(0, 0, 0, 0);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+  for (const run of state.runs) {
+    if (!run.visible || !run.loaded) continue;
+    if (run.pathsDirty || run.pathLoadedAt !== run.loaded) rebuildPaths(run);
+    if (!run.segCount) continue;
+    const {k, frac} = frameAt(run, clock.t);
+    const mode = state.paths.mode;
+    const pmax = mode === 'age' ? Math.max(run.T - 1, 1)
+               : mode === 'dist' ? Math.max(run.distMax, 1e-9)
+               : (run.meta.burial_max || 0.01);
+    gl.useProgram(progSeg.prog);
+    gl.uniform4fv(progSeg.u.uQuant, run.quantU);
+    gl.uniform4fv(progSeg.u.uView, viewUniform());
+    gl.uniform2f(progSeg.u.uCanvas, canvas.width, canvas.height);
+    gl.uniform1f(progSeg.u.uWidthPx, state.paths.width * (window.devicePixelRatio || 1));
+    gl.uniform1f(progSeg.u.uNow, k + frac);
+    gl.uniform1f(progSeg.u.uPmax, pmax);
+    gl.uniform2fv(progSeg.u.uVR, effRange(mode === 'solid' ? 'age' : mode));
+    gl.uniform1i(progSeg.u.uSolid, mode === 'solid' ? 1 : 0);
+    const pc = hex2rgb(state.paths.color);
+    gl.uniform3f(progSeg.u.uSolidColor, pc[0]/255, pc[1]/255, pc[2]/255);
+    gl.activeTexture(gl.TEXTURE0); gl.bindTexture(gl.TEXTURE_2D, cmapTex(state.paths.cmap));
+    gl.uniform1i(progSeg.u.uCmap, 0);
+    gl.bindVertexArray(run.segVAO);
+    gl.drawArraysInstanced(gl.TRIANGLE_STRIP, 0, 4, run.segCount);
+    gl.bindVertexArray(null);
+  }
+  gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+  gl.viewport(0, 0, canvas.width, canvas.height);
+  gl.useProgram(progBlit.prog);
+  gl.uniform1f(progBlit.u.uAlpha, state.paths.alpha);
+  gl.activeTexture(gl.TEXTURE0); gl.bindTexture(gl.TEXTURE_2D, off.tex);
+  gl.uniform1i(progBlit.u.uTex, 0);
+  gl.bindBuffer(gl.ARRAY_BUFFER, screenQuad);
+  gl.enableVertexAttribArray(0);
+  gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 8, 0);
+  gl.drawArrays(gl.TRIANGLES, 0, 3);
+}
+
+function drawScene() {
+  const clock = state.clock;
+  gl.viewport(0, 0, canvas.width, canvas.height);
+  gl.disable(gl.DEPTH_TEST);
+  gl.clearColor(0.906, 0.918, 0.933, 1);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+  gl.enable(gl.BLEND);
+  gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+
+  drawTiles();
+  gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+  drawMeshLayer();
+  if (typeof ForcingTab !== 'undefined') ForcingTab.drawLayer();   // forcing field + quivers
+  if (typeof SeedingTab !== 'undefined') SeedingTab.drawLayer();   // seed-point preview
+  if (state.paths.show && state.showParticles) drawPathsFBO(clock);
+  if (state.showPoints && state.showParticles) for (const run of state.runs) {
+    if (!run.visible || !run.loaded) continue;
+    const {k, frac} = frameAt(run, clock.t);
+    const kk = Math.min(k, run.loaded - 1);
+    const kNext = Math.min(k + 1, run.loaded - 1);
+    drawPoints(run, frac, kk, kNext);
+  }
+  drawPolyOutlines();
+  drawConnectivity();
+}
+
+let lastTime = performance.now(), fpsEMA = 0;
+function render(now) {
+  requestAnimationFrame(render);
+  if (state.exporting) return;
+  resize();
+  const dt = Math.min(0.1, (now - lastTime) / 1000);
+  lastTime = now;
+
+  const clock = state.clock;
+  if (clock.playing) {
+    clock.t += clock.speed * dt;
+    const front = loadedFrontier();
+    if (clock.t >= Math.min(clock.t1, front)) clock.t = Math.min(clock.t1, front);
+    if (clock.t >= clock.t1) { clock.playing = false; refreshPlayBtn(); }
+    updateTimelineUI();
+    state.dirty = true;
+  }
+  if (!state.dirty) { updateFps(now, true); return; }
+  state.dirty = state.clock.playing;
+  drawScene();
+  updateFps(now, false);
+}
+
+function updateFps(now, idle) {
+  if (!updateFps.last) updateFps.last = now;
+  const dt = now - updateFps.last;
+  updateFps.last = now;
+  if (!idle)
+    fpsEMA = fpsEMA ? fpsEMA * 0.92 + (1000 / Math.max(dt, 0.01)) * 0.08 : 1000 / Math.max(dt, 0.01);
+  if (!updateFps.tick || now - updateFps.tick > 500) {
+    updateFps.tick = now;
+    $('st-fps').innerHTML = `<b>${state.clock.playing ? Math.round(fpsEMA) : '–'}</b> fps`;
+    updateLoadStatus();
+  }
+}
+
+function updateLoadStatus() {
+  let tot = 0, got = 0;
+  for (const r of state.runs) { tot += r.T; got += r.loaded; }
+  const el = $('st-load');
+  if (tot && got < tot) {
+    el.style.display = '';
+    el.innerHTML = `loading <b>${Math.round(got / tot * 100)}%</b>`;
+  } else el.style.display = 'none';
+}
+

--- a/sedtrails-gui/web/js/core/state.js
+++ b/sedtrails-gui/web/js/core/state.js
@@ -1,0 +1,53 @@
+"use strict";
+/* ═════════════════════════ global state ═════════════════════════ */
+const state = {
+  runs: [],
+  world0: null,
+  polygons: [],                                  // flat list: {name, verts, color}
+  rules: [],
+  defaultApp: {action: 'tint', color: '#8b939e', colorby: 'burial'},
+  defaultAutoSet: false,
+  view: {cx: 0, cy: 0, ppm: 0.01},
+  clock: {playing: false, t: 0, t0: 0, t1: 1, speed: 0.125},   // 3 h/s default
+  pointSize: 3, alpha: 0.85, decim: 1,
+  pointCmap: 'viridis',
+  ranges: {burial: [null, null], age: [null, null], first: [null, null],
+           dist: [null, null]},                  // user overrides (null = auto)
+  fade: {bur: false, depth: 0.05, imm: false, alpha: 0.1},
+  paths: {show: false, width: 1.5, alpha: 0.6, mode: 'age',
+          color: '#1f6fd6', cmap: 'viridis'},
+  showBasemap: true,
+  basemap: 'sat',
+  showModel: false,
+  modelLayer: 'bed',
+  meshAlpha: 1.0,
+  mesh: null,
+  showOutlines: true,
+  showPoints: true,
+  showParticles: true,                           // master eye (Layers panel group)
+  showConnectivity: true,
+  connectivity: null,                            // last matrix (Connectivity tab)
+  tool: 'pan',
+  draft: [],
+  editSel: null,
+  dirty: true,
+  selCount: 0,
+  exporting: false,
+};
+
+const CONDS = [
+  ['start', 'start in'], ['end', 'end in'], ['ever', 'ever visit'],
+  ['bur_ge', 'are buried ≥ (m)'], ['bur_lt', 'are buried < (m)'], ['always', '— (all)'],
+];
+const CONDS2 = CONDS.filter(c => c[0] !== 'always');
+const ACTIONS = [['hide', 'hidden'], ['color', 'colored'], ['colorby', 'colored by']];
+const COLORBYS = [
+  ['burial', 'burial depth'], ['age', 'age'], ['first', 'time of first polygon visit'],
+];
+const DEFAULT_APPS = [
+  ['tint', 'in their simulation color'],
+  ['color', 'colored'],
+  ['colorby', 'colored by'],
+  ['hide', 'hidden'],
+];
+

--- a/sedtrails-gui/web/js/core/tabs.js
+++ b/sedtrails-gui/web/js/core/tabs.js
@@ -1,0 +1,32 @@
+"use strict";
+/* ═════════════════════════ tab switching (GUI) ═════════════════════════ */
+const TAB_TITLES = {
+  settings: 'SedTRAILS settings', seeding: 'Populations',
+  run: 'Run', viewer: 'Viewer', connectivity: 'Connectivity',
+};
+
+const Tabs = {
+  current: null,
+  hooks: {},                       // name -> {enter(), leave()}
+  register(name, h) { this.hooks[name] = h || {}; },
+  activate(name) {
+    if (name === this.current) return;
+    const old = this.current;
+    if (old && this.hooks[old] && this.hooks[old].leave) this.hooks[old].leave();
+    this.current = name;
+    document.body.className = 'tab-' + name;
+    document.querySelectorAll('.tabbtn').forEach(b =>
+      b.classList.toggle('active', b.dataset.tab === name));
+    document.querySelectorAll('.tabpanel').forEach(p =>
+      p.classList.toggle('active', p.dataset.tab === name));
+    const t = $('paneltitle');
+    if (t) t.textContent = TAB_TITLES[name] || name;
+    if (this.hooks[name] && this.hooks[name].enter) this.hooks[name].enter();
+    if (typeof LayersPanel !== 'undefined') LayersPanel.refresh();
+    if (typeof state === 'object') state.dirty = true;
+  },
+};
+
+document.querySelectorAll('.tabbtn').forEach(b =>
+  b.onclick = () => Tabs.activate(b.dataset.tab));
+Tabs.activate('settings');

--- a/sedtrails-gui/web/js/core/tiles.js
+++ b/sedtrails-gui/web/js/core/tiles.js
@@ -1,0 +1,132 @@
+"use strict";
+/* ═════════════════════════ live tile layer ═════════════════════════ */
+const TILE_PROVIDERS = {
+  sat: {url: (z,x,y) => `https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/${z}/${y}/${x}`,
+        maxZoom: 19, attribution: 'Imagery © Esri, Maxar, Earthstar Geographics'},
+  gray: {url: (z,x,y) => `https://basemaps.cartocdn.com/light_all/${z}/${x}/${y}.png`,
+         maxZoom: 19, attribution: '© CARTO · © OpenStreetMap contributors'},
+};
+const tileCache = new Map();
+let tileFetches = 0;
+
+function tileKey(p, z, x, y) { return `${p}/${z}/${x}/${y}`; }
+
+function requestTile(provider, z, x, y) {
+  const key = tileKey(provider, z, x, y);
+  if (tileCache.has(key)) return tileCache.get(key);
+  if (tileFetches >= 14) return null;
+  const entry = {loading: true};
+  tileCache.set(key, entry);
+  tileFetches++;
+  const img = new Image();
+  img.crossOrigin = 'anonymous';
+  img.onload = () => {
+    tileFetches--;
+    const tex = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, img);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    entry.loading = false;
+    entry.tex = tex;
+    trimTileCache();
+    state.dirty = true;
+  };
+  img.onerror = () => { tileFetches--; entry.loading = false; entry.failed = true; };
+  img.src = TILE_PROVIDERS[provider].url(z, x, y);
+  return entry;
+}
+
+function trimTileCache() {
+  if (tileCache.size <= 400) return;
+  const keys = [...tileCache.keys()];
+  for (let i = 0; i < keys.length - 320; i++) {
+    const e = tileCache.get(keys[i]);
+    if (e && e.tex) gl.deleteTexture(e.tex);
+    tileCache.delete(keys[i]);
+  }
+}
+
+function localToWgs(lx, ly) {
+  return rdToWgs(lx + state.world0[0], ly + state.world0[1]);
+}
+
+function drawTiles() {
+  if (!state.showBasemap || !state.world0) { $('attribution').textContent = ''; return; }
+  const prov = TILE_PROVIDERS[state.basemap];
+  $('attribution').textContent = prov.attribution;
+
+  const [ , latC] = localToWgs(state.view.cx, state.view.cy);
+  const mercPerPx = (1 / state.view.ppm) / Math.cos(latC * Math.PI / 180);
+  let z = Math.max(3, Math.min(prov.maxZoom, Math.round(Math.log2(156543.03 / mercPerPx))));
+
+  const dpr = window.devicePixelRatio || 1;
+  const w = canvas.width / dpr, h = canvas.height / dpr;
+  let mx0 = Infinity, my0 = Infinity, mx1 = -Infinity, my1 = -Infinity;
+  for (const [px, py] of [[0,0],[w,0],[0,h],[w,h]]) {
+    const [lx, ly] = screenToWorld(px, py);
+    const m = wgsToMerc(...localToWgs(lx, ly));
+    mx0 = Math.min(mx0, m[0]); mx1 = Math.max(mx1, m[0]);
+    my0 = Math.min(my0, m[1]); my1 = Math.max(my1, m[1]);
+  }
+  let tx0, tx1, ty0, ty1;
+  while (true) {
+    const n = 2 ** z, f = n / (2 * MERC_HALF);
+    tx0 = Math.floor((mx0 + MERC_HALF) * f); tx1 = Math.floor((mx1 + MERC_HALF) * f);
+    ty0 = Math.floor((MERC_HALF - my1) * f); ty1 = Math.floor((MERC_HALF - my0) * f);
+    if ((tx1 - tx0 + 1) * (ty1 - ty0 + 1) <= 80 || z <= 3) break;
+    z--;
+  }
+
+  const draws = new Map();
+  for (let x = tx0; x <= tx1; x++) for (let y = ty0; y <= ty1; y++) {
+    const n = 2 ** z;
+    if (x < 0 || y < 0 || x >= n || y >= n) continue;
+    const e = requestTile(state.basemap, z, x, y);
+    if (e && e.tex) { draws.set(tileKey(state.basemap, z, x, y), {z, x, y, tex: e.tex}); continue; }
+    let az = z, ax = x, ay = y;
+    for (let k = 0; k < 5 && az > 3; k++) {
+      az--; ax >>= 1; ay >>= 1;
+      const a = tileCache.get(tileKey(state.basemap, az, ax, ay));
+      if (a && a.tex) { draws.set(tileKey(state.basemap, az, ax, ay), {z: az, x: ax, y: ay, tex: a.tex}); break; }
+    }
+  }
+
+  const list = [...draws.values()].sort((a, b) => a.z - b.z);
+  if (!drawTiles.buf) drawTiles.buf = gl.createBuffer();
+  gl.useProgram(progTex.prog);
+  gl.uniform4fv(progTex.u.uView, viewUniform());
+  gl.activeTexture(gl.TEXTURE0);
+  gl.uniform1i(progTex.u.uTex, 0);
+  gl.bindBuffer(gl.ARRAY_BUFFER, drawTiles.buf);
+  gl.enableVertexAttribArray(0); gl.enableVertexAttribArray(1);
+  gl.disable(gl.BLEND);
+  const w0 = state.world0;
+  for (const t of list) {
+    const n = 2 ** t.z;
+    const tmx0 = t.x / n * 2 * MERC_HALF - MERC_HALF;
+    const tmx1 = (t.x + 1) / n * 2 * MERC_HALF - MERC_HALF;
+    const tmy1 = MERC_HALF - t.y / n * 2 * MERC_HALF;
+    const tmy0 = MERC_HALF - (t.y + 1) / n * 2 * MERC_HALF;
+    const corner = (mx, my) => {
+      const [x, y] = wgsToRd(...mercToWgs(mx, my));
+      return [x - w0[0], y - w0[1]];
+    };
+    const [sw, se, nw, ne] = [corner(tmx0, tmy0), corner(tmx1, tmy0),
+                              corner(tmx0, tmy1), corner(tmx1, tmy1)];
+    const quad = new Float32Array([
+      sw[0], sw[1], 0, 1,   se[0], se[1], 1, 1,
+      nw[0], nw[1], 0, 0,   ne[0], ne[1], 1, 0,
+    ]);
+    gl.bufferData(gl.ARRAY_BUFFER, quad, gl.DYNAMIC_DRAW);
+    gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 16, 0);
+    gl.vertexAttribPointer(1, 2, gl.FLOAT, false, 16, 8);
+    gl.bindTexture(gl.TEXTURE_2D, t.tex);
+    gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+  }
+  gl.disableVertexAttribArray(1);
+  gl.enable(gl.BLEND);
+}
+

--- a/sedtrails-gui/web/js/core/util.js
+++ b/sedtrails-gui/web/js/core/util.js
@@ -1,0 +1,91 @@
+"use strict";
+/* ═════════════════════════ helpers & constants ═════════════════════════ */
+const $ = id => document.getElementById(id);
+const SENT = 65535;
+const PALETTE = ['#3d7fd1','#f0842c','#3aa35c','#d14b4b','#9166cf','#d668b5',
+                 '#b0a028','#2ba7ae','#8a5f4a','#6e86d0','#54b389','#d98ba8',
+                 '#a8935e','#79b23f','#e0937c','#7f8a96'];
+const SWATCHES = ['#d14b4b','#f0842c','#e8c531','#3aa35c','#2ba7ae','#3d7fd1','#9166cf','#d668b5',
+                  '#8c2f2f','#a85a1c','#9a8420','#256e3d','#1d7076','#28558c','#61458a','#93477c',
+                  '#f2a3a3','#f7c797','#f2e394','#a3d9b5','#9fd6da','#a9c7ec','#c8b5e8','#e8b5d8',
+                  '#111111','#555555','#999999','#cccccc','#ffffff','#7a5c45','#c9b380','#8fd14f'];
+const SIM_TINTS = ['#1f6fd6','#f0842c','#3aa35c','#d668b5','#b0a028','#9166cf'];
+const NEUTRAL = '#8b939e';
+const CMAPS = {
+  viridis: [[68,1,84],[72,36,117],[65,68,135],[53,95,141],[42,120,142],
+    [33,145,140],[34,168,132],[68,190,112],[122,209,81],[189,223,38],[253,231,37]],
+  turbo: [[48,18,59],[70,107,227],[40,187,235],[62,240,161],[162,252,60],
+    [241,204,32],[249,112,21],[196,31,6],[122,4,3]],
+  plasma: [[13,8,135],[84,2,163],[139,10,165],[185,50,137],[219,92,104],
+    [244,136,73],[254,188,43],[240,249,33]],
+  RdBu: [[103,0,31],[178,24,43],[214,96,77],[244,165,130],[253,219,199],[247,247,247],
+    [209,229,240],[146,197,222],[67,147,195],[33,102,172],[5,48,97]].reverse(),
+  gray: [[45,45,45],[235,235,235]],
+  // terrain-like for bed level: deep blue → shallow cyan → sand → vegetated land
+  topo: [[8,40,88],[28,84,146],[60,140,190],[125,195,215],[190,230,225],
+    [240,232,180],[210,200,120],[150,160,90],[120,120,70]],
+  // cyclic (first stop == last stop) — for direction/phase maps on [-180, 180]
+  phase: [[201,58,180],[212,68,70],[190,133,38],[131,178,56],[47,187,145],
+    [58,153,214],[121,95,222],[201,58,180]],
+};
+const MAX_RULES = 16;
+
+function hex2rgb(h) {
+  return [parseInt(h.slice(1,3),16), parseInt(h.slice(3,5),16), parseInt(h.slice(5,7),16)];
+}
+function fmtInt(n) { return n.toLocaleString('en-US'); }
+function debounce(fn, ms) {
+  let t = null;
+  return (...a) => { clearTimeout(t); t = setTimeout(() => fn(...a), ms); };
+}
+function toast(msg, isErr) {
+  const el = document.createElement('div');
+  el.className = 'toast' + (isErr ? ' err' : '');
+  el.textContent = msg;
+  document.body.appendChild(el);
+  setTimeout(() => el.remove(), isErr ? 6000 : 3500);
+  if (isErr) console.error(msg);
+}
+async function api(route, body) {
+  const opt = body === undefined ? {} :
+    {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify(body)};
+  const r = await fetch(route, opt);
+  if (!r.ok) {
+    let msg = r.statusText;
+    try { msg = (await r.json()).error || msg; } catch (e) {}
+    throw new Error(msg);
+  }
+  return r;
+}
+const apiJson = async (route, body) => (await api(route, body)).json();
+
+/* ── RD New (EPSG:28992) ⇄ WGS84 ⇄ WebMercator (±0.3 m) ── */
+function rdToWgs(x, y) {
+  const dX = (x - 155000) * 1e-5, dY = (y - 463000) * 1e-5;
+  const somN = 3235.65389*dY - 32.58297*dX*dX - 0.24750*dY*dY - 0.84978*dX*dX*dY
+    - 0.06550*dY*dY*dY - 0.01709*dX*dX*dY*dY - 0.00738*dX + 0.00530*dX*dX*dX*dX
+    - 0.00039*dX*dX*dY*dY*dY + 0.00033*dX*dX*dX*dX*dY - 0.00012*dX*dY;
+  const somE = 5260.52916*dX + 105.94684*dX*dY + 2.45656*dX*dY*dY - 0.81885*dX*dX*dX
+    + 0.05594*dX*dY*dY*dY - 0.05607*dX*dX*dX*dY + 0.01199*dY - 0.00256*dX*dX*dX*dY*dY
+    + 0.00128*dX*dY*dY*dY*dY + 0.00022*dY*dY - 0.00022*dX*dX + 0.00026*dX*dX*dX*dX*dX;
+  return [5.38720621 + somE/3600, 52.15517440 + somN/3600];
+}
+function wgsToRd(lon, lat) {
+  const dp = 0.36*(lat - 52.15517440), dl = 0.36*(lon - 5.38720621);
+  const x = 155000 + 190094.945*dl - 11832.228*dp*dl - 114.221*dp*dp*dl - 32.391*dl*dl*dl
+    - 0.705*dp - 2.340*dp*dp*dp*dl - 0.608*dp*dl*dl*dl - 0.008*dl*dl + 0.148*dp*dp*dl*dl*dl;
+  const y = 463000 + 309056.544*dp + 3638.893*dl*dl + 73.077*dp*dp - 157.984*dp*dl*dl
+    + 59.788*dp*dp*dp + 0.433*dl - 6.439*dp*dp*dl*dl - 0.032*dp*dl + 0.092*dl*dl*dl*dl
+    - 0.054*dp*dl*dl*dl*dl;
+  return [x, y];
+}
+const EARTH_R = 6378137, MERC_HALF = Math.PI * EARTH_R;
+function wgsToMerc(lon, lat) {
+  return [EARTH_R * lon * Math.PI / 180,
+          EARTH_R * Math.log(Math.tan(Math.PI / 4 + lat * Math.PI / 360))];
+}
+function mercToWgs(mx, my) {
+  return [mx / EARTH_R * 180 / Math.PI,
+          (2 * Math.atan(Math.exp(my / EARTH_R)) - Math.PI / 2) * 180 / Math.PI];
+}
+

--- a/sedtrails-gui/web/js/tabs/connectivity.js
+++ b/sedtrails-gui/web/js/tabs/connectivity.js
@@ -1,0 +1,174 @@
+"use strict";
+/* ═════════════════════════ Connectivity tab (v0) ═════════════════════════
+   Polygon-to-polygon connectivity matrix over an imported simulation: which
+   particles start in polygon i and end in (or ever visit) polygon j. Uses the
+   shared polygon library (draw/import polygons in the Viewer tab) and the
+   cached per-polygon classification. Future metrics (time-lagged, flux-
+   weighted, network measures) become new `mode` values on the same endpoint. */
+
+const ConnectivityTab = (() => {
+  let lastResult = null;
+
+  async function refreshSims() {
+    const sel = $('con-sim');
+    const cur = sel.value;
+    sel.innerHTML = '';
+    try {
+      const reg = await apiJson('/api/registry');
+      for (const s of reg.simulations) {
+        const o = document.createElement('option');
+        o.value = s.id;
+        o.textContent = `${s.name} · ${fmtInt(s.n_particles)} × ${s.n_timesteps}`;
+        sel.appendChild(o);
+      }
+      // prefer the run loaded in the Particle viewer: a remembered selection
+      // from an older session silently computes against the wrong simulation
+      const loaded = (state.runs || []).map(r => r.id);
+      const has = v => [...sel.options].some(o => o.value === v);
+      if (loaded.includes(cur) && has(cur)) sel.value = cur;
+      else if (loaded.length && has(loaded[loaded.length - 1])) sel.value = loaded[loaded.length - 1];
+      else if (has(cur)) sel.value = cur;
+    } catch (e) {}
+    refreshInfo();
+  }
+
+  function refreshInfo() {
+    const n = allPolys().length;      // closed shapes only (polygons & boxes)
+    $('con-info').textContent = n >= 2 ?
+      `${n} polygon(s) from the Objects panel` :
+      'Draw or import at least 2 polygons (Objects panel, top right) to compute connectivity.';
+    $('con-compute').disabled = n < 2 || !$('con-sim').value;
+  }
+
+  /* auto-generated geomorphic cells (Pearson et al. 2021): k-means on the
+     forcing bathymetry → auto_cell_* polygons in the shared Objects panel */
+  const AUTO_RE = /^(auto_)?cell_\d+$/;      // also matches pre-rename cell_NN
+
+  async function genCells() {
+    const meta = (typeof ForcingTab !== 'undefined') && ForcingTab.state.meta;
+    if (!meta) return toast('open a forcing file first (Forcing tab)', true);
+    const scalars = (meta.variables || []).filter(v => !v.is_vector_comp);
+    const bed = scalars.find(v => /bed/i.test(v.name)) || scalars[0];
+    const n = Math.max(2, Math.min(200, parseInt($('con-ncells').value, 10) || 12));
+    $('con-gencells').disabled = true;
+    $('con-status').textContent = 'clustering bathymetry…';
+    try {
+      const r = await apiJson('/api/polygons/auto',
+                              {forcing_id: meta.id, n, var: bed ? bed.name : null});
+      state.polygons = state.polygons.filter(p => !AUTO_RE.test(p.name));
+      for (const p of r.polygons)
+        state.polygons.push({name: p.name, type: 'polygon', verts: p.verts});
+      onPolygonsChanged();
+      $('con-status').textContent =
+        `${r.polygons.length} cells generated` +
+        (bed ? ` (k-means on ${bed.name})` : '') + ' — see the Objects panel';
+    } catch (e) {
+      toast('auto cells: ' + e.message, true);
+      $('con-status').textContent = '';
+    }
+    $('con-gencells').disabled = false;
+    refreshInfo();
+  }
+
+  /* drop every auto-generated cell in one click (also wired from the Objects
+     panel toolbar via ConnectivityTab.removeAutoCells) */
+  function removeAutoCells() {
+    const n = state.polygons.filter(p => AUTO_RE.test(p.name)).length;
+    if (!n) return toast('no auto-generated cells to remove', true);
+    if (!confirm(`Remove all ${n} auto-generated cell(s)?`)) return;
+    state.polygons = state.polygons.filter(p => !AUTO_RE.test(p.name));
+    onPolygonsChanged();
+    if (typeof ObjectsPanel !== 'undefined') ObjectsPanel.refresh();
+    $('con-status').textContent = `${n} auto-generated cell(s) removed`;
+    refreshInfo();
+  }
+
+  async function compute() {
+    const bundle = $('con-sim').value;
+    if (!bundle) return toast('import a simulation first (Viewer tab)', true);
+    const polys = allPolys().map(p => ({key: p.key, verts: p.verts}));
+    $('con-compute').disabled = true;
+    $('con-status').textContent = 'computing… (first time classifies all particles)';
+    try {
+      lastResult = await apiJson('/api/connectivity/compute', {
+        bundle_id: bundle, polygons: polys,
+        mode: $('con-mode').value, normalize: $('con-norm').value,
+      });
+      state.connectivity = lastResult;   // the map layer (render.js) draws this
+      state.dirty = true;
+      renderMatrix(lastResult);
+      const simLbl = $('con-sim').selectedOptions.length ?
+        $('con-sim').selectedOptions[0].textContent : bundle;
+      let status = `${simLbl} — ${fmtInt(lastResult.n_particles)} particles · ` +
+        `${fmtInt(lastResult.n_unassigned)} start outside all polygons`;
+      if (lastResult.n_unassigned === lastResult.n_particles) {
+        status += ' ⚠ no particle starts inside any polygon — check that the ' +
+          'simulation selected above matches the polygons\' area';
+      }
+      $('con-status').textContent = status;
+    } catch (e) {
+      toast('connectivity: ' + e.message, true);
+      $('con-status').textContent = '';
+    }
+    $('con-compute').disabled = false;
+  }
+
+  function cellColor(v, vmax) {
+    if (!vmax || v <= 0) return 'transparent';
+    const f = Math.min(1, v / vmax);
+    return `color-mix(in srgb, var(--accent) ${Math.round(f * 82)}%, var(--panel))`;
+  }
+
+  function renderMatrix(r) {
+    const frac = r.normalize === 'fraction';
+    const vmax = frac ? 1 : Math.max(1, ...r.matrix.flat());
+    const fmt = v => frac ? (v * 100).toFixed(1) + '%' : fmtInt(v);
+    let html = '<table class="conmat"><tr><th class="corner">from \\ to</th>';
+    for (const l of r.labels) html += `<th title="${l}">${l}</th>`;
+    html += '<th class="dim">n start</th></tr>';
+    r.matrix.forEach((row, i) => {
+      html += `<tr><th title="${r.labels[i]}">` +
+        `<span class="swatch" style="background:${polyColorOf(r.labels[i])}"></span> ${r.labels[i]}</th>`;
+      row.forEach((v, j) => {
+        const fg = frac ? v > vmax * 0.55 : v > vmax * 0.55;
+        html += `<td style="background:${cellColor(v, vmax)}${fg ? ';color:#fff' : ''}">${fmt(v)}</td>`;
+      });
+      html += `<td class="dim">${fmtInt(r.row_counts[i])}</td></tr>`;
+    });
+    html += '</table>';
+    $('con-result').innerHTML = html;
+    $('con-resultsec').open = true;      // sections collapse by default now
+    $('con-csv').style.display = '';
+    if (typeof LayersPanel !== 'undefined') LayersPanel.refresh();
+  }
+
+  function exportCsv() {
+    if (!lastResult) return;
+    const r = lastResult;
+    const rows = [['from\\to', ...r.labels, 'n_start']];
+    r.matrix.forEach((row, i) => rows.push([r.labels[i], ...row, r.row_counts[i]]));
+    const csv = rows.map(x => x.join(',')).join('\n');
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(new Blob([csv], {type: 'text/csv'}));
+    a.download = `connectivity_${r.mode}_${r.normalize}.csv`;
+    a.click();
+    URL.revokeObjectURL(a.href);
+  }
+
+  let wired = false;
+  function enter() {
+    if (!wired) {
+      $('con-compute').onclick = compute;
+      $('con-csv').onclick = exportCsv;
+      $('con-sim').onchange = refreshInfo;
+      $('con-gencells').onclick = genCells;
+      $('con-delcells').onclick = removeAutoCells;
+      wired = true;
+    }
+    if (typeof ForcingTab !== 'undefined') ForcingTab.enter();  // map background
+    refreshSims();
+  }
+
+  Tabs.register('connectivity', {enter});
+  return {refreshSims, removeAutoCells, AUTO_RE};
+})();

--- a/sedtrails-gui/web/js/tabs/forcing.js
+++ b/sedtrails-gui/web/js/tabs/forcing.js
@@ -1,0 +1,861 @@
+"use strict";
+/* ═════════════════════════ Forcing tab ═════════════════════════
+   netCDF forcing viewer as a user-managed LAYER STACK: each layer shows one
+   variable — a scalar map, a vector-derived map (magnitude/x/y/direction) or
+   instanced quiver arrows — with its own colormap/range/opacity, drawn
+   bottom→top in user order. Time is driven by the shared global clock
+   (state.clock); the tab keeps a per-timestep fine-step slider.
+   The layers draw inside the shared scene (between the model layer and the
+   particles), so they also serve as background for Seeding/Viewer/Connectivity. */
+
+const ForcingTab = (() => {
+  const F = {
+    id: null, meta: null,
+    mesh: null,      // {posB, idxB, nTris, nVerts, nodeIdx, nNodes, nodeBuf, gathered}
+    show: true,      // master toggle for the whole forcing stack
+    layers: [],      // bottom→top; see addLayer() for the per-layer model
+    nextId: 1,
+    t: 0,            // current timestep index
+    timeDays: null,  // Float64Array abs epoch-days per timestep (clock link)
+    lastK: 0,
+    cache: new Map(), vcache: new Map(), dcache: new Map(),
+    inflight: new Map(),
+  };
+  const CACHE_MAX = 30;
+  const VEC_STYLES = [['mag', 'magnitude map'], ['x', 'x map'], ['y', 'y map'],
+                      ['dir', 'direction map'], ['arrows', 'arrows']];
+
+  /* ── GL programs ────────────────────────────────────────────────────────── */
+  const FRC_VS = `#version 300 es
+  precision highp float;
+  layout(location=0) in vec2 aPos;
+  layout(location=1) in float aVal;
+  uniform vec4 uView;
+  uniform vec2 uOff;
+  out float vVal;
+  void main() { vVal = aVal; gl_Position = vec4((aPos + uOff) * uView.xy + uView.zw, 0.0, 1.0); }`;
+  const FRC_FS = `#version 300 es
+  precision mediump float;
+  in float vVal;
+  uniform vec2 uClim;
+  uniform float uAlpha;
+  uniform sampler2D uRamp;
+  out vec4 frag;
+  void main() {
+    if (vVal < -1e29) discard;
+    float f = clamp((vVal - uClim.x) / max(uClim.y - uClim.x, 1e-12), 0.0, 1.0);
+    vec4 c = texture(uRamp, vec2(f, 0.5));
+    frag = vec4(c.rgb * uAlpha, uAlpha);
+  }`;
+
+  const ARR_VS = `#version 300 es
+  precision highp float;
+  layout(location=0) in vec2 aTemplate;   // arrow template in unit space
+  layout(location=1) in vec2 aAnchor;     // per-instance node position (world, abs)
+  layout(location=2) in vec2 aUV;         // per-instance vector
+  uniform vec4 uView;
+  uniform vec2 uOff, uCanvas;
+  uniform float uScale, uMagRef;
+  uniform sampler2D uRamp;
+  uniform int uColorMag;
+  uniform vec3 uColor;
+  out vec4 vColor;
+  void main() {
+    float mag = length(aUV);
+    if (mag <= 1e-12 || aAnchor.x < -1e29 || aUV.x < -1e29) {
+      gl_Position = vec4(2.0, 2.0, 2.0, 1.0); vColor = vec4(0.0); return;
+    }
+    vec2 dir = aUV / mag;
+    float lenPx = clamp(mag / max(uMagRef, 1e-12) * uScale, 3.0, 3.0 * uScale);
+    vec2 t = aTemplate * lenPx;
+    vec2 px = vec2(t.x * dir.x - t.y * dir.y, t.x * dir.y + t.y * dir.x);
+    vec2 clip = (aAnchor + uOff) * uView.xy + uView.zw;
+    gl_Position = vec4(clip + px / (uCanvas * 0.5), 0.0, 1.0);
+    vec3 col = (uColorMag == 1)
+      ? texture(uRamp, vec2(clamp(mag / max(uMagRef * 1.5, 1e-12), 0.0, 1.0), 0.5)).rgb
+      : uColor;
+    vColor = vec4(col, 0.9);
+  }`;
+  const ARR_FS = `#version 300 es
+  precision mediump float;
+  in vec4 vColor; out vec4 frag;
+  void main() { frag = vec4(vColor.rgb * vColor.a, vColor.a); }`;
+
+  let progFrc = null, progArr = null, arrTemplate = null;
+  function ensurePrograms() {
+    if (progFrc) return;
+    progFrc = compile(FRC_VS, FRC_FS);
+    progArr = compile(ARR_VS, ARR_FS);
+    // arrow as 3 line segments: shaft + two head strokes (unit length along +x)
+    arrTemplate = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, arrTemplate);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([
+      0, 0, 1, 0,          // shaft
+      1, 0, 0.68, 0.16,    // head upper
+      1, 0, 0.68, -0.16,   // head lower
+    ]), gl.STATIC_DRAW);
+  }
+
+  /* ── layer model ────────────────────────────────────────────────────────── */
+  function addLayer(sel) {          // sel = {kind:'scalar', varName} | {kind:'vector', pair}
+    const L = {
+      id: F.nextId++, kind: sel.kind,
+      varName: sel.varName || null, pair: sel.pair || null,
+      style: sel.kind === 'vector' ? 'mag' : 'map',
+      cmap: sel.kind === 'vector' ? 'turbo' : 'viridis',
+      alpha: 0.9, range: [0, 1], userRange: false, visible: true, ready: false,
+      stride: 4, scale: 40, scaleF: 0.5, colorMag: true, magP98: 1, color: '#ffffff',
+      gl: {vao: null, valB: null, vecBuf: null, arrVAO: null, arrStride: 0},
+      pending: null, _rangeUI: null,
+    };
+    F.layers.push(L);
+    return L;
+  }
+
+  function layerLabel(L) {
+    return L.kind === 'scalar' ? L.varName : L.pair.label;
+  }
+  function layerKey(L) {
+    return L.kind === 'scalar' ? 's|' + L.varName : 'v|' + L.pair.x + '|' + L.style;
+  }
+  function isMapStyle(L) { return !(L.kind === 'vector' && L.style === 'arrows'); }
+
+  function freeLayerGL(L) {
+    const g = L.gl;
+    if (g.vao) gl.deleteVertexArray(g.vao);
+    if (g.valB) gl.deleteBuffer(g.valB);
+    if (g.arrVAO) gl.deleteVertexArray(g.arrVAO);
+    if (g.vecBuf) gl.deleteBuffer(g.vecBuf);
+    L.gl = {vao: null, valB: null, vecBuf: null, arrVAO: null, arrStride: 0};
+    L.ready = false;
+  }
+  function removeLayer(L) {
+    freeLayerGL(L);
+    F.layers = F.layers.filter(x => x !== L);
+  }
+
+  function ensureMapGL(L) {
+    if (L.gl.vao) return;
+    const valB = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, valB);
+    gl.bufferData(gl.ARRAY_BUFFER, F.mesh.nVerts * 4, gl.DYNAMIC_DRAW);
+    const vao = gl.createVertexArray();
+    gl.bindVertexArray(vao);
+    gl.bindBuffer(gl.ARRAY_BUFFER, F.mesh.posB);
+    gl.enableVertexAttribArray(0); gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 8, 0);
+    gl.bindBuffer(gl.ARRAY_BUFFER, valB);
+    gl.enableVertexAttribArray(1); gl.vertexAttribPointer(1, 1, gl.FLOAT, false, 4, 0);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, F.mesh.idxB);
+    gl.bindVertexArray(null);
+    L.gl.vao = vao; L.gl.valB = valB;
+  }
+  function ensureArrGL(L) {
+    if (L.gl.arrVAO) return;
+    const vecBuf = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, vecBuf);
+    gl.bufferData(gl.ARRAY_BUFFER, F.mesh.nNodes * 8, gl.DYNAMIC_DRAW);
+    const arrVAO = gl.createVertexArray();
+    gl.bindVertexArray(arrVAO);
+    gl.bindBuffer(gl.ARRAY_BUFFER, arrTemplate);
+    gl.enableVertexAttribArray(0); gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 8, 0);
+    gl.enableVertexAttribArray(1);
+    gl.enableVertexAttribArray(2);
+    gl.vertexAttribDivisor(1, 1);
+    gl.vertexAttribDivisor(2, 1);
+    gl.bindVertexArray(null);
+    L.gl.arrVAO = arrVAO; L.gl.vecBuf = vecBuf; L.gl.arrStride = 0;
+  }
+
+  /* ── open a forcing file ────────────────────────────────────────────────── */
+  async function open(path, base) {
+    const r = await apiJson('/api/forcing/open', {path, base: base || null});
+    F.id = r.id;
+    F.meta = r.meta;
+    F.cache.clear(); F.vcache.clear(); F.dcache.clear();
+    for (const L of F.layers) freeLayerGL(L);
+    F.mesh = null;
+    F.t = Math.min(F.t, Math.max(0, F.meta.n_timesteps - 1));
+    buildTimeDays();
+    $('frc-path').value = F.meta.path;
+    const src = $('frc-src');
+    if (src) src.textContent = F.meta.path + '  (from Settings → inputs → data)';
+    localStorage.setItem('stgui_last_forcing', F.meta.path);
+
+    if (!state.world0) state.world0 = [F.meta.extent[0], F.meta.extent[2]];
+    if (!state.runs.length) {           // fit view to the forcing domain
+      fitView({meta: {extent: F.meta.extent}});
+    }
+
+    if (r.mesh) await loadForcingMesh();
+    else if (r.mesh_job) {
+      $('frc-info').textContent = 'building cell mesh…';
+      await pollJob(r.mesh_job);
+      await loadForcingMesh();
+    }
+    // drop layers whose variable/pair no longer exists; default layer if empty
+    const varOk = n => F.meta.variables.some(v => v.name === n);
+    F.layers = F.layers.filter(L =>
+      L.kind === 'scalar' ? varOk(L.varName)
+                          : F.meta.vector_pairs.some(p => p.x === L.pair.x));
+    if (!F.layers.length) {
+      // defaults: bed level as a topo map + white arrows of the first vector pair
+      const scalars = F.meta.variables.filter(v => !v.is_vector_comp);
+      const bed = scalars.find(v => /bed/i.test(v.name)) ||
+                  scalars.find(v => /depth/i.test(v.name)) || scalars[0];
+      if (bed) {
+        const L = addLayer({kind: 'scalar', varName: bed.name});
+        if (/bed|depth/i.test(bed.name)) L.cmap = 'topo';
+      }
+      if (F.meta.vector_pairs.length) {
+        const A = addLayer({kind: 'vector', pair: F.meta.vector_pairs[0]});
+        A.style = 'arrows';
+        A.colorMag = false;               // uniform white arrows
+      }
+    }
+    refreshPanel();
+    if (typeof updateClockRange === 'function') {
+      updateClockRange();
+      if (F.timeDays && state.clock.t < F.timeDays[0]) state.clock.t = F.timeDays[0];
+      updateTimelineUI();
+    }
+    await updateLayers();
+    if (typeof LayersPanel !== 'undefined') LayersPanel.refresh();
+    state.dirty = true;
+  }
+
+  function buildTimeDays() {
+    const times = F.meta.times || [];
+    let firstValid = -1;
+    const td = new Float64Array(times.length);
+    for (let i = 0; i < times.length; i++) {
+      const v = Date.parse(String(times[i]).replace(' ', 'T') + ':00Z') / 86400000;
+      td[i] = v;
+      if (isFinite(v) && firstValid < 0) firstValid = i;
+    }
+    if (firstValid < 0) { F.timeDays = null; return; }
+    for (let i = 0; i < firstValid; i++) td[i] = td[firstValid];
+    for (let i = firstValid + 1; i < td.length; i++)
+      if (!isFinite(td[i])) td[i] = td[i - 1];
+    F.timeDays = td;
+    F.lastK = 0;
+  }
+
+  async function pollJob(jobId) {
+    for (;;) {
+      const j = await apiJson('/api/job/' + jobId);
+      if (j.status === 'done') return;
+      if (j.status === 'error') throw new Error(j.message);
+      $('frc-info').textContent = `building cell mesh… ${Math.round((j.progress || 0) * 100)}%`;
+      await new Promise(res => setTimeout(res, 400));
+    }
+  }
+
+  async function loadForcingMesh() {
+    ensurePrograms();
+    const buf = await (await api(`/api/forcing/${F.id}/mesh`)).arrayBuffer();
+    const nl = new Uint8Array(buf).indexOf(10);
+    const head = JSON.parse(new TextDecoder().decode(new Uint8Array(buf, 0, nl)));
+    let o = nl + 1;
+    const xy = new Float32Array(buf.slice(o, o + head.n_verts * 8)); o += head.n_verts * 8;
+    const nodeIdx = new Uint32Array(buf.slice(o, o + head.n_verts * 4)); o += head.n_verts * 4;
+    const tris = new Uint32Array(buf.slice(o, o + head.n_tris * 12)); o += head.n_tris * 12;
+    const nodes = new Float32Array(buf.slice(o, o + head.n_nodes * 8));
+
+    const posB = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, posB);
+    gl.bufferData(gl.ARRAY_BUFFER, xy, gl.STATIC_DRAW);
+    const idxB = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, idxB);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, tris, gl.STATIC_DRAW);
+
+    // quiver: per-instance anchor positions (static, decimated later via stride)
+    const nodeBuf = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, nodeBuf);
+    gl.bufferData(gl.ARRAY_BUFFER, nodes, gl.STATIC_DRAW);
+
+    F.mesh = {posB, idxB, nTris: head.n_tris, nVerts: head.n_verts, nodeIdx,
+              nNodes: head.n_nodes, nodeBuf, cellP01: head.cell_p01 || null,
+              gathered: new Float32Array(head.n_verts)};
+    $('frc-info').textContent =
+      `${fmtInt(F.meta.n_nodes)} nodes · ${fmtInt(F.meta.n_timesteps)} timesteps` +
+      (F.meta.times.length ? ` · ${F.meta.times[0]} → ${F.meta.times[F.meta.times.length - 1]}` : '');
+  }
+
+  /* ── data fetching (LRU cache + in-flight dedup + prefetch) ─────────────── */
+  function lru(map, key, val) {
+    map.set(key, val);
+    if (map.size > CACHE_MAX) map.delete(map.keys().next().value);
+  }
+
+  function fetchField(varName, t) {
+    const key = varName + '|' + t;
+    if (F.cache.has(key)) return Promise.resolve(F.cache.get(key));
+    if (F.inflight.has(key)) return F.inflight.get(key);
+    const p = (async () => {
+      const r = await api(`/api/forcing/${F.id}/field?var=${encodeURIComponent(varName)}&t=${t}`);
+      const rng = (r.headers.get('X-Data-Range') || '0,1').split(',').map(Number);
+      const arr = new Float32Array(await r.arrayBuffer());
+      arr.range = rng;
+      lru(F.cache, key, arr);
+      return arr;
+    })().finally(() => F.inflight.delete(key));
+    F.inflight.set(key, p);
+    return p;
+  }
+
+  function fetchVector(pair, t) {
+    const key = 'v|' + pair.x + '|' + t;
+    if (F.vcache.has(key)) return Promise.resolve(F.vcache.get(key));
+    if (F.inflight.has(key)) return F.inflight.get(key);
+    const p = (async () => {
+      const r = await api(`/api/forcing/${F.id}/vector?x=${encodeURIComponent(pair.x)}&y=${encodeURIComponent(pair.y)}&t=${t}`);
+      const arr = new Float32Array(await r.arrayBuffer());
+      arr.p98 = parseFloat(r.headers.get('X-Mag-P98') || '1');
+      lru(F.vcache, key, arr);
+      return arr;
+    })().finally(() => F.inflight.delete(key));
+    F.inflight.set(key, p);
+    return p;
+  }
+
+  /* magnitude / x / y / direction slab derived from an interleaved vector slab */
+  function deriveSlab(pair, t, style, vec) {
+    const key = pair.x + '|' + t + '|' + style;
+    if (F.dcache.has(key)) return F.dcache.get(key);
+    const n = F.mesh.nNodes;
+    const out = new Float32Array(n);
+    for (let i = 0; i < n; i++) {
+      const u = vec[2 * i], v = vec[2 * i + 1];
+      if (u < -1e29 || v < -1e29) { out[i] = -1e30; continue; }
+      out[i] = style === 'x' ? u
+             : style === 'y' ? v
+             : style === 'mag' ? Math.hypot(u, v)
+             : Math.atan2(v, u) * 180 / Math.PI;     // dir, math convention: CCW from east
+    }
+    lru(F.dcache, key, out);
+    return out;
+  }
+
+  function defaultRange(L) {
+    const p = L.magP98 || 1;
+    if (L.style === 'mag') return [0, p * 1.25];
+    if (L.style === 'x' || L.style === 'y') return [-p, p];
+    if (L.style === 'dir') return [-180, 180];
+    return L.range;
+  }
+
+  /* ── upload the current timestep of every visible layer to the GPU ──────── */
+  function updateLayers(only) {
+    if (!F.mesh) { state.dirty = true; return Promise.resolve(); }
+    const todo = F.layers.filter(L => L.visible && (!only || L === only));
+    return Promise.all(todo.map(L => uploadLayer(L, F.t)));
+  }
+
+  /* loading indicator (statusbar chip) */
+  let nLoading = 0;
+  function loadStart() {
+    nLoading++;
+    const s = $('st-frc');
+    if (s) s.style.display = '';
+  }
+  function loadEnd() {
+    nLoading = Math.max(0, nLoading - 1);
+    if (!nLoading) {
+      const s = $('st-frc');
+      if (s) s.style.display = 'none';
+    }
+  }
+
+  async function uploadLayer(L, t) {
+    const tok = layerKey(L) + '|' + t;
+    L.pending = tok;
+    const wasReady = L.ready;
+    loadStart();
+    try {
+      if (L.kind === 'scalar') {
+        const vals = await fetchField(L.varName, t);
+        if (L.pending !== tok) return;
+        if (!L.userRange && vals.range) setRange(L, vals.range[0], vals.range[1]);
+        uploadMap(L, vals);
+      } else {
+        const vec = await fetchVector(L.pair, t);
+        if (L.pending !== tok) return;
+        L.magP98 = vec.p98 || 1;
+        if (L.style === 'arrows') {
+          ensureArrGL(L);
+          gl.bindBuffer(gl.ARRAY_BUFFER, L.gl.vecBuf);
+          gl.bufferSubData(gl.ARRAY_BUFFER, 0, vec);
+        } else {
+          if (!L.userRange) { const r = defaultRange(L); setRange(L, r[0], r[1]); }
+          uploadMap(L, deriveSlab(L.pair, t, L.style, vec));
+        }
+      }
+      L.ready = true;
+      state.dirty = true;
+      if (!wasReady) refreshLayersPanel();   // card leaves its "loading…" state
+      if (t + 1 < F.meta.n_timesteps) {      // prefetch for smooth scrubbing
+        if (L.kind === 'scalar') fetchField(L.varName, t + 1).catch(() => {});
+        else fetchVector(L.pair, t + 1).catch(() => {});
+      }
+    } catch (e) { toast('forcing: ' + e.message, true); }
+    finally { loadEnd(); }
+  }
+
+  function setRange(L, lo, hi) {
+    L.range = [lo, hi];
+    if (L._rangeUI) L._rangeUI(lo, hi);
+  }
+
+  function uploadMap(L, nodeVals) {
+    ensureMapGL(L);
+    const g = F.mesh.gathered, ni = F.mesh.nodeIdx;
+    for (let i = 0; i < g.length; i++) g[i] = nodeVals[ni[i]];
+    gl.bindBuffer(gl.ARRAY_BUFFER, L.gl.valB);
+    gl.bufferSubData(gl.ARRAY_BUFFER, 0, g);
+  }
+
+  /* ── clock sync: follow the shared playbar (state.clock.t, abs days) ────── */
+  function syncClock() {
+    const td = F.timeDays;
+    if (!td || !td.length) return null;
+    const t = state.clock.t;
+    let k = F.lastK;
+    const inSlot = i => td[i] <= t && (i + 1 >= td.length || t < td[i + 1]);
+    if (!(k >= 0 && k < td.length && inSlot(k))) {
+      if (k + 1 < td.length && inSlot(k + 1)) k = k + 1;          // playback fast path
+      else if (t <= td[0]) k = 0;
+      else if (t >= td[td.length - 1]) k = td.length - 1;
+      else {
+        let lo = 0, hi = td.length - 1;
+        while (hi - lo > 1) { const m = (lo + hi) >> 1; if (td[m] <= t) lo = m; else hi = m; }
+        k = lo;
+      }
+    }
+    F.lastK = k;
+    if (k !== F.t) {
+      F.t = k;
+      const tl = $('frc-time'); if (tl) tl.value = k;
+      updateTimeLabel();
+      return updateLayers();
+    }
+    return null;
+  }
+
+  /* set the clock to an absolute day and resolve when the upload finished
+     (used by the video export loop so frames aren't stale) */
+  async function setTime(absDay) {
+    state.clock.t = absDay;
+    const p = syncClock();
+    if (p) await p;
+  }
+
+  /* ── draw (called from drawScene, after the model layer) ────────────────── */
+  function drawLayer() {
+    syncClock();
+    if (!F.mesh || !state.world0 || !F.show) return;
+    const off = [-state.world0[0], -state.world0[1]];
+    for (const L of F.layers) {
+      if (!L.visible || !L.ready) continue;
+      if (L.kind === 'vector' && L.style === 'arrows') drawQuivers(L, off);
+      else drawMap(L, off);
+    }
+  }
+
+  function drawMap(L, off) {
+    if (!L.gl.vao) return;
+    gl.useProgram(progFrc.prog);
+    gl.uniform4fv(progFrc.u.uView, viewUniform());
+    gl.uniform2fv(progFrc.u.uOff, off);
+    gl.uniform2f(progFrc.u.uClim, L.range[0], L.range[1]);
+    gl.uniform1f(progFrc.u.uAlpha, L.alpha);
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, cmapTex(L.cmap));
+    gl.uniform1i(progFrc.u.uRamp, 0);
+    gl.bindVertexArray(L.gl.vao);
+    gl.drawElements(gl.TRIANGLES, F.mesh.nTris * 3, gl.UNSIGNED_INT, 0);
+    gl.bindVertexArray(null);
+  }
+
+  function drawQuivers(L, off) {
+    if (!L.gl.arrVAO) return;
+    gl.bindVertexArray(L.gl.arrVAO);
+    if (L.gl.arrStride !== L.stride) {   // decimate by advancing `stride` nodes per instance
+      gl.bindBuffer(gl.ARRAY_BUFFER, F.mesh.nodeBuf);
+      gl.vertexAttribPointer(1, 2, gl.FLOAT, false, 8 * L.stride, 0);
+      gl.bindBuffer(gl.ARRAY_BUFFER, L.gl.vecBuf);
+      gl.vertexAttribPointer(2, 2, gl.FLOAT, false, 8 * L.stride, 0);
+      L.gl.arrStride = L.stride;
+    }
+    gl.useProgram(progArr.prog);
+    gl.uniform4fv(progArr.u.uView, viewUniform());
+    gl.uniform2fv(progArr.u.uOff, off);
+    gl.uniform2f(progArr.u.uCanvas, canvas.width, canvas.height);
+    // world-anchored arrow length: a p98-magnitude arrow spans cell_p01·50^f
+    // meters (log scale, f = scale slider 0..1) — arrows zoom with the map
+    const p01 = F.mesh.cellP01 || 100;
+    const lenW = p01 * Math.pow(50, L.scaleF == null ? 0.5 : L.scaleF);
+    gl.uniform1f(progArr.u.uScale, lenW * state.view.ppm);
+    gl.uniform1f(progArr.u.uMagRef, L.magP98);
+    gl.uniform1i(progArr.u.uColorMag, L.colorMag ? 1 : 0);
+    const rgb = hex2rgb(L.color || '#ffffff');
+    gl.uniform3f(progArr.u.uColor, rgb[0] / 255, rgb[1] / 255, rgb[2] / 255);
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, cmapTex(L.cmap));
+    gl.uniform1i(progArr.u.uRamp, 0);
+    gl.drawArraysInstanced(gl.LINES, 0, 6, Math.floor(F.mesh.nNodes / L.stride));
+    gl.bindVertexArray(null);
+  }
+
+  /* ── panel UI ───────────────────────────────────────────────────────────── */
+  function refreshPanel() {
+    refreshAddChoices();
+    refreshLayersPanel();
+    const tl = $('frc-time');
+    tl.max = F.meta ? Math.max(0, F.meta.n_timesteps - 1) : 0;
+    tl.value = F.t;
+    updateTimeLabel();
+  }
+
+  function refreshAddChoices() {
+    const sel = $('frc-add-var');
+    sel.innerHTML = '';
+    if (!F.meta) return;
+    const ogV = document.createElement('optgroup');
+    ogV.label = 'vector fields';
+    for (const p of F.meta.vector_pairs) {
+      const op = document.createElement('option');
+      op.value = 'v:' + p.x;
+      op.textContent = p.label;
+      ogV.appendChild(op);
+    }
+    if (ogV.children.length) sel.appendChild(ogV);
+    const ogS = document.createElement('optgroup');
+    ogS.label = 'scalars';
+    for (const v of F.meta.variables.filter(v => !v.is_vector_comp)) {
+      const op = document.createElement('option');
+      op.value = 's:' + v.name;
+      op.textContent = v.name + (v.units ? ` [${v.units}]` : '');
+      op.title = v.long_name;
+      ogS.appendChild(op);
+    }
+    if (ogS.children.length) sel.appendChild(ogS);
+  }
+
+  function refreshLayersPanel() {
+    const box = $('frc-layers');
+    box.innerHTML = '';
+    if (!F.layers.length) {
+      box.innerHTML = '<div class="hint">no layers — add one below</div>';
+    }
+    // GIS convention: list top layer first (reverse of draw order)
+    for (let i = F.layers.length - 1; i >= 0; i--) box.appendChild(buildLayerCard(F.layers[i]));
+    if (typeof LayersPanel !== 'undefined') LayersPanel.refresh();
+  }
+
+  function buildLayerCard(L) {
+    const card = document.createElement('div');
+    card.className = 'rule';
+    const rerender = () => { refreshLayersPanel(); state.dirty = true; };
+
+    // ── header: eye · label · reorder/remove tools ──
+    const head = document.createElement('div');
+    head.style.cssText = 'display:flex;align-items:center;gap:6px;width:100%';
+    const eye = document.createElement('button');
+    eye.className = 'eye' + (L.visible ? '' : ' off');
+    eye.textContent = '👁';
+    eye.onclick = () => {
+      L.visible = !L.visible;
+      eye.classList.toggle('off', !L.visible);
+      if (L.visible && !L.ready) updateLayers(L);
+      state.dirty = true;
+      if (typeof LayersPanel !== 'undefined') LayersPanel.refresh();
+    };
+    head.appendChild(eye);
+    const lbl = document.createElement('b');
+    lbl.textContent = layerLabel(L);
+    lbl.style.cssText = 'font-size:12px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap';
+    head.appendChild(lbl);
+    const tools = document.createElement('span');
+    tools.className = 'tools';
+    const mk = (txt, title, fn) => {
+      const b = document.createElement('button');
+      b.className = 'mini'; b.textContent = txt; b.title = title; b.onclick = fn;
+      tools.appendChild(b);
+    };
+    const idx = () => F.layers.indexOf(L);
+    mk('▲', 'draw later (on top)', () => {
+      const i = idx();
+      if (i < F.layers.length - 1) {
+        [F.layers[i], F.layers[i + 1]] = [F.layers[i + 1], F.layers[i]];
+        rerender();
+      }
+    });
+    mk('▼', 'draw earlier (below)', () => {
+      const i = idx();
+      if (i > 0) { [F.layers[i], F.layers[i - 1]] = [F.layers[i - 1], F.layers[i]]; rerender(); }
+    });
+    mk('✕', 'remove layer', () => { removeLayer(L); rerender(); });
+    head.appendChild(tools);
+    card.appendChild(head);
+
+    const row = (label, ...els) => {
+      const r = document.createElement('div');
+      r.className = 'row small';
+      r.style.width = '100%';
+      if (label) {
+        const s = document.createElement('span');
+        s.className = 'dim'; s.style.width = '58px'; s.textContent = label;
+        r.appendChild(s);
+      }
+      for (const el of els) r.appendChild(el);
+      card.appendChild(r);
+      return r;
+    };
+    const mkSel = (opts, val, fn) => {
+      const s = document.createElement('select');
+      s.className = 'grow';
+      for (const [v, txt] of opts) {
+        const op = document.createElement('option');
+        op.value = v; op.textContent = txt;
+        s.appendChild(op);
+      }
+      s.value = val;
+      s.onchange = () => fn(s.value);
+      return s;
+    };
+
+    if (!L.ready) {
+      const ld = document.createElement('span');
+      ld.className = 'dim small';
+      ld.textContent = '⏳ loading…';
+      head.insertBefore(ld, tools);
+    }
+
+    // ── variable: ONE list holding vector fields AND scalars, so a layer can
+    //    switch between the two kinds in place ──
+    const varSel = document.createElement('select');
+    varSel.className = 'grow';
+    const addOpts = (lbl, items) => {
+      if (!items.length) return;
+      const og = document.createElement('optgroup');
+      og.label = lbl;
+      for (const [v, txt] of items) {
+        const op = document.createElement('option');
+        op.value = v; op.textContent = txt;
+        og.appendChild(op);
+      }
+      varSel.appendChild(og);
+    };
+    addOpts('vector fields', F.meta.vector_pairs.map(p => ['v:' + p.x, p.label]));
+    addOpts('scalars', F.meta.variables.filter(v => !v.is_vector_comp)
+      .map(v => ['s:' + v.name, v.name + (v.units ? ` [${v.units}]` : '')]));
+    varSel.value = L.kind === 'scalar' ? 's:' + L.varName : 'v:' + L.pair.x;
+    varSel.onchange = () => {
+      const v = varSel.value;
+      freeLayerGL(L);                    // kind may change — rebuild GL state
+      L.userRange = false;
+      if (v.startsWith('v:')) {
+        L.kind = 'vector';
+        L.pair = F.meta.vector_pairs.find(p => p.x === v.slice(2));
+        if (L.style === 'map') L.style = 'mag';
+        if (L.cmap === 'viridis') L.cmap = 'turbo';
+      } else {
+        L.kind = 'scalar';
+        L.varName = v.slice(2);
+        L.style = 'map';
+        if (L.cmap === 'phase' || L.cmap === 'RdBu' || L.cmap === 'turbo') L.cmap = 'viridis';
+      }
+      updateLayers(L).then(rerender);
+    };
+    row('variable', varSel);
+    if (L.kind === 'vector') {
+      // ── style (vector layers only) ──
+      row('style', mkSel(VEC_STYLES, L.style, v => {
+        L.style = v;
+        L.userRange = false;
+        L.ready = false;
+        if (v === 'dir') L.cmap = 'phase';
+        else if (v === 'x' || v === 'y') L.cmap = 'RdBu';
+        else if (L.cmap === 'phase' || L.cmap === 'RdBu') L.cmap = 'turbo';
+        updateLayers(L).then(rerender);
+      }));
+    }
+
+    if (isMapStyle(L)) {
+      // ── colormap (direction is locked to the cyclic phase map) ──
+      if (L.style !== 'dir') {
+        row('colormap', mkSel(Object.keys(CMAPS).filter(c => c !== 'phase').map(c => [c, c]),
+          L.cmap, v => { L.cmap = v; ramp.style.background = cmapCss(v); state.dirty = true; }));
+      }
+      // ── range ──
+      const inLo = document.createElement('input');
+      const inHi = document.createElement('input');
+      for (const el of [inLo, inHi]) { el.type = 'number'; el.step = 'any'; el.style.width = '74px'; }
+      const to = document.createElement('span'); to.className = 'dim'; to.textContent = 'to';
+      const rst = document.createElement('button');
+      rst.className = 'mini'; rst.textContent = '↺'; rst.title = 'reset to data range';
+      const setUI = (lo, hi) => {
+        inLo.value = +lo.toPrecision(4); inHi.value = +hi.toPrecision(4);
+        lblLo.textContent = +lo.toPrecision(3); lblHi.textContent = +hi.toPrecision(3);
+      };
+      L._rangeUI = setUI;
+      inLo.onchange = inHi.onchange = () => {
+        L.userRange = true;
+        L.range = [parseFloat(inLo.value), parseFloat(inHi.value)];
+        lblLo.textContent = inLo.value; lblHi.textContent = inHi.value;
+        state.dirty = true;
+      };
+      rst.onclick = () => { L.userRange = false; updateLayers(L); };
+      const rrow = row('range', inLo, to, inHi, rst);
+      if (L.style === 'dir') rrow.classList.add('grey');
+      // ── opacity ──
+      const op = document.createElement('input');
+      op.type = 'range'; op.min = '0.15'; op.max = '1'; op.step = '0.05'; op.value = L.alpha;
+      op.oninput = () => { L.alpha = parseFloat(op.value); state.dirty = true; };
+      row('opacity', op);
+      // ── mini colorbar ──
+      const ramp = document.createElement('div');
+      ramp.className = 'ramp';
+      ramp.style.cssText = 'height:8px;border-radius:3px;flex:1;background:' + cmapCss(L.cmap);
+      const lblLo = document.createElement('span'); lblLo.className = 'dim small';
+      const lblHi = document.createElement('span'); lblHi.className = 'dim small';
+      row('', lblLo, ramp, lblHi);
+      setUI(L.range[0], L.range[1]);
+    } else {
+      // ── arrows controls ──
+      const dn = document.createElement('input');
+      dn.type = 'range'; dn.min = '0'; dn.max = '4'; dn.step = '1';
+      dn.value = String(Math.max(0, Math.min(4, Math.round(Math.log2(L.stride || 4)))));
+      const dnLbl = document.createElement('span');
+      dnLbl.className = 'dim small';
+      const dTxt = () => L.stride === 1 ? 'all' : '1 / ' + L.stride;
+      dnLbl.textContent = dTxt();
+      dn.oninput = () => {
+        L.stride = 2 ** parseInt(dn.value, 10);
+        dnLbl.textContent = dTxt();
+        state.dirty = true;
+      };
+      row('density', dn, dnLbl);
+      const sc = document.createElement('input');
+      sc.type = 'range'; sc.min = '0'; sc.max = '1'; sc.step = '0.01';
+      sc.value = String(L.scaleF == null ? 0.5 : L.scaleF);
+      sc.title = 'arrow size on the map — smallest ≈ the finest model cells, ' +
+                 'largest = 50× that (log scale)';
+      sc.oninput = () => { L.scaleF = parseFloat(sc.value); state.dirty = true; };
+      row('scale', sc);
+      const cm = document.createElement('label');
+      const cb = document.createElement('input');
+      cb.type = 'checkbox'; cb.checked = L.colorMag;
+      cb.onchange = () => { L.colorMag = cb.checked; state.dirty = true; rerender(); };
+      cm.appendChild(cb);
+      cm.appendChild(document.createTextNode(' color by magnitude'));
+      row('', cm);
+      if (L.colorMag) {
+        row('colormap', mkSel(Object.keys(CMAPS).filter(c => c !== 'phase').map(c => [c, c]),
+          L.cmap, v => { L.cmap = v; state.dirty = true; }));
+      } else if (typeof mkColorBtn === 'function') {
+        row('color', mkColorBtn(() => L.color || '#ffffff',
+          c => { L.color = c; state.dirty = true; }, 'arrow color'));
+      }
+    }
+    return card;
+  }
+
+  function updateTimeLabel() {
+    $('frc-tlabel').textContent = F.meta && F.meta.times[F.t] ?
+      `${F.meta.times[F.t]}  (${F.t + 1}/${F.meta.n_timesteps})` : '–';
+  }
+
+  /* fine-step controls drive the SHARED clock (playbar follows) */
+  function gotoStep(k) {
+    if (!F.meta) return;
+    k = Math.max(0, Math.min(F.meta.n_timesteps - 1, k));
+    if (F.timeDays) {
+      state.clock.playing = false;
+      if (typeof refreshPlayBtn === 'function') refreshPlayBtn();
+      state.clock.t = F.timeDays[k];
+      if (typeof updateTimelineUI === 'function') updateTimelineUI();
+      syncClock();
+    } else {
+      F.t = k;
+      updateTimeLabel();
+      updateLayers();
+    }
+    $('frc-time').value = F.t;
+    state.dirty = true;
+  }
+
+  function wire() {
+    $('frc-open').onclick = async () => {
+      try {
+        const r = await apiJson('/api/pickfile?kind=nc');
+        if (r.paths && r.paths[0]) await open(r.paths[0]);
+      } catch (e) { toast(String(e), true); }
+    };
+    $('frc-load').onclick = async () => {
+      const p = $('frc-path').value.trim();
+      if (!p) return toast('enter a netCDF path first', true);
+      try { await open(p); } catch (e) { toast(String(e), true); }
+    };
+    $('frc-add').onclick = () => {
+      const v = $('frc-add-var').value;
+      if (!v || !F.meta) return;
+      if (v.startsWith('v:')) {
+        const pair = F.meta.vector_pairs.find(p => p.x === v.slice(2));
+        if (pair) addLayer({kind: 'vector', pair});
+      } else {
+        addLayer({kind: 'scalar', varName: v.slice(2)});
+      }
+      refreshLayersPanel();
+      updateLayers();
+    };
+    const eye = (id, get, set) => {
+      const b = $(id);
+      const upd = () => b.classList.toggle('off', !get());
+      b.onclick = ev => { ev.preventDefault(); ev.stopPropagation(); set(!get()); upd(); };
+      upd();
+    };
+    eye('eye-frc', () => F.show, v => {
+      F.show = v; state.dirty = true;
+      if (typeof LayersPanel !== 'undefined') LayersPanel.refresh();
+    });
+    $('frc-time').oninput = () => gotoStep(parseInt($('frc-time').value, 10));
+    $('frc-step-b').onclick = () => gotoStep(F.t - 1);
+    $('frc-step-f').onclick = () => gotoStep(F.t + 1);
+  }
+
+  let wired = false;
+  /* open the forcing file referenced by the loaded config (called on config
+     load from the Settings tab, and lazily on first entry of a map tab) */
+  async function autoOpenFromConfig() {
+    if (!wired) { wire(); wired = true; }
+    const cfg = typeof SettingsTab !== 'undefined' ? SettingsTab.getConfig() : null;
+    const cfgPath = cfg ? SettingsTab.getPath() : null;
+    const dataRel = cfg && cfg.inputs && cfg.inputs.data;
+    if (!dataRel) return false;
+    if (F.meta && F.meta.raw_input === dataRel) return true;   // already open
+    const base = cfgPath ? cfgPath.replace(/[\\/][^\\/]+$/, '') : null;
+    try {
+      await open(dataRel, base);
+      F.meta.raw_input = dataRel;
+      return true;
+    } catch (e) { toast('forcing: ' + e.message, true); return false; }
+  }
+
+  async function enter() {
+    if (!wired) { wire(); wired = true; }
+    try {
+      // always re-sync with the config: the Settings tab's inputs.data is the
+      // single source of the forcing file (no-op when unchanged)
+      if (!(await autoOpenFromConfig()) && !F.id) {
+        const last = localStorage.getItem('stgui_last_forcing');
+        if (last) await open(last);
+      }
+    } catch (e) { /* nothing auto-openable yet */ }
+  }
+
+  // no own tab anymore: the forcing sections live in the Viewer tab, whose
+  // enter hook (app.js) calls ForcingTab.enter()
+  return {drawLayer, open, state: F, enter, autoOpenFromConfig, setTime,
+          updateLayers, refreshLayersPanel};
+})();

--- a/sedtrails-gui/web/js/tabs/run.js
+++ b/sedtrails-gui/web/js/tabs/run.js
@@ -1,0 +1,180 @@
+"use strict";
+/* ═════════════════════════ Run tab ═════════════════════════
+   Launch `sedtrails run` on the loaded config, stream the log, show progress
+   (output-slot count from the streaming netCDF) with an ETA, and hand the
+   finished result straight to the Viewer tab. */
+
+const RunTab = (() => {
+  let pollTimer = null;
+  let logOffset = 0;
+  let lastState = null;
+  let autoImported = false;   // auto-import fires once per run
+
+  const el = id => $(id);
+  const fmtBytes = b => b == null ? '?' :
+    b > 1024**3 ? (b / 1024**3).toFixed(1) + ' GB' :
+    b > 1024**2 ? (b / 1024**2).toFixed(1) + ' MB' : Math.round(b / 1024) + ' kB';
+  const fmtDur = s => {
+    if (s == null) return '–';
+    s = Math.round(s);
+    const h = Math.floor(s / 3600), m = Math.floor(s % 3600 / 60), ss = s % 60;
+    return (h ? h + 'h ' : '') + (h || m ? m + 'm ' : '') + ss + 's';
+  };
+
+  /* ── summary card ───────────────────────────────────────────────────────── */
+  async function refreshSummary() {
+    const cfg = SettingsTab.getConfig();
+    const path = SettingsTab.getPath();
+    const box = el('run-summary');
+    if (!cfg || !path) {
+      box.innerHTML = '<div class="placeholder">Load (and save) a configuration in the ' +
+        'Settings tab first — the run uses the yaml file on disk.</div>';
+      el('run-start').disabled = true;
+      return;
+    }
+    el('run-start').disabled = false;
+    let est = null;
+    try { est = await apiJson('/api/config/estimate', {config: SettingsTab.getPruned()}); }
+    catch (e) {}
+    const pops = (cfg.particles && cfg.particles.populations || [])
+      .map(p => p.name || '?').join(', ');
+    box.innerHTML =
+      `<div class="row small"><span class="dim" style="width:78px">Config</span><span class="grow" style="word-break:break-all">${path}</span></div>` +
+      `<div class="row small"><span class="dim" style="width:78px">Populations</span><span>${pops || '–'}</span></div>` +
+      `<div class="row small"><span class="dim" style="width:78px">Duration</span><span>${(cfg.time && cfg.time.duration) || '(forcing length)'}</span></div>` +
+      `<div class="row small"><span class="dim" style="width:78px">Est. output</span><span>` +
+      (est && est.bytes ? `${fmtInt(est.particles)} particles × ${fmtInt(est.slots)} slots ≈ ${fmtBytes(est.bytes)}` : 'unknown') +
+      `</span></div>` +
+      (SettingsTab.isDirty() ? '<div class="hint" style="color:var(--warn)">⚠ unsaved changes — save first, the run reads the file on disk</div>' : '');
+  }
+
+  /* ── run control ────────────────────────────────────────────────────────── */
+  async function start() {
+    const path = SettingsTab.getPath();
+    if (!path) return toast('save the configuration first', true);
+    if (SettingsTab.isDirty() && !confirm('The config has unsaved changes; the run uses the file on disk. Start anyway?')) return;
+    try {
+      await apiJson('/api/run/start', {config_path: path});
+      el('run-log').textContent = '';
+      logOffset = 0;
+      autoImported = false;
+      startPolling();
+    } catch (e) { toast('start failed: ' + e.message, true); }
+  }
+
+  async function stop() {
+    if (!confirm('Stop the running simulation? The output file may be left incomplete.')) return;
+    try { await apiJson('/api/run/stop', {}); } catch (e) { toast(String(e), true); }
+  }
+
+  function startPolling() {
+    clearInterval(pollTimer);
+    pollTimer = setInterval(poll, 1000);
+    poll();
+  }
+
+  async function poll() {
+    let st;
+    try { st = await apiJson('/api/run/status'); }
+    catch (e) { return; }
+    const running = st.state === 'running';
+    el('run-start').style.display = running ? 'none' : '';
+    el('run-stop').style.display = running ? '' : 'none';
+    el('run-state').textContent = st.state === 'idle' ? '' :
+      `${st.state}${st.returncode !== null && st.state !== 'running' ? ` (exit ${st.returncode})` : ''}` +
+      (st.elapsed ? ` · elapsed ${fmtDur(st.elapsed)}` : '');
+    el('run-state').style.color =
+      st.state === 'error' ? 'var(--err)' : st.state === 'done' ? 'var(--ok)' : 'var(--dim)';
+
+    const p = st.progress;
+    const bar = el('run-prog');
+    if (p && st.state !== 'idle') {
+      bar.style.display = '';
+      bar.firstElementChild.style.width = (st.state === 'done' ? 100 : (p.pct || 0)) + '%';
+      // always show whatever progress source is available (slots > log % > bytes)
+      const parts = [];
+      if (p.pct != null) parts.push(`${(st.state === 'done' ? 100 : p.pct).toFixed(0)}%`);
+      if (p.written_slots != null && p.total_slots)
+        parts.push(`output slot ${p.written_slots}/${p.total_slots}`);
+      else if (p.bytes != null)
+        parts.push(`output ${fmtBytes(p.bytes)}` + (p.est_bytes ? ` of ≈${fmtBytes(p.est_bytes)}` : ''));
+      if (running && p.eta_s != null) parts.push(`~${fmtDur(p.eta_s)} remaining`);
+      el('run-progtxt').textContent = parts.join(' · ');
+    } else {
+      bar.style.display = 'none';
+      el('run-progtxt').textContent = '';
+    }
+
+    try {
+      const lg = await apiJson('/api/run/log?offset=' + logOffset);
+      if (lg.lines.length) {
+        logOffset = lg.offset;
+        const pre = el('run-log');
+        const stick = pre.scrollTop + pre.clientHeight >= pre.scrollHeight - 20;
+        pre.textContent += lg.lines.join('\n') + '\n';
+        if (pre.textContent.length > 400000) pre.textContent = pre.textContent.slice(-300000);
+        if (stick) pre.scrollTop = pre.scrollHeight;
+      }
+    } catch (e) {}
+
+    el('run-import').style.display = st.state === 'done' && st.result_path ? '' : 'none';
+    el('run-import').onclick = () => importResult(st);
+
+    if (!running && lastState === 'running') {
+      toast(st.state === 'done' ? 'Simulation finished ✓' :
+            st.state === 'stopped' ? 'Simulation stopped' : 'Simulation failed — see log', st.state === 'error');
+      refreshSummary();
+      // finished cleanly → results go straight into the viewer
+      if (st.state === 'done' && st.result_path && !autoImported) {
+        autoImported = true;
+        importResult(st);
+      }
+    }
+    lastState = st.state;
+    if (!running && st.state !== 'idle') { clearInterval(pollTimer); pollTimer = null; }
+  }
+
+  /* silent import: no modal — the GUI already knows result path, forcing and name.
+     A rerun replaces the previously imported run of the same name (update). */
+  async function importResult(st) {
+    Tabs.activate('viewer');
+    const frc = (typeof ForcingTab !== 'undefined' && ForcingTab.state.meta) ?
+      ForcingTab.state.meta.path : null;
+    const cfgName = (st.config_path || '').split(/[\\/]/).pop().replace(/\.ya?ml$/i, '') || 'run';
+    toast('Importing result…');
+    try {
+      const {job_id} = await apiJson('/api/import',
+        {nc_path: st.result_path, forcing_path: frc, name: cfgName});
+      for (;;) {
+        await new Promise(r => setTimeout(r, 500));
+        const j = await apiJson('/api/job/' + job_id);
+        if (j.status === 'error') throw new Error(j.message);
+        if (j.status === 'unknown') throw new Error('server restarted during import — retry');
+        if (j.status === 'done') {
+          state.runs.filter(r => r.meta.run_name === cfgName).forEach(removeRun);
+          await loadRun(j.bundle, 1);
+          toast('Result loaded ✓');
+          break;
+        }
+      }
+    } catch (e) { toast('Import failed: ' + e.message, true); }
+  }
+
+  let wired = false;
+  async function enter() {
+    if (!wired) {
+      el('run-start').onclick = start;
+      el('run-stop').onclick = stop;
+      wired = true;
+    }
+    await SettingsTab.init();
+    refreshSummary();
+    startPolling();
+  }
+
+  Tabs.register('run', {enter, leave() {
+    // keep polling while a run is active so the toast still fires elsewhere
+    if (lastState !== 'running') { clearInterval(pollTimer); pollTimer = null; }
+  }});
+  return {refreshSummary};
+})();

--- a/sedtrails-gui/web/js/tabs/schema-form.js
+++ b/sedtrails-gui/web/js/tabs/schema-form.js
@@ -1,0 +1,289 @@
+"use strict";
+/* ═════════════════ schema-driven form generator (Settings tab) ═════════════════
+   Renders a JSON-Schema (draft 2020-12) as an editable form bound directly to a
+   plain config object. Generic walker + a small override table for the parts
+   with structure the schema alone can't express nicely (populations, exactly-
+   one-of choosers). Values the user leaves empty stay ABSENT from the config,
+   so schema defaults keep applying at run time (shown as placeholders).      */
+
+const SchemaForm = (() => {
+  let SCHEMAS = null;                       // {main, population, visualization}
+  const URN = f => `urn:sedtrails:config:${f}.schema.json`;
+
+  function setSchemas(s) { SCHEMAS = s; }
+
+  /* ── $ref resolution; returns [schema, root-for-#-refs] ─────────────────── */
+  function resolve(schema, root) {
+    let guard = 0;
+    while (schema && schema.$ref && guard++ < 8) {
+      const ref = schema.$ref;
+      if (ref.startsWith('#/')) {
+        let t = root;
+        for (const part of ref.slice(2).split('/')) t = t && t[part];
+        if (!t) break;
+        schema = t;
+      } else {
+        const name = ['main', 'population', 'visualization'].find(n => ref === URN(n));
+        if (!name) break;
+        root = SCHEMAS[name];
+        schema = root;
+      }
+    }
+    return [schema || {}, root];
+  }
+
+  /* ── small helpers ──────────────────────────────────────────────────────── */
+  const label = k => k.replace(/_/g, ' ');
+  const fmtVal = v => typeof v === 'boolean' ? (v ? 'True' : 'False') : String(v);
+  const fmtDefault = d => typeof d === 'object' ? JSON.stringify(d) : fmtVal(d);
+
+  function infoBtn(schema) {
+    if (!schema.description && schema.default === undefined) return '';
+    const parts = [];
+    if (schema.description) parts.push(schema.description);
+    if (schema.default !== undefined) parts.push(`Default: ${fmtDefault(schema.default)}`);
+    const txt = parts.join('\n\n').replace(/"/g, '&quot;');
+    return `<button class="mini info" data-info="${txt}" tabindex="-1">ⓘ</button>`;
+  }
+
+  function ensure(obj, key, init) {
+    if (obj[key] === undefined || obj[key] === null) obj[key] = init;
+    return obj[key];
+  }
+
+  /* getter for the container at `path` inside cfg, creating objects on demand */
+  function containerAt(cfg, path) {
+    let o = cfg;
+    for (const p of path) o = ensure(o, p, typeof p === 'number' ? [] : {});
+    return o;
+  }
+
+  /* ── leaf widgets ───────────────────────────────────────────────────────── */
+  function coerce(schema, raw) {
+    if (raw === '') return undefined;
+    const t = Array.isArray(schema.type) ? schema.type[0] : schema.type;
+    if (t === 'integer') { const v = parseInt(raw, 10); return isNaN(v) ? undefined : v; }
+    if (t === 'number') { const v = parseFloat(raw); return isNaN(v) ? undefined : v; }
+    if (t === 'boolean') return raw === 'true';
+    return raw;
+  }
+
+  function leafWidget(schema, value, onSet) {
+    const t = Array.isArray(schema.type) ? schema.type.find(x => x !== 'null') : schema.type;
+    let el;
+    if (schema.enum) {
+      el = document.createElement('select');
+      const opts = ['', ...schema.enum.filter(o => o !== schema.default)];
+      for (const o of opts) {
+        const op = document.createElement('option');
+        op.value = o;
+        op.textContent = o === '' ?
+          (schema.default !== undefined ? `${fmtVal(schema.default)} (default)` : '(unset)') : o;
+        el.appendChild(op);
+      }
+      if (value !== undefined && value !== null && String(value) === String(schema.default)) value = '';
+      el.value = value === undefined || value === null ? '' : String(value);
+      el.onchange = () => onSet(coerce(schema, el.value));
+    } else if (t === 'boolean') {
+      el = document.createElement('select');
+      const options = schema.default !== undefined
+        ? [['', `${fmtVal(schema.default)} (default)`],
+           [String(!schema.default), fmtVal(!schema.default)]]
+        : [['', '(unset)'], ['true', 'True'], ['false', 'False']];
+      for (const [v, txt] of options) {
+        const op = document.createElement('option');
+        op.value = v;
+        op.textContent = txt;
+        el.appendChild(op);
+      }
+      if (value !== undefined && value !== null && value === schema.default) value = '';
+      el.value = value === undefined || value === null ? '' : String(value);
+      el.onchange = () => onSet(coerce({type: 'boolean'}, el.value));
+    } else if (t === 'number' || t === 'integer') {
+      el = document.createElement('input');
+      el.type = 'number';
+      el.step = t === 'integer' ? '1' : 'any';
+      if (schema.minimum !== undefined) el.min = schema.minimum;
+      if (schema.maximum !== undefined) el.max = schema.maximum;
+      if (schema.default !== undefined) el.placeholder = `${schema.default} (default)`;
+      el.value = value === undefined || value === null ? '' : value;
+      el.onchange = () => onSet(coerce(schema, el.value));
+    } else if (schema.type === 'array') {
+      el = document.createElement('textarea');
+      el.rows = Math.min(4, Math.max(2, (value || []).length));
+      el.placeholder = 'one entry per line';
+      el.value = (value || []).join('\n');
+      el.onchange = () => {
+        const arr = el.value.split('\n').map(s => s.trim()).filter(Boolean);
+        onSet(arr.length ? arr : undefined);
+      };
+    } else {                                         // string / mixed
+      el = document.createElement('input');
+      el.type = 'text';
+      if (schema.default !== undefined) el.placeholder = `${schema.default} (default)`;
+      el.value = value === undefined || value === null ? '' : String(value);
+      el.onchange = () => onSet(el.value === '' ? undefined : el.value);
+    }
+    return el;
+  }
+
+  /* ── field row ──────────────────────────────────────────────────────────── */
+  function fieldRow(ctx, schema, key, path, required) {
+    const pointer = path.join('/');
+    const row = document.createElement('div');
+    row.className = 'sf-field';
+    row.dataset.pointer = pointer;
+    const lbl = document.createElement('span');
+    lbl.className = 'sf-label dim';
+    lbl.innerHTML = label(key) + (required ? ' <b class="req">*</b>' : '');
+    row.appendChild(lbl);
+
+    const parent = () => containerAt(ctx.cfg, path.slice(0, -1));
+    const widget = leafWidget(schema, get(ctx.cfg, path), v => {
+      const obj = parent();
+      if (v === undefined) delete obj[path[path.length - 1]];
+      else obj[path[path.length - 1]] = v;
+      ctx.onChange(pointer);
+    });
+    widget.classList.add('sf-input');
+    row.appendChild(widget);
+    row.insertAdjacentHTML('beforeend', infoBtn(schema));
+    return row;
+  }
+
+  function get(cfg, path) {
+    let o = cfg;
+    for (const p of path) { if (o === undefined || o === null) return undefined; o = o[p]; }
+    return o;
+  }
+
+  /* ── exactly-one-of chooser (tracer_methods, strategy, burial_depth) —
+     a dropdown selects the active branch; its fields render below ─────────── */
+  function chooser(ctx, path, options, renderBranch, freshBranch, title) {
+    const wrap = document.createElement('div');
+    wrap.className = 'sf-chooser';
+    wrap.dataset.pointer = path.join('/');
+    const current = get(ctx.cfg, path) || {};
+    const active = options.find(o => current[o] !== undefined) || null;
+
+    const bar = document.createElement('div');
+    bar.className = 'row small';
+    if (title) {
+      const lbl = document.createElement('span');
+      lbl.className = 'sf-label dim';
+      lbl.textContent = title;
+      bar.appendChild(lbl);
+    }
+    const sel = document.createElement('select');
+    sel.className = 'grow';
+    if (!active) {
+      const ph = document.createElement('option');
+      ph.value = '';
+      ph.textContent = `— choose ${title || 'an option'} —`;
+      sel.appendChild(ph);
+    }
+    for (const o of options) {
+      const op = document.createElement('option');
+      op.value = o;
+      op.textContent = label(o);
+      sel.appendChild(op);
+    }
+    if (active) sel.value = active;
+    sel.onchange = () => {
+      if (!sel.value) return;
+      const obj = containerAt(ctx.cfg, path.slice(0, -1));
+      obj[path[path.length - 1]] = {[sel.value]: freshBranch(sel.value)};
+      ctx.onChange(path.join('/'));
+      ctx.rerender();
+    };
+    bar.appendChild(sel);
+    wrap.appendChild(bar);
+    if (active) wrap.appendChild(renderBranch(active, [...path, active]));
+    return wrap;
+  }
+
+  /* ── object walker ──────────────────────────────────────────────────────── */
+  function renderObject(ctx, schema, root, path, container) {
+    const props = schema.properties || {};
+    const required = new Set(schema.required || []);
+    for (const key of Object.keys(props)) {
+      const p = [...path, key];
+      const ov = ctx.override(p, props[key], root);
+      if (ov === null) continue;                       // suppressed
+      if (ov) { container.appendChild(ov); continue }  // custom element
+      const [sub, subRoot] = resolve(props[key], root);
+      const merged = {...sub, ...props[key]};          // ref-site desc/default win
+      delete merged.$ref;
+      if (sub.type === 'object' && (sub.properties || sub.$defs)) {
+        const g = document.createElement('details');
+        g.className = 'sf-group';
+        g.dataset.pointer = p.join('/');
+        // ALL groups collapsed by default; only a user click (kept in openState
+        // across re-renders) opens one
+        g.open = ctx.openState[p.join('/')] === true;
+        g.innerHTML = `<summary>${label(key)} ${infoBtn(merged)}</summary>`;
+        const body = document.createElement('div');
+        body.className = 'sec';
+        renderObject(ctx, sub, subRoot, p, body);
+        g.appendChild(body);
+        container.appendChild(g);
+      } else {
+        container.appendChild(fieldRow(ctx, merged, key, p, required.has(key)));
+      }
+    }
+  }
+
+  /* ── public: render the whole form ──────────────────────────────────────── */
+  function render(container, cfg, opts) {
+    const openState = {};
+    container.querySelectorAll('details[data-pointer]').forEach(d => {
+      openState[d.dataset.pointer] = d.open;
+    });
+    container.innerHTML = '';
+    const ctx = {
+      cfg,
+      onChange: opts.onChange,
+      rerender: () => render(container, cfg, opts),
+      override: (path, schema, root) => opts.override(ctx, path, schema, root),
+      openState,
+    };
+    renderObject(ctx, SCHEMAS.main, SCHEMAS.main, [], container);
+    return ctx;
+  }
+
+  return {setSchemas, getSchemas: () => SCHEMAS, resolve, render, fieldRow, chooser,
+          renderObject, leafWidget, containerAt, get, label, infoBtn, URN};
+})();
+
+/* ── info popover (single, shared) — shows on hover, hides on leave ────────── */
+(() => {
+  let showTimer = null;
+  const show = btn => {
+    const pop = $('infopop');
+    if (!pop) return;
+    pop.textContent = btn.dataset.info;
+    pop.style.display = 'block';
+    const r = btn.getBoundingClientRect();
+    pop.style.left = Math.min(r.left, window.innerWidth - 340) + 'px';
+    pop.style.top = (r.bottom + 6) + 'px';
+  };
+  const hide = () => {
+    clearTimeout(showTimer);
+    const pop = $('infopop');
+    if (pop) pop.style.display = 'none';
+  };
+  document.addEventListener('mouseover', e => {
+    const btn = e.target.closest && e.target.closest('button.info');
+    if (btn) {
+      clearTimeout(showTimer);
+      showTimer = setTimeout(() => show(btn), 120);
+    }
+  });
+  document.addEventListener('mouseout', e => {
+    if (e.target.closest && e.target.closest('button.info')) hide();
+  });
+  document.addEventListener('click', e => {         // touch / keyboard fallback
+    const btn = e.target.closest && e.target.closest('button.info');
+    if (btn) { show(btn); e.preventDefault(); } else hide();
+  });
+})();

--- a/sedtrails-gui/web/js/tabs/seeding.js
+++ b/sedtrails-gui/web/js/tabs/seeding.js
@@ -1,0 +1,837 @@
+"use strict";
+/* ═════════════════════════ Populations tab ═════════════════════════
+   One card per population covering the whole population schema. Everything
+   that determines the release POSITIONS (source object, distribution,
+   coordinates, seed, counts) is edited ONLY in the "Modify seeding…" modal —
+   the card shows a read-only summary of it; all other settings stay editable
+   in the card. Settings are bound to the same config object as the Settings
+   tab; previews come from the backend, which runs sedtrails' own seeding
+   strategies (exact WYSIWYG). The old draw-tool/confirm-card machinery below
+   is kept but unused. */
+
+const SeedingTab = (() => {
+  const S = {
+    tool: null,            // {mode: 'point'|'transect'|'bbox'|'poly', pop: index}
+    draft: [],             // clicked world coords for the armed tool
+    pending: null,         // finished-but-unconfirmed shape {mode, pts, pop}
+    previews: {},          // popIndex -> {buf, n, visible:'auto'|true|false, key, label}
+    downAt: null,
+    applied: {},           // popName -> {obj, verts} — the source object last
+                           // applied to that population (drives the ⟳ Update button)
+  };
+
+  const popSchema = () => SchemaForm.resolve({$ref: SchemaForm.URN('population')}, null)[0];
+  const cfg = () => SettingsTab.getConfig();
+  const pops = () => {
+    const c = cfg();
+    return (c && c.particles && c.particles.populations) || [];
+  };
+  const cfgBase = () => {
+    const p = SettingsTab.getPath();
+    return p ? p.replace(/[\\/][^\\/]+$/, '') : null;
+  };
+
+  /* preview visibility: ONE group toggle (Layers panel), same on every map
+     tab — the old per-population tri-state ('auto' = seeding tab only) is
+     gone; previews are hollow rings so they never read as simulated particles */
+  let showPreviews = true;
+  function previewShown(pv) { return !!pv && showPreviews; }
+  function setShowPreviews(v) { showPreviews = !!v; state.dirty = true; }
+  function setPreviewVisible(i, v) {               // legacy per-pop hook (unused)
+    const pv = S.previews[i] = S.previews[i] || {};
+    pv.visible = v;
+    state.dirty = true;
+  }
+
+  /* ── strategy mutation helpers (used on Apply only) ─────────────────────── */
+  function strategyOf(pop) {
+    const seeding = pop.seeding = pop.seeding || {};
+    return seeding.strategy = seeding.strategy || {};
+  }
+  function ensureBranch(pop, name, fresh) {
+    const st = strategyOf(pop);
+    if (!st[name]) {
+      for (const k of Object.keys(st)) delete st[k];
+      st[name] = fresh;
+    }
+    return st[name];
+  }
+  const rd = v => Math.round(v * 10) / 10;
+
+  /* ── draw tools: clicks accumulate a draft; finishing → pending confirm ─── */
+  function applyClick(mode, pt) {
+    S.draft.push(pt);
+    if (mode === 'transect' && S.draft.length === 2) finishShape();
+    else if (mode === 'bbox' && S.draft.length === 2) finishShape();
+    state.dirty = true;
+  }
+
+  function finishShape() {
+    if (!S.tool || !S.draft.length) return cancelTool();
+    if (S.tool.mode === 'poly' && S.draft.length < 3) return cancelTool();
+    S.pending = {mode: S.tool.mode, pts: S.draft.slice(), pop: S.tool.pop};
+    S.tool = null;
+    S.draft = [];
+    canvas.classList.remove('drawing');
+    $('drawhint').style.display = 'none';
+    state.dirty = true;
+    renderPanel();
+  }
+
+  function armTool(mode, popIndex) {
+    if (S.tool && S.tool.mode === mode && S.tool.pop === popIndex) {
+      // clicking the active tool again finishes an open-ended shape
+      if (mode === 'point' || mode === 'poly') return finishShape();
+      return cancelTool();
+    }
+    S.pending = null;
+    S.tool = {mode, pop: popIndex};
+    S.draft = [];
+    canvas.classList.add('drawing');
+    const hints = {
+      point: 'Click release points · Enter or the tool button to finish · Esc to cancel',
+      transect: 'Click start and end of the segment · Esc to cancel',
+      bbox: 'Click two opposite corners of the box · Esc to cancel',
+      poly: 'Click to add vertices · Enter/double-click to finish · Esc to cancel',
+    };
+    $('drawhint-text').textContent = hints[mode];
+    $('btn-edit-done').style.display = 'none';
+    $('drawhint').style.display = 'flex';
+    renderPanel();
+  }
+
+  function cancelTool() {
+    S.tool = null;
+    S.draft = [];
+    canvas.classList.remove('drawing');
+    $('drawhint').style.display = 'none';
+    state.dirty = true;
+    renderPanel();
+  }
+
+  function afterEdit() {
+    SettingsTab.touch();
+    state.dirty = true;
+    renderPanel();
+    refreshPreviews();
+  }
+
+  /* ── seed from an object in the central store (Objects panel) ───────────
+     Turns the picked object into a pending shape; applyFromObject() consumes
+     it right away (the confirm-card flow is gone). */
+  function usePendingFromObject(o, popIndex) {
+    const type = o.type || 'polygon';
+    let pts = o.verts.map(v => v.slice());
+    if (type === 'bbox') {                       // stored as 4 corners → 2 corners
+      const xs = pts.map(v => v[0]), ys = pts.map(v => v[1]);
+      pts = [[Math.min(...xs), Math.min(...ys)], [Math.max(...xs), Math.max(...ys)]];
+    }
+    const mode = {polygon: 'poly', bbox: 'bbox', transect: 'transect', point: 'point'}[type];
+    S.pending = {mode, pts, pop: popIndex, from: o.name};
+    state.dirty = true;
+    renderPanel();
+  }
+
+  /* ── apply the pending shape to the chosen population. REPLACE semantics:
+     "seed from object X" always mirrors X exactly (so ⟳ Update re-applies
+     changed coordinates without duplicating locations/segments) ────────────── */
+  function applyPending(popIndex, asWhat) {
+    const p = S.pending;
+    const pop = pops()[popIndex];
+    if (!p || !pop) return;
+    if (p.mode === 'point') {
+      const br = ensureBranch(pop, 'point', {locations: []});
+      br.locations = p.pts.map(pt => `${rd(pt[0])},${rd(pt[1])}`);
+    } else if (p.mode === 'transect') {
+      const br = ensureBranch(pop, 'transect', {segments: [], k: 100});
+      br.segments = [
+        `${rd(p.pts[0][0])},${rd(p.pts[0][1])} ${rd(p.pts[1][0])},${rd(p.pts[1][1])}`];
+    } else {                                      // bbox | poly → random / grid area
+      const name = asWhat === 'grid' ? 'grid' : 'random';
+      const st = strategyOf(pop);
+      if (st[name] === undefined) {               // switching branch: start fresh
+        for (const k of Object.keys(st)) delete st[k];
+        st[name] = name === 'grid' ? {separation: {dx: 100, dy: 100}}
+                                   : {nlocations: 100, seed: 42};
+      }
+      const br = st[name];
+      if (p.mode === 'bbox') {
+        const [a, b] = p.pts;
+        br.bbox = `${rd(Math.min(a[0], b[0]))},${rd(Math.min(a[1], b[1]))} ` +
+                  `${rd(Math.max(a[0], b[0]))},${rd(Math.max(a[1], b[1]))}`;
+        delete br.poly;
+      } else {
+        br.poly = p.pts.map(q => `${rd(q[0])},${rd(q[1])}`);
+        delete br.bbox;
+      }
+    }
+    // remember which object seeded this population: if that object is edited
+    // later, the population card offers a one-click ⟳ Update
+    if (p.from) {
+      const src = state.polygons.find(o => o.name === p.from);
+      if (src) S.applied[pop.name || String(popIndex)] =
+        {obj: p.from, verts: JSON.stringify(src.verts)};
+    }
+    S.pending = null;
+    afterEdit();
+  }
+
+  /* apply an object's coordinates to a population IMMEDIATELY (no confirm
+     card): the strategy is derived from the object type — point set → point,
+     transect → transect, polygon/box → area. asWhat picks the area
+     distribution ('random'|'grid'); default keeps the population's current. */
+  function applyFromObject(o, popIndex, asWhat) {
+    const pop = pops()[popIndex];
+    if (!pop) return;
+    if (!asWhat) {
+      const st = pop.seeding && pop.seeding.strategy;
+      asWhat = st && st.grid ? 'grid' : 'random';
+    }
+    usePendingFromObject(o, popIndex);
+    applyPending(popIndex, asWhat);
+  }
+
+  /* switch random ↔ grid keeping the current area when the source object is gone */
+  function switchAreaBranch(pop, name) {
+    const st = strategyOf(pop);
+    const old = st.random || st.grid || {};
+    const bbox = old.bbox, poly = old.poly;
+    for (const k of Object.keys(st)) delete st[k];
+    st[name] = name === 'grid' ? {separation: {dx: 100, dy: 100}}
+                               : {nlocations: 100, seed: 42};
+    if (bbox !== undefined) st[name].bbox = bbox;
+    if (poly !== undefined) st[name].poly = poly;
+    afterEdit();
+  }
+
+  function buildConfirmCard() {
+    const p = S.pending;
+    const card = document.createElement('div');
+    card.className = 'rule default';
+    const summary = {
+      point: `${p.pts.length} release point${p.pts.length > 1 ? 's' : ''}`,
+      transect: 'transect segment',
+      bbox: 'bounding box',
+      poly: `polygon (${p.pts.length} vertices)`,
+    }[p.mode];
+    const head = document.createElement('div');
+    head.style.cssText = 'width:100%;font-weight:600';
+    head.textContent = p.from ? `"${p.from}" as ${summary}` : `New ${summary}`;
+    card.appendChild(head);
+
+    const row = document.createElement('div');
+    row.className = 'row small';
+    row.style.width = '100%';
+    row.appendChild(document.createTextNode('apply to'));
+    const selPop = document.createElement('select');
+    pops().forEach((pop, i) => {
+      const op = document.createElement('option');
+      op.value = i;
+      op.textContent = pop.name || 'population ' + (i + 1);
+      selPop.appendChild(op);
+    });
+    selPop.value = Math.min(p.pop, pops().length - 1);
+    row.appendChild(selPop);
+
+    let selAs = null;
+    if (p.mode === 'bbox' || p.mode === 'poly') {
+      row.appendChild(document.createTextNode('as'));
+      selAs = document.createElement('select');
+      for (const [v, txt] of [['random', 'random area'], ['grid', 'regular grid area']]) {
+        const op = document.createElement('option');
+        op.value = v; op.textContent = txt;
+        selAs.appendChild(op);
+      }
+      const st = (pops()[p.pop] || {}).seeding && pops()[p.pop].seeding.strategy;
+      selAs.value = st && st.grid ? 'grid' : 'random';
+      row.appendChild(selAs);
+    } else {
+      const what = document.createElement('span');
+      what.className = 'dim';
+      what.textContent = p.mode === 'point' ? 'as point release locations (added)'
+                                            : 'as a transect segment (added)';
+      row.appendChild(what);
+    }
+    card.appendChild(row);
+
+    const note = document.createElement('div');
+    note.className = 'hint';
+    note.style.width = '100%';
+    note.textContent = (p.mode === 'bbox' || p.mode === 'poly')
+      ? 'Replaces the release area of the chosen population. Nothing changes until Apply.'
+      : 'Added to the chosen population. Nothing changes until Apply.';
+    card.appendChild(note);
+
+    const btns = document.createElement('div');
+    btns.className = 'row';
+    btns.style.width = '100%';
+    const ok = document.createElement('button');
+    ok.className = 'primary';
+    ok.textContent = 'Apply';
+    ok.onclick = () => applyPending(parseInt(selPop.value, 10), selAs ? selAs.value : null);
+    const no = document.createElement('button');
+    no.textContent = 'Cancel';
+    no.onclick = () => { S.pending = null; state.dirty = true; renderPanel(); };
+    btns.appendChild(ok);
+    btns.appendChild(no);
+    card.appendChild(btns);
+    return card;
+  }
+
+  /* ── canvas events (active only on this tab while a tool is armed) ──────── */
+  canvas.addEventListener('mousedown', e => { S.downAt = [e.clientX, e.clientY]; });
+  canvas.addEventListener('click', e => {
+    if (Tabs.current !== 'seeding' || !S.tool || !state.world0) return;
+    if (S.downAt && Math.hypot(e.clientX - S.downAt[0], e.clientY - S.downAt[1]) > 4) return;
+    applyClick(S.tool.mode, screenToRd(e.clientX, e.clientY));
+  });
+  canvas.addEventListener('dblclick', e => {
+    if (Tabs.current === 'seeding' && S.tool &&
+        (S.tool.mode === 'poly' || S.tool.mode === 'point')) {
+      e.preventDefault();
+      S.draft.pop();                       // drop the extra click from the dblclick
+      finishShape();
+    }
+  });
+  window.addEventListener('keydown', e => {
+    if (Tabs.current !== 'seeding') return;
+    if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+    if (S.tool) {
+      if (e.key === 'Enter' && (S.tool.mode === 'poly' || S.tool.mode === 'point')) finishShape();
+      else if (e.key === 'Escape') cancelTool();
+    } else if (S.pending && e.key === 'Escape') {
+      S.pending = null; state.dirty = true; renderPanel();
+    }
+  });
+
+  /* ── preview (exact seed locations from the backend) ────────────────────── */
+  const refreshPreviews = debounce(async () => {
+    const c = cfg();
+    if (!c) return;
+    for (let i = 0; i < pops().length; i++) {
+      const pop = pops()[i];
+      const key = JSON.stringify([pop.seeding && pop.seeding.strategy,
+                                  pop.seeding && pop.seeding.quantity, state.world0]);
+      const pv = S.previews[i] = S.previews[i] || {visible: 'auto'};
+      if (pv.key === key) continue;
+      pv.key = key;
+      try {
+        const r = await apiJson('/api/seeding/preview',
+                                {population: SettingsTab.prune(pop), base: cfgBase()});
+        const arr = new Float32Array(r.points.length * 2);
+        const w0 = state.world0 || [0, 0];
+        r.points.forEach((p, k) => { arr[k*2] = p[0] - w0[0]; arr[k*2+1] = p[1] - w0[1]; });
+        if (!pv.buf) pv.buf = gl.createBuffer();
+        gl.bindBuffer(gl.ARRAY_BUFFER, pv.buf);
+        gl.bufferData(gl.ARRAY_BUFFER, arr, gl.DYNAMIC_DRAW);
+        pv.n = r.points.length;
+        pv.label = `${fmtInt(r.n_locations)} locations × ${fmtInt(r.quantity)} = ` +
+                   `${fmtInt(r.n_particles)} particles` + (r.capped ? ' (preview capped)' : '');
+        pv.error = null;
+      } catch (e) {
+        pv.n = 0;
+        pv.label = null;
+        pv.error = String(e.message || e);
+      }
+      const lbl = $(`seed-count-${i}`);
+      if (lbl) {
+        lbl.textContent = pv.label || pv.error || '';
+        lbl.classList.toggle('err', !!pv.error);
+      }
+      state.dirty = true;
+    }
+    if (typeof LayersPanel !== 'undefined') LayersPanel.refresh();
+  }, 350);
+
+  /* ── map layer: previews + draft/pending shape ──────────────────────────── */
+  function drawShapePts(mode, pts, w0, buf) {
+    const closed = mode === 'poly' && pts.length > 2;
+    const isBox = mode === 'bbox' && pts.length === 2;
+    let disp = pts;
+    if (isBox) {
+      const [a, b] = pts;
+      disp = [[a[0], a[1]], [b[0], a[1]], [b[0], b[1]], [a[0], b[1]], [a[0], a[1]]];
+    } else if (closed) {
+      disp = [...pts, pts[0]];
+    }
+    const arr = new Float32Array(disp.length * 2);
+    disp.forEach((p, k) => { arr[k*2] = p[0] - w0[0]; arr[k*2+1] = p[1] - w0[1]; });
+    gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+    gl.bufferData(gl.ARRAY_BUFFER, arr, gl.DYNAMIC_DRAW);
+    gl.enableVertexAttribArray(0);
+    gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 8, 0);
+    gl.uniform1f(progFlat.u.uRound, 0);
+    if (disp.length > 1 && mode !== 'point')
+      gl.drawArrays(gl.LINE_STRIP, 0, disp.length);
+    gl.uniform1f(progFlat.u.uRound, 1);
+    gl.drawArrays(gl.POINTS, 0, mode === 'point' ? pts.length : disp.length);
+    gl.uniform1f(progFlat.u.uRound, 0);
+  }
+
+  function drawLayer() {
+    if (!state.world0) return;
+    gl.useProgram(progFlat.prog);
+    gl.uniform4fv(progFlat.u.uView, viewUniform());
+    gl.uniform1f(progFlat.u.uPtSize, 7);
+    if (!drawLayer.buf) drawLayer.buf = gl.createBuffer();
+
+    for (const [i, pv] of Object.entries(S.previews)) {
+      if (!previewShown(pv) || !pv.n || !pv.buf) continue;
+      gl.bindBuffer(gl.ARRAY_BUFFER, pv.buf);
+      gl.enableVertexAttribArray(0);
+      gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 8, 0);
+      const rgb = hex2rgb(PALETTE[i % PALETTE.length]);
+      gl.uniform4f(progFlat.u.uColor, rgb[0]/255, rgb[1]/255, rgb[2]/255, 0.9);
+      gl.uniform1f(progFlat.u.uRound, 2);      // hollow ring ≠ simulated particles
+      gl.drawArrays(gl.POINTS, 0, pv.n);
+      gl.uniform1f(progFlat.u.uRound, 0);
+    }
+    if (Tabs.current === 'seeding') {
+      const w0 = state.world0;
+      gl.uniform4f(progFlat.u.uColor, 0.85, 0.55, 0.1, 1.0);
+      if (S.draft.length && S.tool)
+        drawShapePts(S.tool.mode, S.draft, w0, drawLayer.buf);
+      else if (S.pending)
+        drawShapePts(S.pending.mode, S.pending.pts, w0, drawLayer.buf);
+    }
+  }
+
+  /* ── panel: one card per population covering the WHOLE population schema
+     (particle settings + seeding) — the Settings tab links here ──────────── */
+  function renderPanel() {
+    const box = $('seeding-pops');
+    const c = cfg();
+    if (!c) {
+      box.innerHTML = '<div class="placeholder">Load a configuration in the Settings tab first.</div>';
+      return;
+    }
+    const openState = {};
+    box.querySelectorAll('details[data-pointer]').forEach(d => openState[d.dataset.pointer] = d.open);
+    box.innerHTML = '';
+    const ps = popSchema();
+    const ctx = {
+      cfg: c,
+      onChange: () => { SettingsTab.touch(); refreshPreviews(); },
+      rerender: renderPanel,
+      openState,
+    };
+    // full population form; name/type/seeding render explicitly at the top of
+    // each card, barriers is not exposed, strategy params render chooser-less
+    ctx.override = (path, schema, root) => {
+      const p = path.map(x => typeof x === 'number' ? '*' : x).join('/');
+      if (p.endsWith('populations/*/name') || p.endsWith('populations/*/particle_type') ||
+          p.endsWith('populations/*/seeding') || p.endsWith('populations/*/barriers'))
+        return null;
+      if (p.endsWith('populations/*/seeding/strategy'))
+        return null;                       // rendered explicitly inside renderSeeding
+      return SettingsTab.override(ctx, path, schema, root);
+    };
+
+    pops().forEach((pop, i) => {
+      const card = document.createElement('details');
+      card.className = 'sf-group sf-pop';
+      card.dataset.pointer = `seedpop/${i}`;
+      card.open = openState[`seedpop/${i}`] === true;   // collapsed by default
+      card.innerHTML =
+        `<summary><span class="swatch" style="background:${PALETTE[i % PALETTE.length]}"></span>` +
+        ` ${pop.name || 'population ' + (i + 1)} <span class="dim small">(${pop.particle_type || '?'})</span>` +
+        `<span class="poptools"><button class="mini" data-act="dup" title="duplicate">⧉</button>` +
+        `<button class="mini danger" data-act="del" title="remove">✕</button></span></summary>`;
+      card.querySelector('[data-act=dup]').onclick = e => {
+        e.preventDefault();
+        const copy = JSON.parse(JSON.stringify(pop));
+        copy.name = (copy.name || 'population') + '_copy';
+        pops().splice(i + 1, 0, copy);
+        afterEdit();
+      };
+      card.querySelector('[data-act=del]').onclick = e => {
+        e.preventDefault();
+        if (!confirm(`Remove population "${pop.name || i + 1}"?`)) return;
+        pops().splice(i, 1);
+        afterEdit();
+      };
+      const body = document.createElement('div');
+      body.className = 'sec';
+      // explicit order: name/type on top, then seeding (the important part,
+      // always open), then the remaining particle settings
+      const base = ['particles', 'populations', i];
+      body.appendChild(SchemaForm.fieldRow(ctx, ps.properties.name, 'name',
+                                           [...base, 'name'], true));
+      body.appendChild(SchemaForm.fieldRow(ctx, ps.properties.particle_type,
+                                           'particle_type', [...base, 'particle_type'], true));
+      body.appendChild(renderSeeding(ctx, [...base, 'seeding']));
+      SchemaForm.renderObject(ctx, ps, ps, base, body);
+      card.appendChild(body);
+      box.appendChild(card);
+    });
+
+    const addRow = document.createElement('div');
+    addRow.className = 'row';
+    addRow.style.margin = '8px 10px';
+    const add = document.createElement('button');
+    add.textContent = '＋ Add population';
+    add.onclick = () => {
+      if (!c.particles) c.particles = {};
+      if (!c.particles.populations) c.particles.populations = [];
+      c.particles.populations.push(
+        SettingsTab.newPopulation(c.particles.populations.length + 1));
+      afterEdit();
+    };
+    addRow.appendChild(add);
+    box.appendChild(addRow);
+  }
+
+  /* one-line description of the current release positions (panel summary) */
+  function strategySummary(st, srcName) {
+    if (!st || !Object.keys(st).length) return 'No release locations yet.';
+    const inObj = srcName ? ` in "${srcName}"` : '';
+    if (st.point) return `point release — ${(st.point.locations || []).length} location(s)`;
+    if (st.transect) return `transect${srcName ? ` "${srcName}"` : ''} — ` +
+      `${(st.transect.segments || []).length} segment(s), k=${st.transect.k}`;
+    if (st.random) return `random points${inObj} — ${st.random.nlocations} locations, ` +
+      `seed ${st.random.seed}`;
+    if (st.grid) {
+      const s = st.grid.separation || {};
+      return `regular grid${inObj} — dx ${s.dx} m × dy ${s.dy} m`;
+    }
+    if (st.file_points) return 'release locations from a points file';
+    return '';
+  }
+
+  /* the seeding block inside a population card — always visible (no collapse):
+     a read-only summary of the release positions + the "Modify seeding…"
+     button (the modal is the ONLY place positions change), ⟳ Update when the
+     source object moved, the live count, then the schema-driven form for the
+     remaining (non-position) seeding fields like release_type */
+  function renderSeeding(ctx, path) {
+    const i = path[2];                 // ['particles', 'populations', i, 'seeding']
+    const pop = pops()[i];
+    const ps = popSchema();
+    const g = document.createElement('div');
+    g.className = 'sf-group sf-pinned';
+    g.dataset.pointer = path.join('/');
+    g.innerHTML = '<div class="sf-pinnedhead">seeding</div>';
+    const body = document.createElement('div');
+    body.className = 'sec';
+
+    const lk = S.applied[pop.name || String(i)];
+    const src = lk && state.polygons.find(q => q.name === lk.obj);
+    const st = pop.seeding && pop.seeding.strategy;
+
+    const srow = document.createElement('div');
+    srow.className = 'row small';
+    const sum = document.createElement('span');
+    sum.className = 'grow';
+    sum.textContent = strategySummary(st, src && lk.obj);
+    if (!st || !Object.keys(st).length) sum.className = 'grow dim';
+    srow.appendChild(sum);
+    body.appendChild(srow);
+
+    const brow = document.createElement('div');
+    brow.className = 'row';
+    const mod = document.createElement('button');
+    mod.className = 'grow';
+    mod.textContent = '✎ Modify seeding…';
+    mod.title = 'select an object and set distribution, coordinates, seed, counts';
+    mod.onclick = () => openSeedingModal(i);
+    brow.appendChild(mod);
+    // ⟳ Update: re-sync coordinates from a changed source object (settings kept)
+    if (src && JSON.stringify(src.verts) !== lk.verts) {
+      const upd = document.createElement('button');
+      upd.className = 'mini okbtn';
+      upd.textContent = '⟳ Update';
+      upd.title = `"${lk.obj}" changed — re-apply its coordinates to this population`;
+      upd.onclick = () => applyFromObject(src, i);
+      brow.appendChild(upd);
+    }
+    body.appendChild(brow);
+
+    const pv = S.previews[i];
+    const count = document.createElement('div');
+    count.className = 'hint';
+    count.id = `seed-count-${i}`;
+    count.textContent = pv && (pv.label || pv.error) || '';
+    body.appendChild(count);
+
+    SchemaForm.renderObject(ctx, ps.properties.seeding, ps, path, body);
+    g.appendChild(body);
+    return g;
+  }
+
+  /* strategy parameters only — kept for reference, no longer rendered in the
+     panel (position settings moved into the Modify-seeding modal) */
+  function renderStrategyParams(ctx, path) {
+    const ps = popSchema();
+    const stratSchema = ps.properties.seeding.properties.strategy;
+    const cur = SchemaForm.get(ctx.cfg, path) || {};
+    const active = Object.keys(stratSchema.properties).find(o => cur[o] !== undefined);
+    const wrap = document.createElement('div');
+    wrap.dataset.pointer = path.join('/');
+    if (!active) {
+      wrap.innerHTML =
+        '<div class="hint">No release locations yet — pick an object above.</div>';
+      return wrap;
+    }
+    if (active === 'file_points') {
+      const note = document.createElement('div');
+      note.className = 'row small dim';
+      note.textContent = 'release locations come from a points file';
+      wrap.appendChild(note);
+    }
+    const body = document.createElement('div');
+    body.className = 'sf-branch';
+    SchemaForm.renderObject(ctx, stratSchema.properties[active], ps, [...path, active], body);
+    wrap.appendChild(body);
+    return wrap;
+  }
+
+  /* ── "Modify seeding…" modal: the ONLY place release positions change.
+     All edits happen on a deep-cloned draft strategy; Apply commits it to the
+     population, Cancel/✕ just hides the modal and the draft is dropped. */
+  const M = {pop: -1, draft: null, from: null};
+
+  function openSeedingModal(i) {
+    const pop = pops()[i];
+    if (!pop) return;
+    M.pop = i;
+    M.draft = JSON.parse(JSON.stringify((pop.seeding && pop.seeding.strategy) || {}));
+    const lk = S.applied[pop.name || String(i)];
+    M.from = (lk && state.polygons.some(q => q.name === lk.obj)) ? lk.obj : null;
+    $('modal-seeding-title').textContent =
+      `Modify seeding — ${pop.name || 'population ' + (i + 1)}`;
+    $('modal-seeding-count').textContent = '';
+    renderModal();
+    modalCount();
+    $('modal-seeding').style.display = 'flex';
+  }
+
+  /* derive a fresh draft strategy from an object; area objects keep the draft's
+     current distribution + its parameters (same rules as applyPending) */
+  function draftFromObject(o, draft) {
+    const type = o.type || 'polygon';
+    let pts = o.verts.map(v => v.slice());
+    if (type === 'point')
+      return {point: {locations: pts.map(pt => `${rd(pt[0])},${rd(pt[1])}`)}};
+    if (type === 'transect')
+      return {transect: {segments: [
+        `${rd(pts[0][0])},${rd(pts[0][1])} ${rd(pts[1][0])},${rd(pts[1][1])}`],
+        k: (draft.transect && draft.transect.k) || 100}};
+    const grid = !!draft.grid;
+    const br = grid
+      ? {separation: (draft.grid.separation && {...draft.grid.separation}) || {dx: 100, dy: 100}}
+      : {nlocations: (draft.random && draft.random.nlocations) || 100,
+         seed: draft.random && draft.random.seed !== undefined ? draft.random.seed : 42};
+    if (type === 'bbox') {
+      const xs = pts.map(v => v[0]), ys = pts.map(v => v[1]);
+      br.bbox = `${rd(Math.min(...xs))},${rd(Math.min(...ys))} ` +
+                `${rd(Math.max(...xs))},${rd(Math.max(...ys))}`;
+    } else {
+      br.poly = pts.map(q => `${rd(q[0])},${rd(q[1])}`);
+    }
+    return grid ? {grid: br} : {random: br};
+  }
+
+  /* switch the draft's area distribution keeping the area itself */
+  function draftSwitchArea(draft, name) {
+    const old = draft.random || draft.grid || {};
+    const br = name === 'grid' ? {separation: {dx: 100, dy: 100}}
+                               : {nlocations: 100, seed: 42};
+    if (old.bbox !== undefined) br.bbox = old.bbox;
+    if (old.poly !== undefined) br.poly = old.poly;
+    return {[name]: br};
+  }
+
+  /* modal field helpers — every edit mutates M.draft and refreshes the count */
+  function mRow(labelTxt, el) {
+    const row = document.createElement('div');
+    row.className = 'row small';
+    const l = document.createElement('span');
+    l.className = 'sf-label dim';
+    l.textContent = labelTxt;
+    row.appendChild(l);
+    row.appendChild(el);
+    return row;
+  }
+  function mNum(labelTxt, get, set) {
+    const inp = document.createElement('input');
+    inp.type = 'number';
+    inp.className = 'grow';
+    inp.value = get();
+    inp.oninput = () => {
+      const v = parseFloat(inp.value);
+      if (isFinite(v)) { set(v); modalCount(); }
+    };
+    return mRow(labelTxt, inp);
+  }
+  function mLines(labelTxt, lines, set, ph) {
+    const wrap = document.createElement('div');
+    wrap.className = 'field';
+    wrap.innerHTML = `<div class="lbl">${labelTxt}</div>`;
+    const ta = document.createElement('textarea');
+    ta.rows = 4;
+    ta.style.width = '100%';
+    ta.placeholder = ph;
+    ta.value = (lines || []).join('\n');
+    ta.oninput = () => {
+      set(ta.value.split('\n').map(s => s.trim()).filter(Boolean));
+      modalCount();
+    };
+    wrap.appendChild(ta);
+    return wrap;
+  }
+
+  function renderModal() {
+    const body = $('modal-seeding-body');
+    body.innerHTML = '';
+    const draft = M.draft;
+    const glyph = {polygon: '⬠', point: '•', transect: '╱', bbox: '▭'};
+
+    // 1. the source object — the strategy type follows it
+    const sel = document.createElement('select');
+    sel.className = 'grow';
+    const ph = document.createElement('option');
+    ph.value = '';
+    ph.textContent = state.polygons.length
+      ? '— manual coordinates —'
+      : '— no objects yet (Objects panel, top right) —';
+    sel.appendChild(ph);
+    state.polygons.forEach((o, k) => {
+      const op = document.createElement('option');
+      op.value = k;
+      op.textContent = `${glyph[o.type || 'polygon']} ${o.name}`;
+      if (o.name === M.from) op.selected = true;
+      sel.appendChild(op);
+    });
+    sel.onchange = () => {
+      const o = state.polygons[parseInt(sel.value, 10)];
+      if (o) { M.from = o.name; M.draft = draftFromObject(o, M.draft); }
+      else M.from = null;
+      renderModal();
+      modalCount();
+    };
+    body.appendChild(mRow('seed from', sel));
+
+    // 2. derived strategy + type-specific position settings
+    const active = ['point', 'transect', 'random', 'grid', 'file_points']
+      .find(k => draft[k] !== undefined);
+    const kind = {point: 'point release', transect: 'transect release',
+                  random: 'area release', grid: 'area release',
+                  file_points: 'points from file'}[active];
+    const krow = document.createElement('span');
+    krow.className = 'grow dim';
+    krow.textContent = kind || 'pick an object above';
+    body.appendChild(mRow('strategy', krow));
+
+    if (active === 'random' || active === 'grid') {
+      const dsel = document.createElement('select');
+      dsel.className = 'grow';
+      for (const [v, txt] of [['random', 'random points'], ['grid', 'regular grid']]) {
+        const op = document.createElement('option');
+        op.value = v; op.textContent = txt;
+        dsel.appendChild(op);
+      }
+      dsel.value = active;
+      dsel.onchange = () => {
+        M.draft = draftSwitchArea(M.draft, dsel.value);
+        renderModal();
+        modalCount();
+      };
+      body.appendChild(mRow('distribution', dsel));
+
+      const br = draft[active];
+      const area = document.createElement('span');
+      area.className = 'grow dim';
+      area.textContent = br.poly ? `polygon, ${br.poly.length} vertices`
+                       : br.bbox ? `box ${br.bbox}` : 'no area yet';
+      body.appendChild(mRow('area', area));
+      if (active === 'random') {
+        body.appendChild(mNum('n locations', () => br.nlocations,
+                              v => { br.nlocations = Math.max(1, Math.round(v)); }));
+        body.appendChild(mNum('seed', () => br.seed,
+                              v => { br.seed = Math.round(v); }));
+      } else {
+        const sep = br.separation = br.separation || {dx: 100, dy: 100};
+        body.appendChild(mNum('dx (m)', () => sep.dx, v => { sep.dx = v; }));
+        body.appendChild(mNum('dy (m)', () => sep.dy, v => { sep.dy = v; }));
+      }
+    } else if (active === 'point') {
+      body.appendChild(mLines('release locations (x,y per line)',
+        draft.point.locations, v => { draft.point.locations = v; }, '75000,455000'));
+    } else if (active === 'transect') {
+      body.appendChild(mLines('segments (x1,y1 x2,y2 per line)',
+        draft.transect.segments, v => { draft.transect.segments = v; },
+        '75000,455000 76000,456000'));
+      body.appendChild(mNum('k (locations per segment)', () => draft.transect.k,
+                            v => { draft.transect.k = Math.max(2, Math.round(v)); }));
+    } else if (active === 'file_points') {
+      const inp = document.createElement('input');
+      inp.type = 'text';
+      inp.className = 'grow';
+      inp.value = draft.file_points.path || '';
+      inp.oninput = () => { draft.file_points.path = inp.value; modalCount(); };
+      body.appendChild(mRow('points file', inp));
+    } else {
+      const hint = document.createElement('div');
+      hint.className = 'hint';
+      hint.textContent = 'Pick an object to derive the release strategy from its ' +
+        'type: point set → point release, transect → transect, polygon/box → area.';
+      body.appendChild(hint);
+    }
+  }
+
+  /* live particle count in the modal footer, computed on the draft */
+  const modalCount = debounce(async () => {
+    const pop = pops()[M.pop];
+    const el = $('modal-seeding-count');
+    if (!pop || !el) return;
+    if (!M.draft || !Object.keys(M.draft).length) { el.textContent = ''; return; }
+    try {
+      const p2 = JSON.parse(JSON.stringify(SettingsTab.prune(pop)));
+      p2.seeding = p2.seeding || {};
+      p2.seeding.strategy = M.draft;
+      const r = await apiJson('/api/seeding/preview', {population: p2, base: cfgBase()});
+      el.textContent = `${fmtInt(r.n_locations)} locations × ${fmtInt(r.quantity)} = ` +
+                       `${fmtInt(r.n_particles)} particles`;
+      el.classList.remove('err');
+    } catch (e) {
+      el.textContent = String(e.message || e);
+      el.classList.add('err');
+    }
+  }, 350);
+
+  function applySeedingModal() {
+    const pop = pops()[M.pop];
+    if (!pop) return;
+    pop.seeding = pop.seeding || {};
+    pop.seeding.strategy = M.draft;
+    const key = pop.name || String(M.pop);
+    if (M.from) {
+      const src = state.polygons.find(q => q.name === M.from);
+      if (src) S.applied[key] = {obj: M.from, verts: JSON.stringify(src.verts)};
+    } else {
+      delete S.applied[key];           // manual coordinates: no source link
+    }
+    $('modal-seeding').style.display = 'none';
+    afterEdit();
+  }
+
+  function wire() {
+    $('seed-goto-settings').onclick = () => Tabs.activate('settings');
+    $('modal-seeding-apply').onclick = applySeedingModal;
+  }
+
+  let wired = false;
+  async function enter() {
+    if (!wired) { wire(); wired = true; }
+    await SettingsTab.init();
+    if (typeof ForcingTab !== 'undefined') ForcingTab.enter();  // map background
+    renderPanel();
+    refreshPreviews();
+  }
+
+  Tabs.register('seeding', {enter, leave() { if (S.tool) cancelTool(); }});
+  return {drawLayer, refreshPreviews, renderPanel,
+          previews: () => S.previews, previewShown, setPreviewVisible,
+          showPreviews: () => showPreviews, setShowPreviews,
+          popNames: () => pops().map((p, i) => p.name || 'population ' + (i + 1))};
+})();

--- a/sedtrails-gui/web/js/tabs/settings.js
+++ b/sedtrails-gui/web/js/tabs/settings.js
@@ -1,0 +1,655 @@
+"use strict";
+/* ═════════════════════════ Settings tab ═════════════════════════
+   Schema-driven editor for the SedTRAILS simulation yaml. Loads/saves through
+   the backend (comment-preserving via ruamel), validates against the packaged
+   JSON schemas, and shows a live output-size estimate.                       */
+
+const SettingsTab = (() => {
+  let cfg = null;            // the config object bound to the form
+  let cfgPath = null;        // absolute path of the loaded yaml (null = unsaved)
+  let snapshot = '';         // JSON snapshot for dirty detection
+  let roundtrip = null;      // 'ruamel' | 'pyyaml'
+  let schemasReady = false;
+  let formCtx = null;
+
+  const el = id => $(id);
+  const popSchema = () => SchemaForm.resolve({$ref: SchemaForm.URN('population')},
+                                             null)[0];
+
+  /* ── defaults for chooser branches ─────────────────────────────────────── */
+  const FRESH_TRACER = {
+    vanwesten: () => ({flow_field_name: ['bed_load_velocity', 'suspended_velocity']}),
+    soulsby: () => ({flow_field_name: ['grain_velocity']}),
+    passive_tracer: () => ({flow_field_name: ['depth_avg_flow_velocity']}),
+  };
+  const FRESH_STRATEGY = {
+    point: () => ({locations: []}),
+    transect: () => ({segments: [], k: 100}),
+    random: () => ({bbox: '', nlocations: 100, seed: 42}),
+    grid: () => ({bbox: '', separation: {dx: 100, dy: 100}}),
+    file_points: () => ({path: ''}),
+  };
+  const CHARACTERISTICS = {
+    passive: () => ({diffusion_coefficient: 0.0}),
+    sand: () => ({density: 2650.0, grain_size: 0.0005}),
+    mud: () => ({density: 2000.0, size: 0.00005}),
+  };
+  const CHAR_DEF = {passive: 'passive_characteristics', sand: 'sand_characteristics',
+                    mud: 'mud_characteristics'};
+
+  function newPopulation(n) {
+    const prev = cfg.particles && cfg.particles.populations &&
+                 cfg.particles.populations[cfg.particles.populations.length - 1];
+    if (prev) {
+      const copy = JSON.parse(JSON.stringify(prev));
+      copy.name = `population_${n}`;
+      return copy;
+    }
+    return {
+      name: `population_${n}`, particle_type: 'sand',
+      characteristics: CHARACTERISTICS.sand(),
+      tracer_methods: {vanwesten: FRESH_TRACER.vanwesten()},
+      transport_probability: 'no_probability',
+      seeding: {quantity: 1, burial_depth: {constant: 0},
+                strategy: {random: FRESH_STRATEGY.random()}},
+    };
+  }
+
+  /* ── override table for the generic walker ─────────────────────────────── */
+  function override(ctx, path, schema, root) {
+    const p = path.map(x => typeof x === 'number' ? '*' : x).join('/');
+
+    // particles (populations incl. seeding) live entirely in the Populations
+    // tab — hidden here. Existing yaml values are preserved untouched.
+    if (p === 'particles') return null;
+
+    // populations (particle settings + seeding) live in the Populations tab —
+    // Settings shows a link instead. renderPopulations below stays for reuse.
+    if (p === 'particles/populations') {
+      const row = document.createElement('div');
+      row.className = 'sf-field';
+      row.dataset.pointer = path.join('/');
+      const n = (SchemaForm.get(cfg, path) || []).length;
+      row.innerHTML = '<span class="sf-label dim">populations</span>' +
+        `<span class="dim small grow">${n} population(s) — configured in the Populations tab</span>`;
+      const btn = document.createElement('button');
+      btn.className = 'mini';
+      btn.textContent = '↗ Populations';
+      btn.title = 'open the Populations tab';
+      btn.onclick = () => Tabs.activate('seeding');
+      row.appendChild(btn);
+      return row;
+    }
+    if (p === 'visualization') return null;                    // dashboard: not GUI-relevant
+    // 'general' and 'domain' contain only unimplemented/legacy options
+    // (preprocess, n_runs, display_input_metadata, subset/pol cropping) — the
+    // few live ones (input model, numerical scheme) are re-homed under Inputs.
+    // Hidden values in existing yamls are preserved untouched.
+    if (p === 'general' || p === 'domain') return null;
+    if (p === 'inputs') return renderInputsGroup(ctx);
+
+    // physics stays ONE collapsible group: its constants / bed_shear_stress /
+    // bed_slope sub-objects render flat inside (dim sub-label, no nested groups)
+    if (p === 'physics/constants' || p === 'physics/bed_shear_stress' ||
+        p === 'physics/bed_slope') {
+      const wrap = document.createElement('div');
+      wrap.dataset.pointer = path.join('/');
+      const head = document.createElement('div');
+      head.className = 'row small dim';
+      head.textContent = SchemaForm.label(path[path.length - 1]);
+      wrap.appendChild(head);
+      const [sub, subRoot] = SchemaForm.resolve(schema, root);
+      SchemaForm.renderObject(ctx, sub, subRoot, path, wrap);
+      return wrap;
+    }
+
+    if (p.endsWith('populations/*/characteristics')) return renderCharacteristics(ctx, path);
+    if (p.endsWith('seeding/class')) return null;              // unused legacy option
+
+    // release_type: free text in the schema, but only two values are meaningful
+    if (p.endsWith('seeding/release_type'))
+      return SchemaForm.fieldRow(ctx, {...schema, enum: ['instantaneous', 'continuous']},
+                                 'release_type', path, false);
+
+    // seeding lives in its own tab — Settings shows a link instead (the Seeding
+    // tab renders the subtree directly, so this only affects the Settings form)
+    if (p.endsWith('populations/*/seeding')) {
+      const row = document.createElement('div');
+      row.className = 'sf-field';
+      row.dataset.pointer = path.join('/');
+      row.innerHTML = '<span class="sf-label dim">seeding</span>' +
+        '<span class="dim small grow">configured in the Seeding tab</span>';
+      const btn = document.createElement('button');
+      btn.className = 'mini';
+      btn.textContent = '↗ Seeding';
+      btn.title = 'open the Seeding tab';
+      btn.onclick = () => Tabs.activate('seeding');
+      row.appendChild(btn);
+      return row;
+    }
+
+    if (p === 'outputs/directory') {
+      const req = (SchemaForm.getSchemas().main.properties.outputs.required || [])
+                    .includes('directory');
+      return addBrowse(SchemaForm.fieldRow(ctx, mergedSchema(schema, root),
+                                           'directory', path, req), 'dir');
+    }
+
+    if (p.endsWith('populations/*/tracer_methods')) {
+      const ps = popSchema();
+      return SchemaForm.chooser(ctx, path, ['vanwesten', 'soulsby', 'passive_tracer'],
+        (active, bpath) => {
+          const body = document.createElement('div');
+          body.className = 'sf-branch';
+          const [sub, subRoot] = SchemaForm.resolve(
+            ps.properties.tracer_methods.properties[active], ps);
+          SchemaForm.renderObject(ctx, sub, subRoot, bpath, body);
+          return body;
+        },
+        o => FRESH_TRACER[o](), 'tracer method');
+    }
+
+    if (p.endsWith('seeding/strategy')) {
+      const ps = popSchema();
+      const stratSchema = ps.properties.seeding.properties.strategy;
+      return SchemaForm.chooser(ctx, path,
+        ['point', 'transect', 'random', 'grid', 'file_points'],
+        (active, bpath) => {
+          const body = document.createElement('div');
+          body.className = 'sf-branch';
+          SchemaForm.renderObject(ctx, stratSchema.properties[active], ps, bpath, body);
+          return body;
+        },
+        o => FRESH_STRATEGY[o](), 'seeding strategy');
+    }
+
+    if (p.endsWith('seeding/burial_depth')) {
+      const ps = popSchema();
+      const bdSchema = ps.properties.seeding.properties.burial_depth;
+      const BD_LBL = {constant: 'depth below bed [m]',
+                      random: 'max depth [m] (uniform 0–max)'};
+      const wrap = document.createElement('div');
+      wrap.dataset.pointer = path.join('/');
+      const head = document.createElement('div');
+      head.className = 'row small dim';
+      head.innerHTML = 'initial burial depth ' + SchemaForm.infoBtn({description:
+        'Burial depth of the particles at release, below the local bed level. ' +
+        '"constant" buries every particle at the same depth; "random" draws each ' +
+        'particle uniformly between 0 and the given maximum.'});
+      wrap.appendChild(head);
+      wrap.appendChild(SchemaForm.chooser(ctx, path, ['constant', 'random'],
+        (active, bpath) => {
+          const body = document.createElement('div');
+          body.className = 'sf-branch';
+          body.appendChild(SchemaForm.fieldRow(ctx, bdSchema.properties[active],
+                                               BD_LBL[active], bpath, false));
+          return body;
+        },
+        o => 0, ''));                       // the header above already labels it
+      return wrap;
+    }
+
+    if (p === 'outputs/netcdf/compression') {
+      const row = document.createElement('div');
+      row.className = 'sf-field';
+      row.dataset.pointer = path.join('/');
+      row.innerHTML = '<span class="sf-label dim">compression</span>';
+      const sel = document.createElement('select');
+      sel.className = 'sf-input';
+      for (const [v, txt] of [['', '(default: auto)'], ['auto', 'auto'],
+                              ['true', 'on'], ['false', 'off']]) {
+        const op = document.createElement('option');
+        op.value = v; op.textContent = txt;
+        sel.appendChild(op);
+      }
+      const cur = SchemaForm.get(cfg, path);
+      sel.value = cur === undefined ? '' : String(cur);
+      sel.onchange = () => {
+        const obj = SchemaForm.containerAt(cfg, path.slice(0, -1));
+        if (sel.value === '') delete obj.compression;
+        else obj.compression = sel.value === 'auto' ? 'auto' : sel.value === 'true';
+        ctx.onChange(path.join('/'));
+      };
+      row.appendChild(sel);
+      row.insertAdjacentHTML('beforeend', SchemaForm.infoBtn(schema));
+      return row;
+    }
+
+    return undefined;                                    // generic rendering
+  }
+
+  /* ── custom Inputs group (re-homed general options, forcing link, morpho) ── */
+  function addBrowse(row, kind) {
+    const btn = document.createElement('button');
+    btn.className = 'mini';
+    btn.textContent = '…';
+    btn.title = 'Browse';
+    btn.onclick = async () => {
+      try {
+        const r = await apiJson('/api/pickfile?kind=' + kind);
+        if (r.paths && r.paths[0]) {
+          const inp = row.querySelector('.sf-input');
+          inp.value = r.paths[0];
+          inp.dispatchEvent(new Event('change'));
+        }
+      } catch (e) { toast(String(e), true); }
+    };
+    row.appendChild(btn);
+    return row;
+  }
+
+  function mergedSchema(propSchema, root) {
+    const [sub] = SchemaForm.resolve(propSchema, root);
+    const m = {...sub, ...propSchema};
+    delete m.$ref;
+    return m;
+  }
+
+  function selectRow(labelTxt, options, value, onSet, info) {
+    const row = document.createElement('div');
+    row.className = 'sf-field';
+    row.innerHTML = `<span class="sf-label dim">${labelTxt}</span>`;
+    const sel = document.createElement('select');
+    sel.className = 'sf-input';
+    for (const [v, txt] of options) {
+      const o = document.createElement('option');
+      o.value = v;
+      o.textContent = txt;
+      sel.appendChild(o);
+    }
+    sel.value = value;
+    sel.onchange = () => onSet(sel.value);
+    row.appendChild(sel);
+    if (info) row.insertAdjacentHTML('beforeend',
+      `<button class="mini info" data-info="${info.replace(/"/g, '&quot;')}" tabindex="-1">ⓘ</button>`);
+    return row;
+  }
+
+  let morphoInclude = null;   // UI-only: 'yes' | 'no' (no dedicated yaml key exists)
+
+  function renderInputsGroup(ctx) {
+    const main = SchemaForm.getSchemas().main;
+    const P = main.properties;
+    const inputsP = P.inputs.properties;
+    const imSchema = SchemaForm.resolve(P.general.properties.input_model, main)[0];
+
+    const g = document.createElement('details');
+    g.className = 'sf-group';
+    g.dataset.pointer = 'inputs';
+    g.open = ctx.openState['inputs'] === true;   // collapsed by default
+    g.innerHTML = `<summary>inputs ${SchemaForm.infoBtn(P.inputs)}</summary>`;
+    const body = document.createElement('div');
+    body.className = 'sec';
+
+    // forcing file + browse + quick-link to the Viewer tab (forcing layers)
+    const frcRow = addBrowse(
+      SchemaForm.fieldRow(ctx, inputsP.data, 'forcing', ['inputs', 'data'], true), 'nc');
+    const view = document.createElement('button');
+    view.className = 'mini';
+    view.textContent = '↗ view';
+    view.title = 'open in the Viewer tab';
+    view.onclick = () => Tabs.activate('viewer');
+    frcRow.appendChild(view);
+    body.appendChild(frcRow);
+
+    // live options re-homed from the hidden "general" section
+    body.appendChild(SchemaForm.fieldRow(ctx, imSchema.properties.format,
+      'format', ['general', 'input_model', 'format'], false));
+    body.appendChild(SchemaForm.fieldRow(ctx, imSchema.properties.reference_date,
+      'reference date', ['general', 'input_model', 'reference_date'], false));
+    body.appendChild(SchemaForm.fieldRow(ctx, imSchema.properties.morfac,
+      'morfac', ['general', 'input_model', 'morfac'], false));
+    body.appendChild(SchemaForm.fieldRow(ctx,
+      mergedSchema(P.general.properties.numerical_scheme, main),
+      'numerical scheme', ['general', 'numerical_scheme'], false));
+
+    body.appendChild(SchemaForm.fieldRow(ctx, inputsP.read_interval,
+      'read interval', ['inputs', 'read_interval'], false));
+    body.appendChild(SchemaForm.fieldRow(ctx, inputsP.repeat_eulerian_fields,
+      'repeat eulerian fields', ['inputs', 'repeat_eulerian_fields'], false));
+
+    // morphodynamics: bed level source (bed_level_data override)
+    const hasSep = SchemaForm.get(cfg, ['inputs', 'bed_level_data']) !== undefined;
+    if (morphoInclude === null || hasSep) morphoInclude = 'yes';
+    body.appendChild(selectRow('include morphodynamics?',
+      [['yes', 'Yes (default)'], ['no', 'No']], morphoInclude,
+      v => {
+        morphoInclude = v;
+        if (v === 'no' && cfg.inputs) {
+          delete cfg.inputs.bed_level_data;
+          ctx.onChange('inputs/bed_level_data');
+        }
+        ctx.rerender();
+      },
+      'Whether the bed level evolves during the simulation. The bed comes from ' +
+      'the forcing file by default; a separate bed-level file can override it ' +
+      '(measured surveys, tiled morphodynamic predictions).'));
+    if (morphoInclude === 'yes') {
+      body.appendChild(selectRow('bed level source',
+        [['forcing', 'from forcing file (default)'], ['separate', 'from separate file [BETA]']],
+        hasSep ? 'separate' : 'forcing',
+        v => {
+          if (v === 'forcing') { if (cfg.inputs) delete cfg.inputs.bed_level_data; }
+          else SchemaForm.containerAt(cfg, ['inputs']).bed_level_data = '';
+          ctx.onChange('inputs/bed_level_data');
+          ctx.rerender();
+        },
+        inputsP.bed_level_data.description));
+      if (hasSep) {
+        body.appendChild(addBrowse(SchemaForm.fieldRow(ctx, inputsP.bed_level_data,
+          'bed level file', ['inputs', 'bed_level_data'], false), 'nc'));
+      }
+    }
+    // inputs.comp_dir is hidden: unused legacy option
+
+    g.appendChild(body);
+    return g;
+  }
+
+  /* ── populations UI ────────────────────────────────────────────────────── */
+  function renderPopulations(ctx, path) {
+    const wrap = document.createElement('div');
+    wrap.dataset.pointer = path.join('/');
+    const pops = SchemaForm.get(cfg, path) || [];
+    const ps = popSchema();
+
+    pops.forEach((pop, i) => {
+      const card = document.createElement('details');
+      card.className = 'sf-group sf-pop';
+      card.dataset.pointer = [...path, i].join('/');
+      card.open = ctx.openState[card.dataset.pointer] === true;
+      const name = pop && pop.name ? pop.name : `population ${i + 1}`;
+      const type = pop && pop.particle_type ? pop.particle_type : '?';
+      card.innerHTML =
+        `<summary><span class="swatch" style="background:${PALETTE[i % PALETTE.length]}"></span>` +
+        ` ${name} <span class="dim small">(${type})</span>` +
+        `<span class="poptools"><button class="mini" data-act="dup" title="duplicate">⧉</button>` +
+        `<button class="mini danger" data-act="del" title="remove">✕</button></span></summary>`;
+      card.querySelector('[data-act=dup]').onclick = e => {
+        e.preventDefault();
+        const copy = JSON.parse(JSON.stringify(pop));
+        copy.name = (copy.name || 'population') + '_copy';
+        pops.splice(i + 1, 0, copy);
+        ctx.onChange(path.join('/'));
+        ctx.rerender();
+      };
+      card.querySelector('[data-act=del]').onclick = e => {
+        e.preventDefault();
+        pops.splice(i, 1);
+        ctx.onChange(path.join('/'));
+        ctx.rerender();
+      };
+      const body = document.createElement('div');
+      body.className = 'sec';
+      SchemaForm.renderObject(ctx, ps, ps, [...path, i], body);
+      card.appendChild(body);
+      wrap.appendChild(card);
+    });
+
+    const addRow = document.createElement('div');
+    addRow.className = 'row';
+    const add = document.createElement('button');
+    add.textContent = '＋ Add population';
+    add.onclick = () => {
+      SchemaForm.containerAt(cfg, path.slice(0, -1));
+      if (!cfg.particles.populations) cfg.particles.populations = [];
+      cfg.particles.populations.push(newPopulation(cfg.particles.populations.length + 1));
+      ctx.onChange(path.join('/'));
+      ctx.rerender();
+    };
+    addRow.appendChild(add);
+    wrap.appendChild(addRow);
+    return wrap;
+  }
+
+  function renderCharacteristics(ctx, path) {
+    const wrap = document.createElement('div');
+    wrap.className = 'sf-chooser';
+    wrap.dataset.pointer = path.join('/');
+    const popPath = path.slice(0, -1);
+    const pop = SchemaForm.get(cfg, popPath) || {};
+    const type = pop.particle_type || 'passive';
+    const ps = popSchema();
+    const [sub] = SchemaForm.resolve({$ref: '#/$defs/' + CHAR_DEF[type]}, ps);
+    const head = document.createElement('div');
+    head.className = 'row small dim';
+    head.textContent = `characteristics (${type})`;
+    wrap.appendChild(head);
+    const body = document.createElement('div');
+    body.className = 'sf-branch';
+    SchemaForm.renderObject(ctx, sub, ps, path, body);
+    wrap.appendChild(body);
+    return wrap;
+  }
+
+  /* ── dirty / snapshot ──────────────────────────────────────────────────── */
+  function markClean() {
+    snapshot = JSON.stringify(cfg); updateChip();
+    // the Run tab renders its "⚠ unsaved changes" hint from isDirty() — clear it now
+    if (typeof RunTab !== 'undefined') RunTab.refreshSummary();
+  }
+  function isDirty() { return cfg !== null && JSON.stringify(cfg) !== snapshot; }
+  function updateChip() {
+    const chip = el('cfgchip');
+    if (chip) {
+      if (!cfg) chip.textContent = '';
+      else {
+        const base = cfgPath ? cfgPath.split(/[\\/]/).pop() : '(unsaved config)';
+        chip.textContent = base + (isDirty() ? ' ●' : '');
+        chip.title = cfgPath || '';
+      }
+    }
+    // topbar save icon mirrors the dirty state: grey when nothing to save
+    const sv = el('tb-save');
+    if (sv) {
+      const needsSave = !!cfg && (isDirty() || !cfgPath);
+      sv.disabled = !needsSave;
+      sv.title = !cfg ? 'no config loaded' : needsSave ? 'Save config' : 'Saved ✓';
+      sv.classList.toggle('attn', needsSave);     // small dot badge, not a blue button
+    }
+    const sa = el('tb-saveas');
+    if (sa) sa.disabled = !cfg;
+  }
+  window.addEventListener('beforeunload', e => {
+    if (isDirty()) { e.preventDefault(); e.returnValue = ''; }
+  });
+
+  /* ── prune empty containers before save/validate ───────────────────────── */
+  function pruned(o) {
+    if (Array.isArray(o)) return o.map(pruned);
+    if (o && typeof o === 'object') {
+      const out = {};
+      for (const [k, v] of Object.entries(o)) {
+        const pv = pruned(v);
+        const emptyObj = pv && typeof pv === 'object' && !Array.isArray(pv)
+                         && Object.keys(pv).length === 0;
+        if (pv !== undefined && !emptyObj) out[k] = pv;
+      }
+      return out;
+    }
+    return o;
+  }
+
+  /* ── validation display ────────────────────────────────────────────────── */
+  function showErrors(errors) {
+    document.querySelectorAll('.sf-err').forEach(x => x.classList.remove('sf-err'));
+    const box = el('set-errors');
+    if (!errors || !errors.length) {
+      box.innerHTML = cfg ? '<span class="ok">✓ configuration is valid</span>' : '';
+      return;
+    }
+    box.innerHTML = errors.map(e =>
+      `<div class="errline" data-goto="${e.pointer}">▸ <b>${e.pointer || '(root)'}</b>: ${e.message}</div>`).join('');
+    for (const e of errors) {
+      let ptr = e.pointer;
+      while (ptr) {
+        const hit = document.querySelector(`#settings-form [data-pointer="${ptr}"]`);
+        if (hit) { hit.classList.add('sf-err'); break; }
+        ptr = ptr.split('/').slice(0, -1).join('/');
+      }
+    }
+    box.querySelectorAll('.errline').forEach(d => d.onclick = () => {
+      let ptr = d.dataset.goto;
+      while (ptr) {
+        const hit = document.querySelector(`#settings-form [data-pointer="${ptr}"]`);
+        if (hit) {
+          let g = hit.closest('details');
+          while (g) { g.open = true; g = g.parentElement.closest('details'); }
+          hit.scrollIntoView({block: 'center'});
+          break;
+        }
+        ptr = ptr.split('/').slice(0, -1).join('/');
+      }
+    });
+  }
+
+  /* ── size estimate ─────────────────────────────────────────────────────── */
+  const refreshEstimate = debounce(async () => {
+    if (!cfg) return;
+    try {
+      const est = await apiJson('/api/config/estimate', {config: pruned(cfg)});
+      const box = el('set-estimate');
+      if (!est.particles || !est.slots) {
+        box.textContent = 'output size: unknown (set duration, save_interval and seeding)';
+        return;
+      }
+      const mb = est.bytes / 1024 / 1024;
+      const size = mb > 1024 ? (mb / 1024).toFixed(1) + ' GB' : mb.toFixed(1) + ' MB';
+      box.textContent =
+        `${est.particles_exact ? '' : '≈ '}${fmtInt(est.particles)} particles × ` +
+        `${fmtInt(est.slots)} output slots × ${est.bytes_per_particle_slot} B ` +
+        `= ${size} uncompressed` +
+        (est.compression ? ' (compression will be enabled)' : '');
+    } catch (e) { /* estimate is best-effort */ }
+  }, 400);
+
+  /* ── form rendering ────────────────────────────────────────────────────── */
+  function renderForm() {
+    formCtx = SchemaForm.render(el('settings-form'), cfg, {
+      onChange: () => { updateChip(); refreshEstimate(); },
+      override,
+    });
+    updateChip();
+    refreshEstimate();
+  }
+
+  /* ── file operations ───────────────────────────────────────────────────── */
+  async function openPath(p) {
+    const r = await apiJson('/api/config/load', {path: p});
+    cfg = r.config || {};
+    cfgPath = r.path;
+    roundtrip = r.roundtrip;
+    localStorage.setItem('stgui_last_config', cfgPath);
+    el('set-path').value = cfgPath;
+    if (roundtrip === 'pyyaml') {
+      toast('ruamel.yaml not installed — comments in this file will not be preserved on save', true);
+    }
+    markClean();
+    renderForm();
+    showErrors(null);
+    // the referenced forcing file loads (and shows) immediately; an existing
+    // result file of this config loads into the viewer as well
+    if (typeof ForcingTab !== 'undefined')
+      ForcingTab.autoOpenFromConfig().catch(() => {});
+    if (typeof autoImportResult === 'function') autoImportResult();
+    const v = await apiJson('/api/config/validate', {config: pruned(cfg)});
+    showErrors(v.errors);
+  }
+
+  async function save(saveAs) {
+    if (!cfg) return;
+    let p = cfgPath;
+    if (saveAs || !p) {
+      const sug = p ? p.split(/[\\/]/).pop() : 'sedtrails-config.yaml';
+      const r = await apiJson(`/api/picksave?ext=.yaml&name=${encodeURIComponent(sug)}`);
+      if (!r.path) return;
+      p = r.path;
+    }
+    try {
+      const r = await apiJson('/api/config/save', {path: p, config: pruned(cfg)});
+      cfgPath = r.path;
+      el('set-path').value = cfgPath;
+      localStorage.setItem('stgui_last_config', cfgPath);
+      markClean();
+      showErrors(r.validation.errors);
+      toast(r.validation.valid ? 'Saved ✓' : 'Saved — but the config has validation errors',
+            !r.validation.valid);
+    } catch (e) { toast('save failed: ' + e, true); }
+  }
+
+  /* ── wiring ────────────────────────────────────────────────────────────── */
+  // init runs from app.js (startup) AND from tab hooks — memoize the promise
+  // so concurrent callers share one run instead of double-loading the config
+  let initP = null;
+  function initOnce() {
+    return initP || (initP = init().catch(e => { initP = null; throw e; }));
+  }
+  async function init() {
+    if (schemasReady) return;
+    const s = await apiJson('/api/schema');
+    SchemaForm.setSchemas(s);
+    schemasReady = true;
+
+    el('set-open').onclick = async () => {
+      try {
+        const r = await apiJson('/api/pickfile?kind=yaml');
+        if (r.paths && r.paths[0]) await openPath(r.paths[0]);
+        else if (r.error) toast('native dialog unavailable: ' + r.error, true);
+      } catch (e) { toast(String(e), true); }
+    };
+    el('set-path').addEventListener('keydown', async e => {
+      if (e.key !== 'Enter') return;
+      const p = el('set-path').value.trim();
+      if (!p) return;
+      try { await openPath(p); } catch (err) { toast(String(err), true); }
+    });
+    el('tb-save').onclick = () => save(false);
+    el('tb-saveas').onclick = () => save(true);
+
+    async function newFromTemplate() {
+      const r = await apiJson('/api/config/template');
+      cfg = r.config;
+      cfgPath = null;
+      el('set-path').value = '';
+      markClean();
+      renderForm();
+      showErrors(null);
+    }
+
+    const last = localStorage.getItem('stgui_last_config');
+    if (last) {
+      try { await openPath(last); } catch (e) { /* file moved — fine */ }
+    }
+    if (!cfg) {
+      el('settings-form').innerHTML =
+        '<div class="placeholder">Open an existing SedTRAILS yaml (Open…, or type a path and ' +
+        'press Enter) — or <a href="#" id="set-template-link">start from a template</a>.<br>' +
+        'All options below come straight from the packaged JSON schemas — hover the ⓘ ' +
+        'symbols for documentation.</div>';
+      const link = el('set-template-link');
+      if (link) link.onclick = e => {
+        e.preventDefault();
+        newFromTemplate().catch(err => toast(String(err), true));
+      };
+    }
+    updateChip();
+  }
+
+  Tabs.register('settings', {enter() { initOnce().catch(e => toast(String(e), true)); }});
+  if (Tabs.current === 'settings') initOnce().catch(e => toast(String(e), true));
+
+  return {
+    getConfig: () => cfg,
+    getPath: () => cfgPath,
+    getPruned: () => cfg ? pruned(cfg) : null,
+    isDirty,
+    openPath,
+    override,                                   // reused by the Seeding tab
+    prune: pruned,
+    touch: () => { updateChip(); refreshEstimate(); },
+    newPopulation,                              // reused by the Populations tab
+    save: () => save(false),
+    schemasReady: () => schemasReady,
+    init: initOnce,
+  };
+})();

--- a/sedtrails-gui/web/js/tabs/viewer-export.js
+++ b/sedtrails-gui/web/js/tabs/viewer-export.js
@@ -1,0 +1,241 @@
+"use strict";
+/* ═════════════════════════ export (PNG / MP4) ═════════════════════════ */
+function expSize() {
+  const v = $('exp-res').value;
+  if (v === 'current') return [canvas.width, canvas.height];
+  const [w, h] = v.split('x').map(Number);
+  return [w, h];
+}
+
+async function tilesSettled(maxMs) {
+  const t0 = performance.now();
+  while (performance.now() - t0 < maxMs) {
+    drawScene();
+    if (tileFetches === 0) { drawScene(); return; }
+    await new Promise(r => setTimeout(r, 250));
+  }
+  drawScene();
+}
+
+function canvasBlob() {
+  return new Promise(res => canvas.toBlob(res, 'image/png'));
+}
+
+async function withExportCanvas(w, h, fn, vp) {
+  const save = {w: canvas.width, h: canvas.height, ppm: state.view.ppm,
+                cx: state.view.cx, cy: state.view.cy};
+  state.exporting = true;
+  try {
+    canvas.width = w; canvas.height = h;
+    if (vp && state.world0) {
+      // saved viewport: exact reproducible framing (absolute world coords)
+      state.view.cx = vp.cx - state.world0[0];
+      state.view.cy = vp.cy - state.world0[1];
+      state.view.ppm = w / vp.worldW;
+    } else {
+      state.view.ppm = save.ppm * (w / save.w);
+    }
+    await fn();
+  } finally {
+    canvas.width = save.w; canvas.height = save.h;
+    state.view.ppm = save.ppm;
+    state.view.cx = save.cx;
+    state.view.cy = save.cy;
+    state.exporting = false;
+    state.dirty = true;
+    drawScene();
+  }
+}
+
+/* ── saved export viewports: named, fixed framings for reproducible exports ── */
+const VP_KEY = 'stgui_viewports';
+function loadViewports() {
+  try { return JSON.parse(localStorage.getItem(VP_KEY)) || []; } catch (e) { return []; }
+}
+function saveViewports(v) { localStorage.setItem(VP_KEY, JSON.stringify(v)); }
+function selectedViewport() {
+  return loadViewports().find(v => v.name === $('exp-vp').value) || null;
+}
+function refreshVpSelect(selName) {
+  const sel = $('exp-vp');
+  sel.innerHTML = '<option value="">current map view</option>';
+  for (const vp of loadViewports()) {
+    const o = document.createElement('option');
+    o.value = vp.name;
+    o.textContent = '⌗ ' + vp.name;
+    sel.appendChild(o);
+  }
+  if (selName) sel.value = selName;
+  if (sel.value !== (selName || '')) sel.value = '';
+  $('exp-vp-del').style.display = sel.value ? '' : 'none';
+}
+$('exp-vp').onchange = () => { $('exp-vp-del').style.display = $('exp-vp').value ? '' : 'none'; };
+$('exp-vp-del').onclick = () => {
+  const n = $('exp-vp').value;
+  if (!n || !confirm(`Delete viewport "${n}"?`)) return;
+  saveViewports(loadViewports().filter(v => v.name !== n));
+  refreshVpSelect();
+};
+
+/* define a new viewport: hide the modal, show an aspect-locked frame over the
+   map (aspect = the chosen export resolution); pan/zoom underneath, confirm */
+$('exp-vp-new').onclick = () => {
+  if (!state.world0) { toast('Load a simulation or forcing file first', true); return; }
+  const [w, h] = expSize();
+  $('modal-export').style.display = 'none';
+  // hide every panel while framing — only the map and the frame remain
+  const hidden = [];
+  for (const id of ['sidebar', 'sideresize', 'sidebtn', 'floatpanels',
+                    'colorbars', 'coords', 'drawhint']) {
+    const e = $(id);
+    if (!e) continue;
+    hidden.push([e, e.style.display]);
+    e.style.display = 'none';
+  }
+  const ov = $('vpselect');
+  const rect = $('vpselect-rect');
+  ov.style.display = 'block';
+  const layout = () => {
+    const aspect = h / w;
+    const availW = window.innerWidth * 0.72;
+    const availH = (window.innerHeight - 40 - 58) * 0.78;
+    let rw = availW, rh = rw * aspect;
+    if (rh > availH) { rh = availH; rw = rh / aspect; }
+    rect.style.width = rw + 'px';
+    rect.style.height = rh + 'px';
+    rect.style.left = (window.innerWidth - rw) / 2 + 'px';
+    rect.style.top = 40 + ((window.innerHeight - 40 - 58) - rh) / 2 + 'px';
+  };
+  layout();
+  window.addEventListener('resize', layout);
+  const close = () => {
+    ov.style.display = 'none';
+    window.removeEventListener('resize', layout);
+    for (const [e, d] of hidden) e.style.display = d;
+    $('modal-export').style.display = 'flex';
+  };
+  $('vpselect-cancel').onclick = close;
+  $('vpselect-ok').onclick = () => {
+    const r = rect.getBoundingClientRect();
+    const c = screenToRd(r.left + r.width / 2, r.top + r.height / 2);
+    const a = screenToRd(r.left, r.top + r.height / 2);
+    const b = screenToRd(r.right, r.top + r.height / 2);
+    const name = (prompt('Name this viewport:',
+                         'viewport ' + (loadViewports().length + 1)) || '').trim();
+    if (!name) return;                       // keep framing mode open
+    const vps = loadViewports().filter(v => v.name !== name);
+    vps.push({name, cx: c[0], cy: c[1], worldW: Math.abs(b[0] - a[0])});
+    saveViewports(vps);
+    close();
+    refreshVpSelect(name);
+  };
+};
+
+async function doExport() {
+  if (!state.runs.length) { toast('Load a simulation first', true); return; }
+  const fmt = document.querySelector('input[name=expfmt]:checked').value;
+  const [w, h] = expSize();
+  const vp = selectedViewport();
+  // remember the export settings for next time (incl. the chosen viewport)
+  localStorage.setItem('stgui_export_last', JSON.stringify({
+    fmt, res: $('exp-res').value, fps: $('exp-fps').value,
+    dpf: $('exp-dpf').value, vp: $('exp-vp').value}));
+  const msg = $('exp-msg');
+  const prog = $('exp-prog');
+  const name = state.runs[0].meta.run_name.replace(/\W+/g, '_');
+  try {
+    if (fmt === 'png') {
+      const {path} = await apiJson('/api/picksave?ext=.png&name=' + encodeURIComponent(name + '.png'));
+      if (!path) return;
+      msg.textContent = 'rendering…';
+      await withExportCanvas(w, h, async () => {
+        await tilesSettled(6000);
+        const blob = await canvasBlob();
+        msg.textContent = 'saving…';
+        const r = await fetch('/api/savefile?path=' + encodeURIComponent(path),
+                              {method: 'POST', body: blob});
+        if (!r.ok) throw new Error((await r.json()).error || 'save failed');
+      }, vp);
+      msg.textContent = '✓ saved to ' + path;
+      toast('PNG saved: ' + path);
+    } else {
+      const fps = Math.max(1, parseInt($('exp-fps').value) || 12);
+      const dpf = Math.max(0.25, parseFloat($('exp-dpf').value) || 1);
+      const d0 = Date.parse($('exp-t0').value + 'T00:00:00Z') / 86400000;
+      const d1 = Date.parse($('exp-t1').value + 'T00:00:00Z') / 86400000;
+      if (!isFinite(d0) || !isFinite(d1) || d1 <= d0) throw new Error('invalid period');
+      const nFrames = Math.max(2, Math.floor((d1 - d0) / dpf) + 1);
+      const {path} = await apiJson('/api/picksave?ext=.mp4&name=' + encodeURIComponent(name + '.mp4'));
+      if (!path) return;
+      const {job} = await apiJson('/api/video/start', {path, fps});
+      prog.style.display = '';
+      const clockSave = state.clock.t;
+      const playingSave = state.clock.playing;
+      state.clock.playing = false;
+      await withExportCanvas(w, h, async () => {
+        await tilesSettled(6000);
+        for (let i = 0; i < nFrames; i++) {
+          state.clock.t = Math.min(d0 + i * dpf, state.clock.t1);
+          if (typeof ForcingTab !== 'undefined')      // forcing layer must not be stale
+            await ForcingTab.setTime(state.clock.t);
+          drawScene();
+          const blob = await canvasBlob();
+          const r = await fetch(`/api/video/frame?job=${job}&i=${i}`,
+                                {method: 'POST', body: blob});
+          if (!r.ok) throw new Error('frame upload failed');
+          prog.firstElementChild.style.width = Math.round((i + 1) / nFrames * 90) + '%';
+          msg.textContent = `frame ${i + 1}/${nFrames}`;
+        }
+      }, vp);
+      state.clock.t = clockSave;
+      state.clock.playing = playingSave;
+      msg.textContent = 'encoding mp4…';
+      await apiJson('/api/video/finish', {job});
+      prog.firstElementChild.style.width = '100%';
+      msg.textContent = '✓ saved to ' + path;
+      toast('MP4 saved: ' + path);
+    }
+  } catch (e) {
+    msg.textContent = '✗ ' + e.message;
+    toast('Export failed: ' + e.message, true);
+  }
+}
+
+function openExport() {
+  if (!state.runs.length) { toast('Load a simulation first', true); return; }
+  $('modal-export').style.display = 'flex';
+  $('exp-prog').style.display = 'none';
+  $('exp-msg').textContent = '';
+  $('exp-t0').value = fmtDate(state.clock.t0);
+  $('exp-t1').value = fmtDate(state.clock.t1);
+  // restore the last-used export settings (resolution, format, fps, viewport)
+  let last = {};
+  try { last = JSON.parse(localStorage.getItem('stgui_export_last')) || {}; } catch (e) {}
+  if (last.res) $('exp-res').value = last.res;
+  if (last.fmt) {
+    const r = document.querySelector(`input[name=expfmt][value="${last.fmt}"]`);
+    if (r) r.checked = true;
+    $('exp-mp4opts').style.display = last.fmt === 'mp4' ? '' : 'none';
+  }
+  if (last.fps) $('exp-fps').value = last.fps;
+  if (last.dpf) $('exp-dpf').value = last.dpf;
+  refreshVpSelect(last.vp || '');
+  refreshExpDuration();
+}
+function refreshExpDuration() {
+  const fps = Math.max(1, parseInt($('exp-fps').value) || 12);
+  const dpf = Math.max(0.25, parseFloat($('exp-dpf').value) || 1);
+  const d0 = Date.parse($('exp-t0').value + 'T00:00:00Z') / 86400000;
+  const d1 = Date.parse($('exp-t1').value + 'T00:00:00Z') / 86400000;
+  const n = isFinite(d0) && isFinite(d1) && d1 > d0 ? Math.floor((d1 - d0) / dpf) + 1 : 0;
+  $('exp-duration').textContent = n ? `${n} frames → ${(n / fps).toFixed(1)} s of video` : '';
+}
+document.querySelectorAll('input[name=expfmt]').forEach(r => r.onchange = () => {
+  $('exp-mp4opts').style.display =
+    document.querySelector('input[name=expfmt]:checked').value === 'mp4' ? '' : 'none';
+});
+for (const id of ['exp-fps', 'exp-dpf', 'exp-t0', 'exp-t1'])
+  $(id).oninput = refreshExpDuration;
+$('btn-export').onclick = openExport;
+$('btn-do-export').onclick = doExport;
+

--- a/sedtrails-gui/web/js/tabs/viewer-ui.js
+++ b/sedtrails-gui/web/js/tabs/viewer-ui.js
@@ -1,0 +1,601 @@
+"use strict";
+/* ═════════════════════════ UI: simulations ═════════════════════════ */
+function fmtStamp(epochSec) {                    // 'YYYY-MM-DD HH:MM' local time
+  const d = new Date(epochSec * 1000);
+  const p = n => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ` +
+         `${p(d.getHours())}:${p(d.getMinutes())}`;
+}
+
+function refreshSimList() {
+  const el = $('simlist');
+  el.innerHTML = '';
+  for (const run of state.runs) {
+    const card = document.createElement('div');
+    card.className = 'simcard';
+    const pct = Math.round(run.loaded / run.T * 100);
+    const sig = run.meta.source_signature || [];
+    const cached = sig[1] ? `<br>cached copy of the results file of ${fmtStamp(sig[1])}` : '';
+    card.innerHTML = `
+      <div class="name">
+        <input type="checkbox" ${run.visible ? 'checked' : ''} title="show/hide">
+        <span class="tintslot"></span>
+        <span class="grow" style="overflow:hidden;text-overflow:ellipsis">${run.meta.run_name}</span>
+        <button class="mini danger" title="remove">✕</button>
+      </div>
+      <div class="meta">${fmtInt(run.N)} particles${run.stride > 1 ? ` (1/${run.stride})` : ''} · ${run.T} steps${run.meta.has_burial ? ' · burial' : ''}${cached}</div>
+      <div class="loadbar"><div style="width:${pct}%"></div></div>`;
+    card.querySelector('input').onchange = ev => {
+      run.visible = ev.target.checked; updateCounts(); state.dirty = true;
+    };
+    card.querySelector('.tintslot').appendChild(
+      mkColorBtn(() => run.tint, c => { run.tint = c; state.dirty = true; }, 'simulation color'));
+    card.querySelector('button.danger').onclick = () => removeRun(run);
+    el.appendChild(card);
+  }
+  if (typeof LayersPanel !== 'undefined') LayersPanel.refresh();
+}
+
+function removeRun(run) {
+  state.runs = state.runs.filter(r => r !== run);
+  run.frames = null; run.burFrames = null;
+  if (state.mesh && state.mesh.runId === run.id) {
+    state.mesh = null;
+    refreshModelLayers();
+    for (const r of state.runs) loadMesh(r);
+  }
+  updateClockRange(); updateTimelineUI();
+  refreshSimList(); refreshRules(); updateCounts();
+  state.dirty = true;
+}
+
+/* ═════════════════════════ UI: polygons (pills) ═════════════════════════ */
+function refreshPolyList() {
+  const el = $('polylist');
+  el.innerHTML = '';
+  const wrap = document.createElement('div');
+  wrap.className = 'pillwrap';
+  for (const p of state.polygons) {
+    const pill = document.createElement('span');
+    pill.className = 'pill';
+    const isSel = state.editSel && state.editSel.name === p.name;
+    if (isSel) pill.classList.add('selected');
+    pill.title = isSel ? 'editing — drag vertices on the map; click to stop'
+                       : 'click to highlight & edit';
+    const dot = document.createElement('span');
+    dot.className = 'dot';
+    dot.style.background = p.color || '#888';
+    dot.title = 'change polygon color';
+    dot.onclick = ev => {
+      ev.stopPropagation();
+      const pop = $('swatchpop');
+      pop.style.display = 'block';
+      const r = dot.getBoundingClientRect();
+      pop.style.left = Math.min(r.left, window.innerWidth - 190) + 'px';
+      pop.style.top = Math.min(r.bottom + 4, window.innerHeight - 140) + 'px';
+      swatchCb = c => {
+        p.color = c; dot.style.background = c;
+        savePolygons(); rebuildPaletteTex(); state.dirty = true;
+      };
+    };
+    const name = document.createElement('b');
+    name.textContent = p.name;
+    const del = document.createElement('button');
+    del.textContent = '✕'; del.title = 'delete polygon';
+    del.onclick = ev => {
+      ev.stopPropagation();
+      state.polygons = state.polygons.filter(x => x !== p);
+      if (state.editSel && state.editSel.name === p.name) state.editSel = null;
+      onPolygonsChanged();
+    };
+    pill.append(dot, name, del);
+    pill.onclick = () => {
+      state.editSel = isSel ? null : {name: p.name};
+      state.tool = state.editSel ? 'edit' : 'pan';
+      refreshPolyList(); state.dirty = true;
+    };
+    wrap.appendChild(pill);
+  }
+  el.appendChild(wrap);
+  if (!state.polygons.length)
+    el.innerHTML = '<div class="dim small" style="margin:4px 0">No polygons yet — import .txt polygons or draw one on the map.</div>';
+}
+
+function onPolygonsChanged() {
+  ensurePolyColors();
+  savePolygons(); refreshPolyList(); refreshRules(); requestClassifyAll(); state.dirty = true;
+  if (typeof LayersPanel !== 'undefined') LayersPanel.refresh();
+  // the Populations tab lists objects in its seed-from dropdowns — keep current
+  if (typeof SeedingTab !== 'undefined') SeedingTab.renderPanel();
+}
+const savePolygons = debounce(() => {
+  api('/api/polygons', {polygons: state.polygons}).catch(e => toast('Saving polygons failed: ' + e.message, true));
+}, 800);
+
+/* ═════════════════════════ UI: rules ═════════════════════════ */
+function mkSelect(options, value, onchange) {
+  const s = document.createElement('select');
+  for (const [val, label] of options) {
+    const o = document.createElement('option');
+    o.value = val; o.textContent = label;
+    if (val === value) o.selected = true;
+    s.appendChild(o);
+  }
+  s.onchange = () => onchange(s.value);
+  return s;
+}
+function simOptions() {
+  return [['*', state.runs.length > 1 ? 'in all simulations' : 'Particles']]
+    .concat(state.runs.map(r => [r.id, 'in ' + r.meta.run_name]));
+}
+function polyOptions() {
+  return allPolys().map(p => [p.key, p.name])
+    .concat([['*any*', 'any polygon'], ['*none*', 'no polygon']]);
+}
+
+function condWidgets(div, rule, which, refresh) {
+  const cKey = which === 1 ? 'cond' : 'cond2';
+  const pKey = which === 1 ? 'poly' : 'poly2';
+  const tKey = which === 1 ? 'thresh' : 'thresh2';
+  div.appendChild(mkSelect(which === 1 ? CONDS : CONDS2, rule[cKey],
+    v => { rule[cKey] = v; refresh(); onRulesChanged(); }));
+  if (['start', 'end', 'ever'].includes(rule[cKey])) {
+    div.appendChild(mkSelect(polyOptions(), rule[pKey],
+      v => {
+        rule[pKey] = v;
+        // convenience: a plain color rule follows the selected polygon's color
+        if (which === 1 && rule.action === 'color' && !rule.colorTouched
+            && !['*any*', '*none*'].includes(v))
+          rule.color = polyColorOf(v);
+        refresh(); onRulesChanged();
+      }));
+  } else if (['bur_ge', 'bur_lt'].includes(rule[cKey])) {
+    const inp = document.createElement('input');
+    inp.type = 'number'; inp.step = '0.01'; inp.min = '0'; inp.value = rule[tKey];
+    inp.oninput = () => { rule[tKey] = parseFloat(inp.value) || 0; onRulesChanged(); };
+    div.appendChild(inp);
+  }
+}
+
+function refreshRules() {
+  const el = $('rulelist');
+  el.innerHTML = '';
+  const word = t => { const s = document.createElement('span'); s.className = 'word'; s.textContent = t; return s; };
+
+  state.rules.forEach((rule, idx) => {
+    const div = document.createElement('div');
+    div.className = 'rule';
+    if (state.runs.length > 1 || rule.sim !== '*') {
+      div.appendChild(word('Particles'));
+      div.appendChild(mkSelect(simOptions(), rule.sim, v => { rule.sim = v; onRulesChanged(); }));
+      div.appendChild(word('that'));
+    } else div.appendChild(word('Particles that'));
+
+    condWidgets(div, rule, 1, refreshRules);
+
+    if (rule.cond2) {
+      div.appendChild(word('and'));
+      condWidgets(div, rule, 2, refreshRules);
+      const rm = document.createElement('button');
+      rm.className = 'mini'; rm.textContent = '✕and'; rm.title = 'remove second condition';
+      rm.onclick = () => { rule.cond2 = null; refreshRules(); onRulesChanged(); };
+      div.appendChild(rm);
+    } else {
+      const add = document.createElement('button');
+      add.className = 'mini'; add.textContent = '＋and';
+      add.title = 'add a second condition (e.g. start in A AND end in B)';
+      add.onclick = () => {
+        const polys = allPolys();
+        rule.cond2 = 'end';
+        rule.poly2 = polys.length ? polys[0].key : '*any*';
+        rule.thresh2 = 0.05;
+        refreshRules(); onRulesChanged();
+      };
+      div.appendChild(add);
+    }
+
+    div.appendChild(word('are'));
+    div.appendChild(mkSelect(ACTIONS, rule.action, v => { rule.action = v; refreshRules(); onRulesChanged(); }));
+    if (rule.action === 'color') {
+      div.appendChild(mkColorBtn(() => rule.color,
+        c => { rule.color = c; rule.colorTouched = true; onRulesChanged(); }));
+    } else if (rule.action === 'colorby') {
+      div.appendChild(mkSelect(COLORBYS, rule.colorby, v => { rule.colorby = v; onRulesChanged(); }));
+    }
+
+    const tools = document.createElement('span');
+    tools.className = 'tools';
+    const up = document.createElement('button'); up.className = 'mini'; up.textContent = '↑'; up.title = 'evaluate earlier';
+    up.disabled = idx === 0;
+    up.onclick = () => { state.rules.splice(idx-1, 0, state.rules.splice(idx, 1)[0]); refreshRules(); onRulesChanged(); };
+    const del = document.createElement('button'); del.className = 'mini danger'; del.textContent = '✕';
+    del.onclick = () => { state.rules.splice(idx, 1); refreshRules(); onRulesChanged(); };
+    tools.appendChild(up); tools.appendChild(del);
+    div.appendChild(tools);
+    el.appendChild(div);
+  });
+
+  const div = document.createElement('div');
+  div.className = 'rule default';
+  div.appendChild(word(state.rules.length ? 'All other particles are' : 'All particles are'));
+  div.appendChild(mkSelect(DEFAULT_APPS, state.defaultApp.action, v => {
+    state.defaultApp.action = v; state.defaultAutoSet = true; refreshRules(); onRulesChanged();
+  }));
+  if (state.defaultApp.action === 'color') {
+    div.appendChild(mkColorBtn(() => state.defaultApp.color,
+      c => { state.defaultApp.color = c; onRulesChanged(); }));
+  } else if (state.defaultApp.action === 'colorby') {
+    div.appendChild(mkSelect(COLORBYS, state.defaultApp.colorby, v => { state.defaultApp.colorby = v; onRulesChanged(); }));
+  }
+  el.appendChild(div);
+
+  const keys = new Set(allPolys().map(p => p.key));
+  const refsMissing = r => ['start','end','ever'].includes(r.cond) && !['*any*','*none*'].includes(r.poly) && !keys.has(r.poly)
+    || (r.cond2 && ['start','end','ever'].includes(r.cond2) && !['*any*','*none*'].includes(r.poly2) && !keys.has(r.poly2));
+  if (state.rules.some(refsMissing)) {
+    const w = document.createElement('div');
+    w.className = 'dim small';
+    w.textContent = '⚠ some rules reference deleted polygons and are ignored';
+    el.appendChild(w);
+  }
+  refreshScaleRows();
+}
+
+$('btn-add-rule').onclick = () => {
+  const polys = allPolys();
+  const firstKey = polys.length ? polys[0].key : '*any*';
+  state.rules.push({sim: '*', cond: 'start', poly: firstKey,
+                    thresh: 0.05, cond2: null, poly2: '*any*', thresh2: 0.05,
+                    action: 'color',
+                    color: polys.length ? polyColorOf(firstKey) : '#d14b4b',
+                    colorby: 'burial'});
+  refreshRules(); onRulesChanged();
+};
+
+/* ═════════════════════════ UI: modals ═════════════════════════ */
+document.querySelectorAll('[data-close]').forEach(b => {
+  b.onclick = () => { $(b.dataset.close).style.display = 'none'; };
+});
+
+let browseTarget = null;
+document.querySelectorAll('[data-browse]').forEach(b => {
+  b.onclick = async () => {
+    const r = await pickNative(b.dataset.browse, 'nc');
+    if (r === null) openBrowser(b.dataset.browse, b.dataset.ext, false);
+  };
+});
+
+async function pickNative(targetInput, kind) {
+  let res;
+  try {
+    const dir = localStorage.getItem('lastDir') || '';
+    res = await apiJson('/api/pickfile?kind=' + kind + '&dir=' + encodeURIComponent(dir));
+    if (res.paths === null) throw new Error(res.error || 'picker unavailable');
+  } catch (e) {
+    return null;
+  }
+  if (!res.paths.length) return [];
+  const p = res.paths[0];
+  localStorage.setItem('lastDir', p.replace(/[\\\/][^\\\/]*$/, ''));
+  if (targetInput) {
+    $(targetInput).value = p;
+    if (targetInput === 'inp-nc') autofillName();
+  }
+  return res.paths;
+}
+
+async function openBrowser(targetInput, ext, dirMode, title) {
+  browseTarget = {input: targetInput, ext, dirMode};
+  $('browse-title').textContent = title || (dirMode ? 'Select folder' : `Select ${ext} file`);
+  $('browse-usedir').style.display = dirMode ? '' : 'none';
+  $('modal-browse').style.display = 'flex';
+  const start = $(targetInput) && $(targetInput).value ?
+    $(targetInput).value.replace(/[\\\/][^\\\/]*$/, '') : (localStorage.getItem('lastDir') || '');
+  await browseTo(start);
+}
+
+async function browseTo(dir) {
+  try {
+    const res = await apiJson('/api/browse?dir=' + encodeURIComponent(dir || ''));
+    $('browse-path').value = res.dir;
+    if (res.dir) localStorage.setItem('lastDir', res.dir);
+    const list = $('browse-list');
+    list.innerHTML = '';
+    if (res.parent !== null && res.dir) {
+      const up = document.createElement('div');
+      up.className = 'fe'; up.innerHTML = '📁 ..';
+      up.onclick = () => browseTo(res.parent);
+      list.appendChild(up);
+    }
+    for (const d of res.dirs) {
+      const el = document.createElement('div');
+      el.className = 'fe'; el.innerHTML = `📁 ${d.name}`;
+      el.onclick = () => browseTo(d.path);
+      list.appendChild(el);
+    }
+    for (const f of res.files) {
+      if (browseTarget.ext && !f.name.toLowerCase().endsWith(browseTarget.ext)) continue;
+      const el = document.createElement('div');
+      el.className = 'fe';
+      el.innerHTML = `📄 ${f.name}<span class="sz">${(f.size / 1e6).toFixed(1)} MB</span>`;
+      el.onclick = () => {
+        if (browseTarget.input) $(browseTarget.input).value = f.path;
+        if (browseTarget.onPick) browseTarget.onPick(f.path);
+        $('modal-browse').style.display = 'none';
+        if (browseTarget.input === 'inp-nc') autofillName();
+      };
+      list.appendChild(el);
+    }
+    $('browse-hint').textContent = res.dir || 'Select a drive or folder';
+  } catch (e) { toast('Browse failed: ' + e.message, true); }
+}
+$('browse-go').onclick = () => browseTo($('browse-path').value);
+$('browse-path').onkeydown = e => { if (e.key === 'Enter') browseTo($('browse-path').value); };
+$('browse-usedir').onclick = () => {
+  const dir = $('browse-path').value;
+  if (browseTarget.onPick) browseTarget.onPick(dir);
+  $('modal-browse').style.display = 'none';
+};
+
+function autofillName() {
+  const p = $('inp-nc').value;
+  if (!$('inp-name').value && p) {
+    const parts = p.replace(/\\/g, '/').split('/');
+    const stem = parts[parts.length - 1].replace(/\.nc$/i, '');
+    $('inp-name').value = stem === 'sedtrails_results' ? (parts[parts.length - 2] || stem) : stem;
+  }
+}
+
+async function openAddSim() {
+  $('modal-open').style.display = 'flex';
+  $('import-prog').style.display = 'none';
+  $('import-msg').textContent = '';
+  try {
+    const reg = await apiJson('/api/registry');
+    const sel = $('sel-recent');
+    sel.innerHTML = '<option value="">— pick a recent simulation to reopen —</option>';
+    reg.simulations.forEach((s, i) => {
+      const o = document.createElement('option');
+      o.value = i;
+      o.textContent = `${s.name}  ·  ${fmtInt(s.n_particles)} × ${s.n_timesteps}`;
+      sel.appendChild(o);
+    });
+    sel.onchange = () => {
+      const s = reg.simulations[sel.value];
+      if (!s) return;
+      sel.value = '';
+      $('inp-nc').value = s.nc_path;
+      $('inp-forcing').value = s.forcing_path || '';
+      $('inp-name').value = s.name;
+      doImport();
+    };
+  } catch (e) {}
+}
+/* ＋ Add simulation = pick a results netCDF, import with sensible defaults
+   (name from the file, forcing from the open forcing file). The old
+   "Open simulation" modal stays in the DOM only as a fallback when the
+   native file dialog is unavailable. */
+$('btn-add-sim').onclick = async () => {
+  const picked = await pickNative(null, 'nc');
+  if (picked === null) { openAddSim(); return; }
+  if (picked.length) importPath(picked[0]).catch(() => {});
+};
+$('btn-import').onclick = () => doImport();
+
+function resultDisplayName(ncPath) {
+  const parts = ncPath.replace(/\\/g, '/').split('/');
+  const stem = parts[parts.length - 1].replace(/\.nc$/i, '');
+  return stem === 'sedtrails_results' ? (parts[parts.length - 2] || stem) : stem;
+}
+
+/* import a results netCDF without the modal; progress shows under the sim list */
+async function importPath(ncPath, name, opts) {
+  const dispName = name || resultDisplayName(ncPath);
+  const frc = (typeof ForcingTab !== 'undefined' && ForcingTab.state.meta)
+    ? ForcingTab.state.meta.path : null;
+  const st = $('sim-import-status');
+  st.style.display = ''; st.textContent = `importing ${dispName}…`;
+  try {
+    const {job_id} = await apiJson('/api/import',
+      {nc_path: ncPath, forcing_path: frc, name: dispName});
+    for (;;) {
+      await new Promise(r => setTimeout(r, 500));
+      const j = await apiJson('/api/job/' + job_id);
+      if (j.status === 'error') throw new Error(j.message);
+      if (j.status === 'unknown') throw new Error('server restarted during import — retry');
+      st.textContent = `importing ${dispName}… ${Math.round((j.progress || 0) * 100)}%`;
+      if (j.status === 'done') { await loadRun(j.bundle, 1, dispName); break; }
+    }
+    st.style.display = 'none';
+  } catch (e) {
+    st.style.display = 'none';
+    if (!(opts && opts.silent)) toast('Import failed: ' + e.message, true);
+    throw e;
+  }
+}
+
+/* auto-load the loaded config's result file (outputs/directory/
+   sedtrails_results.nc) into the viewer — silent no-op when there is none.
+   Re-imports when the file on disk changed (rerun / external update). */
+let autoImportBusy = false;
+async function autoImportResult() {
+  if (autoImportBusy) return;
+  autoImportBusy = true;
+  try {
+    const cfgPath = typeof SettingsTab !== 'undefined' ? SettingsTab.getPath() : null;
+    if (!cfgPath) return;
+    const r = await apiJson('/api/config/result', {config_path: cfgPath});
+    if (!r.exists) return;
+    const run = await apiJson('/api/run/status');
+    if (run.state === 'running') return;           // being written right now
+    // same naming as the after-run auto-import (run.js) so reruns dedupe
+    const dispName = cfgPath.replace(/\\/g, '/').split('/').pop()
+      .replace(/\.ya?ml$/i, '') || 'run';
+    const cur = state.runs.find(x => x.meta.run_name === dispName);
+    if (cur) {
+      const sig = cur.meta.source_signature || [];
+      if (sig[0] === r.size && sig[1] === r.mtime) return;   // already up to date
+      removeRun(cur);                        // results file changed → reload it
+    }
+    await importPath(r.path, dispName, {silent: true});
+  } catch (e) { /* best-effort */ }
+  finally { autoImportBusy = false; }
+}
+
+const SERVER_LOST =
+  'lost the connection to the local server — the python process probably crashed or was ' +
+  'stopped. Check the terminal running sedtrails_viewer.py for the error, restart it, and ' +
+  'retry: already-imported data is cached, so the retry continues where it left off.';
+
+async function doImport() {
+  const nc = $('inp-nc').value.trim();
+  if (!nc) { toast('Choose a results netCDF first', true); return; }
+  const stride = parseInt($('inp-stride').value);
+  const prog = $('import-prog');
+  prog.style.display = ''; prog.firstElementChild.style.width = '2%';
+  $('import-msg').textContent = 'starting…';
+  try {
+    let job_id;
+    try {
+      ({job_id} = await apiJson('/api/import', {
+        nc_path: nc, forcing_path: $('inp-forcing').value.trim() || null,
+        name: $('inp-name').value.trim() || null}));
+    } catch (e) {
+      throw new Error(e.message === 'Failed to fetch' ? SERVER_LOST : e.message);
+    }
+    let netFails = 0;
+    while (true) {
+      await new Promise(r => setTimeout(r, 500));
+      let j;
+      try {
+        j = await apiJson('/api/job/' + job_id);
+        netFails = 0;
+      } catch (e) {
+        if (++netFails >= 6) throw new Error(SERVER_LOST);
+        continue;
+      }
+      if (j.status === 'unknown')
+        throw new Error('the server was restarted during the import — retry '
+          + '(already-imported data is cached and will be reused).');
+      prog.firstElementChild.style.width = Math.round((j.progress || 0) * 100) + '%';
+      $('import-msg').textContent = j.message || '';
+      if (j.status === 'done') {
+        $('inp-nc').value = ''; $('inp-forcing').value = '';
+        $('inp-name').value = '';
+        await loadRun(j.bundle, stride);
+        break;
+      }
+      if (j.status === 'error') throw new Error(j.message);
+    }
+  } catch (e) {
+    $('import-msg').textContent = '✗ ' + e.message;
+    toast('Import failed: ' + e.message, true);
+  }
+}
+
+/* polygon import + draw dialogs */
+async function importPolygonPaths(paths) {
+  let total = 0;
+  for (const path of paths) {
+    try {
+      const res = await apiJson('/api/polygons/import', {path});
+      for (const p of res.polygons) {
+        p.type = p.type || 'polygon';
+        if (!state.polygons.some(x => x.name === p.name)) state.polygons.push(p);
+        total++;
+      }
+    } catch (e) { toast('Polygon import failed: ' + e.message, true); return; }
+  }
+  if (!total) { toast('No polygons found there', true); return; }
+  toast(`Imported ${total} polygon(s)`);
+  onPolygonsChanged();
+}
+
+$('btn-poly-import').onclick = async () => {
+  const picked = await pickNative(null, 'txt');
+  if (picked !== null) {
+    if (picked.length) importPolygonPaths(picked);
+    return;
+  }
+  browseTarget = {ext: '.txt', dirMode: true, onPick: path => importPolygonPaths([path])};
+  $('browse-title').textContent = 'Select polygon folder or .txt file';
+  $('browse-usedir').style.display = '';
+  $('modal-browse').style.display = 'flex';
+  browseTo(localStorage.getItem('lastDir') || '');
+};
+
+/* one draw flow for every object type — armed from the Objects panel and
+   usable on any map tab (clicks are handled in interact.js) */
+const DRAW_HINTS = {
+  polygon: 'Click to add vertices · Enter/double-click to finish · Esc to cancel',
+  point: 'Click one or more points · Enter/double-click to finish · Esc to cancel',
+  transect: 'Click start and end of the transect · Esc to cancel',
+  bbox: 'Click two opposite corners of the box · Esc to cancel',
+};
+const OBJ_LABEL = {polygon: 'polygon', point: 'point set', transect: 'transect', bbox: 'box'};
+const EDIT_HINT = 'Drag a point to move · click an edge to insert · right-click a point to ' +
+  'delete · Alt-click adds (point sets)';
+
+function startDrawObject(mode) {
+  if (!state.world0) { toast('Open a forcing file or simulation first', true); return; }
+  if (state.tool === 'draw' && state.drawMode === mode) {   // toggle the tool off
+    state.draft = []; state.tool = 'pan';
+  } else {
+    state.tool = 'draw'; state.drawMode = mode;
+    state.draft = []; state.editSel = null;
+  }
+  refreshToolButtons(); state.dirty = true;
+  if (typeof ObjectsPanel !== 'undefined') ObjectsPanel.refresh();
+}
+$('btn-poly-draw').onclick = () => startDrawObject('polygon');   // legacy entry point
+
+function refreshToolButtons() {
+  $('btn-poly-draw').classList.toggle('active', state.tool === 'draw');
+  canvas.classList.toggle('drawing', state.tool === 'draw');
+  if (state.tool !== 'edit') canvas.classList.remove('vtx');
+  const editing = state.tool === 'edit' && state.editSel;
+  $('drawhint-text').textContent = editing ? EDIT_HINT : DRAW_HINTS[state.drawMode || 'polygon'];
+  $('btn-edit-done').style.display = editing ? '' : 'none';
+  $('drawhint').style.display = state.tool === 'draw' || editing ? 'flex' : 'none';
+}
+
+/* the green ✓ Done button in the hint bar closes edit mode (same as Esc) */
+$('btn-edit-done').onclick = () => {
+  state.editSel = null;
+  state.tool = 'pan';
+  refreshToolButtons();
+  state.dirty = true;
+  if (typeof ObjectsPanel !== 'undefined') ObjectsPanel.refresh();
+};
+
+function finishDraft() {
+  const mode = state.drawMode || 'polygon';
+  const need = {polygon: 3, point: 1, transect: 2, bbox: 2}[mode];
+  if (state.draft.length < need) {
+    state.draft = []; state.tool = 'pan'; refreshToolButtons(); state.dirty = true;
+    if (typeof ObjectsPanel !== 'undefined') ObjectsPanel.refresh();
+    return;
+  }
+  $('modal-poly-title').textContent = 'New ' + OBJ_LABEL[mode];
+  $('poly-name').value = '';
+  $('modal-poly').style.display = 'flex';
+  $('poly-name').focus();
+}
+$('poly-save').onclick = () => {
+  const mode = state.drawMode || 'polygon';
+  let name = $('poly-name').value.trim() || OBJ_LABEL[mode] + ' ' + (Date.now() % 10000);
+  while (state.polygons.some(p => p.name === name)) name += '*';
+  let verts = state.draft.map(v => [Math.round(v[0] * 100) / 100, Math.round(v[1] * 100) / 100]);
+  if (mode === 'bbox') {                       // store the full axis-aligned outline
+    const xs = verts.map(v => v[0]), ys = verts.map(v => v[1]);
+    verts = [[Math.min(...xs), Math.min(...ys)], [Math.max(...xs), Math.min(...ys)],
+             [Math.max(...xs), Math.max(...ys)], [Math.min(...xs), Math.max(...ys)]];
+  }
+  state.polygons.push({name, type: mode, verts});
+  state.draft = [];
+  state.tool = 'pan';
+  $('modal-poly').style.display = 'none';
+  refreshToolButtons();
+  onPolygonsChanged();
+};
+

--- a/sedtrails-gui/web/js/tabs/viewer-wiring.js
+++ b/sedtrails-gui/web/js/tabs/viewer-wiring.js
@@ -1,0 +1,202 @@
+"use strict";
+/* ═════════════════════════ playback UI ═════════════════════════ */
+function togglePlay() {
+  if (!clockHasSources()) return;
+  const c = state.clock;
+  if (!c.playing && c.t >= c.t1 - 1e-9) c.t = c.t0;
+  c.playing = !c.playing;
+  refreshPlayBtn();
+  state.dirty = true;
+}
+function refreshPlayBtn() { $('btn-play').textContent = state.clock.playing ? '⏸' : '▶'; }
+function stepDays(d) {
+  const c = state.clock;
+  c.playing = false; refreshPlayBtn();
+  c.t = Math.min(Math.max(c.t + d, c.t0), Math.min(c.t1, loadedFrontier()));
+  updateTimelineUI(); state.dirty = true;
+}
+function updateTimelineUI() {
+  const c = state.clock;
+  const span = Math.max(c.t1 - c.t0, 1e-9);
+  $('timeline').value = Math.round((c.t - c.t0) / span * 1000);
+  // track: solid accent up to the playhead, muted accent to the loaded
+  // frontier (data still streaming in), plain track beyond
+  const pos = Math.max(0, Math.min(100, (c.t - c.t0) / span * 100));
+  const front = Math.max(pos, (loadedFrontier() - c.t0) / span * 100);
+  const loadedCol = 'color-mix(in srgb, var(--accent) 30%, var(--border))';
+  $('timeline').style.setProperty('--tl-bg',
+    `linear-gradient(90deg, var(--accent) 0%, var(--accent) ${pos}%, ` +
+    `${loadedCol} ${pos}%, ${loadedCol} ${front}%, var(--border) ${front}%)`);
+  updateCoverageBands(span);
+  const day = Math.floor(c.t - c.t0) + 1;
+  const total = Math.ceil(span);
+  const hm = new Date(c.t * 86400000).toISOString().slice(11, 16);
+  $('datelabel').textContent = `${fmtDate(c.t)} ${hm} · day ${day}/${total}`;
+}
+
+/* labeled bands above the slider: which part of the clock range each time
+   source covers (forcing may repeat — shown as a faint full-width band around
+   the solid native span). Hover a band for the exact date range. */
+function updateCoverageBands(span) {
+  const c = state.clock;
+  const pct = t => Math.max(0, Math.min(100, (t - c.t0) / span * 100));
+  const band = (el, a, b, color, repeats, title) => {
+    const has = a != null;
+    el.classList.toggle('on', has);
+    if (!has) { el.style.background = 'transparent'; el.title = ''; return; }
+    const faint = repeats ? `color-mix(in srgb, ${color} 25%, transparent)`
+                          : 'transparent';
+    const solid = `color-mix(in srgb, ${color} 55%, transparent)`;
+    el.style.background = `linear-gradient(90deg, ${faint} 0%, ${faint} ${a}%, ` +
+      `${solid} ${a}%, ${solid} ${b}%, ${faint} ${b}%, ${faint} 100%)`;
+    el.title = title;
+  };
+  const ftd = typeof forcingTimeDays === 'function' ? forcingTimeDays() : null;
+  if (ftd) {
+    const cfg = typeof SettingsTab !== 'undefined' ? SettingsTab.getConfig() : null;
+    const repeats = !!(cfg && cfg.inputs && cfg.inputs.repeat_eulerian_fields !== false);
+    band($('tl-cov-frc'), pct(ftd[0]), pct(ftd[ftd.length - 1]), 'var(--ok)', repeats,
+         `Forcing data: ${fmtDate(ftd[0])} → ${fmtDate(ftd[ftd.length - 1])}` +
+         (repeats ? '\nRepeats (is cycled) outside this span — faint part of the band.'
+                  : '\nNo forcing outside this span.'));
+  } else {
+    band($('tl-cov-frc'), null);
+  }
+  if (state.runs.length) {
+    let p0 = Infinity, p1 = -Infinity;
+    for (const r of state.runs) {
+      const td = r.meta.time_days;
+      p0 = Math.min(p0, r.epoch + td[0]);
+      p1 = Math.max(p1, r.epoch + td[td.length - 1]);
+    }
+    band($('tl-cov-par'), pct(p0), pct(p1), 'var(--warn)', false,
+         `Particle results: ${fmtDate(p0)} → ${fmtDate(p1)}`);
+  } else {
+    band($('tl-cov-par'), null);
+  }
+}
+$('btn-play').onclick = togglePlay;
+$('btn-step-f').onclick = () => stepDays(1);
+$('btn-step-b').onclick = () => stepDays(-1);
+$('timeline').oninput = () => {
+  const c = state.clock;
+  c.playing = false; refreshPlayBtn();
+  c.t = c.t0 + (c.t1 - c.t0) * $('timeline').value / 1000;
+  c.t = Math.min(c.t, loadedFrontier());
+  updateTimelineUI(); state.dirty = true;
+};
+$('rng-speed').oninput = () => {
+  // log-mapped: slider 0..1 → 1 h/s .. 30 days/s (default 3 h/s)
+  const f = parseFloat($('rng-speed').value);
+  const lo = 1 / 24, hi = 30;
+  const speed = Math.pow(10, Math.log10(lo) + (Math.log10(hi) - Math.log10(lo)) * f);
+  state.clock.speed = speed;
+  $('lbl-speed').textContent = speed >= 1 ?
+    speed.toFixed(speed < 10 ? 1 : 0) + ' d/s' : (speed * 24).toFixed(1) + ' h/s';
+};
+
+/* ═════════════════════════ control wiring ═════════════════════════ */
+$('rng-size').oninput = () => { state.pointSize = parseFloat($('rng-size').value); state.dirty = true; };
+$('rng-alpha').oninput = () => { state.alpha = parseFloat($('rng-alpha').value); state.dirty = true; };
+$('sel-decim').onchange = () => {
+  state.decim = parseInt($('sel-decim').value);
+  schedulePathRebuild(); state.dirty = true;
+};
+$('rng-pwidth').oninput = () => { state.paths.width = parseFloat($('rng-pwidth').value); state.dirty = true; };
+$('rng-palpha').oninput = () => { state.paths.alpha = parseFloat($('rng-palpha').value); state.dirty = true; };
+$('sel-pathcolor').onchange = () => {
+  state.paths.mode = $('sel-pathcolor').value;
+  $('pathcolor-swatch').style.display = state.paths.mode === 'solid' ? '' : 'none';
+  if (state.paths.mode === 'burial') state.runs.forEach(streamBurial);
+  schedulePathRebuild(); refreshScaleRows(); updateColorbars(); state.dirty = true;
+};
+$('pathcolor-swatch').appendChild(mkColorBtn(() => state.paths.color,
+  c => { state.paths.color = c; state.dirty = true; }));
+$('pathcolor-swatch').style.display = 'none';
+$('sel-basemap').onchange = () => { state.basemap = $('sel-basemap').value; state.dirty = true; };
+$('sel-model').onchange = () => { state.modelLayer = $('sel-model').value; state.dirty = true; };
+$('rng-mesh-alpha').oninput = () => { state.meshAlpha = parseFloat($('rng-mesh-alpha').value); state.dirty = true; };
+
+/* eye show/hide toggles — hidden = greyed-out related controls, stable layout */
+function syncVis() {
+  const eyes = [['eye-basemap', state.showBasemap], ['eye-model', state.showModel],
+                ['eye-poly', state.showOutlines], ['eye-points', state.showPoints],
+                ['eye-paths', state.paths.show]];
+  for (const [id, on] of eyes) $(id).classList.toggle('off', !on);
+  $('sel-basemap').classList.toggle('grey', !state.showBasemap);
+  $('sel-model').classList.toggle('grey', !state.showModel || !state.mesh);
+  $('row-mesh-alpha').classList.toggle('grey', !state.showModel || !state.mesh);
+  $('poly-opts').classList.toggle('grey', !state.showOutlines);
+  $('points-opts').classList.toggle('grey', !state.showPoints);
+  $('paths-opts').classList.toggle('grey', !state.paths.show);
+  $('row-fade-alpha').classList.toggle('grey', !(state.fade.bur || state.fade.imm));
+}
+function wireEye(id, toggle) {
+  $(id).onclick = ev => {
+    ev.preventDefault(); ev.stopPropagation();   // don't collapse the section
+    toggle(); syncVis(); state.dirty = true;
+  };
+}
+wireEye('eye-basemap', () => { state.showBasemap = !state.showBasemap; });
+wireEye('eye-model', () => { state.showModel = !state.showModel; state.modelAutoSet = true; });
+wireEye('eye-poly', () => { state.showOutlines = !state.showOutlines; });
+wireEye('eye-points', () => { state.showPoints = !state.showPoints; });
+wireEye('eye-paths', () => {
+  state.paths.show = !state.paths.show;
+  if (state.paths.show) { schedulePathRebuild(); if (rulesNeedBurial()) state.runs.forEach(streamBurial); }
+  refreshScaleRows(); updateColorbars(); updatePathsNote();
+});
+
+/* fading of buried / immobile particles */
+$('chk-fade-bur').onchange = () => {
+  state.fade.bur = $('chk-fade-bur').checked;
+  if (state.fade.bur) state.runs.forEach(streamBurial);
+  syncVis(); state.dirty = true;
+};
+$('inp-fade-depth').onchange = () => {
+  state.fade.depth = Math.max(parseFloat($('inp-fade-depth').value) || 0.05, 0.001);
+  state.dirty = true;
+};
+$('chk-fade-imm').onchange = () => {
+  state.fade.imm = $('chk-fade-imm').checked;
+  if (state.fade.imm) state.runs.forEach(streamFlags);
+  syncVis(); state.dirty = true;
+};
+$('rng-fade-alpha').oninput = () => {
+  state.fade.alpha = parseFloat($('rng-fade-alpha').value); state.dirty = true;
+};
+$('btn-hide-side').onclick = () => {
+  $('sidebar').classList.add('hidden');
+  $('sidebtn').style.display = 'block';
+  $('sideresize').style.display = 'none';
+};
+$('sidebtn').onclick = () => {
+  $('sidebar').classList.remove('hidden');
+  $('sidebtn').style.display = 'none';
+  $('sideresize').style.display = '';
+};
+
+/* resizable sidebar: drag the divider; the width persists and applies on every
+   tab (the sidebar width is a CSS variable, --sidebar-w) */
+(() => {
+  const rs = $('sideresize');
+  if (!rs) return;
+  const clamp = w => Math.max(320, Math.min(w, window.innerWidth - 380));
+  const apply = w => document.documentElement.style.setProperty('--sidebar-w', w + 'px');
+  const saved = parseInt(localStorage.getItem('stgui_sidebar_w'), 10);
+  if (isFinite(saved)) apply(clamp(saved));
+  rs.onmousedown = e => {
+    e.preventDefault();
+    rs.classList.add('dragging');
+    const move = ev => apply(clamp(ev.clientX));
+    const up = ev => {
+      window.removeEventListener('mousemove', move);
+      window.removeEventListener('mouseup', up);
+      rs.classList.remove('dragging');
+      localStorage.setItem('stgui_sidebar_w', String(clamp(ev.clientX)));
+    };
+    window.addEventListener('mousemove', move);
+    window.addEventListener('mouseup', up);
+  };
+})();
+

--- a/sedtrails-gui/web/js/tabs/viewer.js
+++ b/sedtrails-gui/web/js/tabs/viewer.js
@@ -1,0 +1,672 @@
+"use strict";
+/* ═════════════════════════ polygon registry ═════════════════════════ */
+/* closed shapes only (polygons & boxes) — these are usable for classification,
+   filter rules and connectivity; points/transects live in the same store but
+   are excluded here */
+function allPolys() {
+  return state.polygons
+    .filter(p => !p.type || p.type === 'polygon' || p.type === 'bbox')
+    .map(p => ({key: p.name, verts: p.verts, name: p.name, color: p.color}));
+}
+function ensurePolyColors() {
+  let changed = false;
+  state.polygons.forEach((p, i) => {
+    if (!p.type) p.type = 'polygon';           // legacy entries predate types
+    if (!p.color) { p.color = PALETTE[i % PALETTE.length]; changed = true; }
+  });
+  if (changed) savePolygons();
+  rebuildPaletteTex();
+}
+function polyColorOf(key) {
+  const p = allPolys().find(q => q.key === key);
+  return p && p.color ? p.color : '#d14b4b';
+}
+/* area-weighted polygon centroid (world coords); vertex mean when degenerate —
+   used by the connectivity network layer (render.js) */
+function polyCentroid(p) {
+  const v = p.verts;
+  if (!v || !v.length) return null;
+  let a = 0, cx = 0, cy = 0;
+  for (let i = 0; i < v.length; i++) {
+    const [x0, y0] = v[i], [x1, y1] = v[(i + 1) % v.length];
+    const cr = x0 * y1 - x1 * y0;
+    a += cr; cx += (x0 + x1) * cr; cy += (y0 + y1) * cr;
+  }
+  if (Math.abs(a) < 1e-9)
+    return [v.reduce((s, q) => s + q[0], 0) / v.length,
+            v.reduce((s, q) => s + q[1], 0) / v.length];
+  return [cx / (3 * a), cy / (3 * a)];
+}
+
+/* ═════════════════════════ run loading ═════════════════════════ */
+function makeRun(meta, stride) {
+  const N = Math.floor((meta.n_particles + stride - 1) / stride);
+  const T = meta.n_timesteps;
+  const run = {
+    id: meta.id, meta, stride, N, T,
+    // reference_date may carry a time-of-day ("2025-08-03 21:40:00")
+    epoch: (d => Date.parse(d.length > 10 ? d.replace(' ', 'T') + 'Z'
+                                          : d + 'T00:00:00Z'))
+           (String(meta.reference_date).trim()) / 86400000,
+    frames: new Array(T).fill(null),
+    burFrames: null, burLoading: false,
+    flagFrames: null, flagLoading: false,
+    loaded: 0,
+    attrs: {origin: new Uint8Array(N).fill(255), final: new Uint8Array(N).fill(255),
+            first: new Uint16Array(N).fill(SENT), visited: new Uint32Array(N),
+            at0: new Uint32Array(N), atEnd: new Uint32Array(N)},
+    visible: true,
+    tint: SIM_TINTS[state.runs.length % SIM_TINTS.length],
+    classifying: false,
+    counts: 0,
+    distMax: 0,
+  };
+  const q = meta.quant;
+  run.quantU = [q.sx, q.sy, q.xmin - state.world0[0], q.ymin - state.world0[1]];
+
+  run.posA = gl.createBuffer(); run.posB = gl.createBuffer();
+  run.burA = gl.createBuffer(); run.burB = gl.createBuffer();
+  run.attrB = gl.createBuffer();
+  for (const b of [run.posA, run.posB]) {
+    gl.bindBuffer(gl.ARRAY_BUFFER, b);
+    gl.bufferData(gl.ARRAY_BUFFER, N * 4, gl.DYNAMIC_DRAW);
+  }
+  for (const b of [run.burA, run.burB]) {
+    gl.bindBuffer(gl.ARRAY_BUFFER, b);
+    gl.bufferData(gl.ARRAY_BUFFER, N * 2, gl.DYNAMIC_DRAW);
+  }
+  run.flgA = gl.createBuffer(); run.flgB = gl.createBuffer();
+  for (const b of [run.flgA, run.flgB]) {   // default 1 = mobile (no fade)
+    gl.bindBuffer(gl.ARRAY_BUFFER, b);
+    gl.bufferData(gl.ARRAY_BUFFER, new Uint8Array(N).fill(1), gl.DYNAMIC_DRAW);
+  }
+  gl.bindBuffer(gl.ARRAY_BUFFER, run.attrB);
+  gl.bufferData(gl.ARRAY_BUFFER, N * 16, gl.STATIC_DRAW);
+
+  const idx = new Uint32Array(N);
+  for (let i = 0; i < N; i++) idx[i] = i;
+  let seed = 1234567;
+  for (let i = N - 1; i > 0; i--) {
+    seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+    const j = seed % (i + 1);
+    const t = idx[i]; idx[i] = idx[j]; idx[j] = t;
+  }
+  run.shuffle = idx;
+  run.ebo = gl.createBuffer();
+  gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, run.ebo);
+  gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, idx, gl.STATIC_DRAW);
+
+  run.vaos = [null, null].map((_, half) => {
+    const vao = gl.createVertexArray();
+    gl.bindVertexArray(vao);
+    const cur = half === 0 ? run.posA : run.posB;
+    const nxt = half === 0 ? run.posB : run.posA;
+    gl.bindBuffer(gl.ARRAY_BUFFER, cur);
+    gl.enableVertexAttribArray(0); gl.vertexAttribIPointer(0, 2, gl.UNSIGNED_SHORT, 4, 0);
+    gl.bindBuffer(gl.ARRAY_BUFFER, nxt);
+    gl.enableVertexAttribArray(1); gl.vertexAttribIPointer(1, 2, gl.UNSIGNED_SHORT, 4, 0);
+    gl.bindBuffer(gl.ARRAY_BUFFER, run.attrB);
+    gl.enableVertexAttribArray(2); gl.vertexAttribIPointer(2, 2, gl.UNSIGNED_BYTE, 16, 0);
+    gl.enableVertexAttribArray(3); gl.vertexAttribIPointer(3, 1, gl.UNSIGNED_SHORT, 16, 2);
+    gl.enableVertexAttribArray(6); gl.vertexAttribIPointer(6, 1, gl.UNSIGNED_INT, 16, 4);
+    gl.enableVertexAttribArray(7); gl.vertexAttribIPointer(7, 1, gl.UNSIGNED_INT, 16, 8);
+    gl.enableVertexAttribArray(8); gl.vertexAttribIPointer(8, 1, gl.UNSIGNED_INT, 16, 12);
+    const bcur = half === 0 ? run.burA : run.burB;
+    const bnxt = half === 0 ? run.burB : run.burA;
+    gl.bindBuffer(gl.ARRAY_BUFFER, bcur);
+    gl.enableVertexAttribArray(4); gl.vertexAttribIPointer(4, 1, gl.UNSIGNED_SHORT, 2, 0);
+    gl.bindBuffer(gl.ARRAY_BUFFER, bnxt);
+    gl.enableVertexAttribArray(5); gl.vertexAttribIPointer(5, 1, gl.UNSIGNED_SHORT, 2, 0);
+    gl.bindBuffer(gl.ARRAY_BUFFER, half === 0 ? run.flgA : run.flgB);
+    gl.enableVertexAttribArray(9); gl.vertexAttribIPointer(9, 1, gl.UNSIGNED_BYTE, 1, 0);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, run.ebo);
+    gl.bindVertexArray(null);
+    return vao;
+  });
+  run.bufFrame = [-1, -1];
+  uploadAttrs(run);
+
+  run.segVBO = gl.createBuffer();
+  run.segVAO = gl.createVertexArray();
+  gl.bindVertexArray(run.segVAO);
+  gl.bindBuffer(gl.ARRAY_BUFFER, run.segVBO);
+  gl.enableVertexAttribArray(1); gl.vertexAttribIPointer(1, 4, gl.UNSIGNED_SHORT, 12, 0);
+  gl.vertexAttribDivisor(1, 1);
+  gl.enableVertexAttribArray(2); gl.vertexAttribIPointer(2, 2, gl.UNSIGNED_SHORT, 12, 8);
+  gl.vertexAttribDivisor(2, 1);
+  gl.bindVertexArray(null);
+  run.segCount = 0;
+  run.pathsDirty = true;
+  return run;
+}
+
+function uploadAttrs(run) {
+  const N = run.N;
+  const buf = new ArrayBuffer(N * 16);
+  const u8 = new Uint8Array(buf);
+  const u16 = new Uint16Array(buf);
+  const u32 = new Uint32Array(buf);
+  for (let i = 0; i < N; i++) {
+    u8[i*16]   = run.attrs.origin[i];
+    u8[i*16+1] = run.attrs.final[i];
+    u16[i*8+1] = run.attrs.first[i];
+    u32[i*4+1] = run.attrs.visited[i];
+    u32[i*4+2] = run.attrs.at0[i];
+    u32[i*4+3] = run.attrs.atEnd[i];
+  }
+  gl.bindBuffer(gl.ARRAY_BUFFER, run.attrB);
+  gl.bufferSubData(gl.ARRAY_BUFFER, 0, u8);
+}
+
+async function loadRun(bundleId, stride, name) {
+  if (state.runs.some(r => r.id === bundleId)) { toast('Simulation already loaded'); return; }
+  const meta = await apiJson(`/data/${bundleId}/meta.json`);
+  if (!state.world0) state.world0 = [meta.quant.xmin, meta.quant.ymin];
+  if (name) meta.run_name = name;
+  const run = makeRun(meta, stride);
+  state.runs.push(run);
+
+  $('modal-open').style.display = 'none';
+  updateClockRange();
+  updateTimelineUI();
+  if (state.runs.length === 1) fitView(run);
+  refreshSimList(); refreshRules();
+  streamPositions(run);
+  requestClassify(run);
+  loadMesh(run);
+  if (rulesNeedBurial() || state.fade.bur) streamBurial(run);
+  if (state.fade.imm) streamFlags(run);
+  state.dirty = true;
+}
+
+async function streamPositions(run) {
+  const fullN = run.meta.n_particles;
+  const frameBytes = fullN * 4;
+  const resp = await fetch(`/data/${run.id}/positions.bin`);
+  if (!resp.ok) { toast(`positions.bin failed for ${run.meta.run_name}`, true); return; }
+  const reader = resp.body.getReader();
+  const carry = new Uint8Array(frameBytes);
+  let carryLen = 0, t = 0;
+  try {
+    while (t < run.T) {
+      const {done, value} = await reader.read();
+      if (done) break;
+      let o = 0;
+      while (o < value.length && t < run.T) {
+        const take = Math.min(frameBytes - carryLen, value.length - o);
+        carry.set(value.subarray(o, o + take), carryLen);
+        carryLen += take; o += take;
+        if (carryLen === frameBytes) {
+          const full = new Uint16Array(carry.buffer, 0, fullN * 2);
+          let fr;
+          if (run.stride === 1) {
+            fr = new Uint16Array(fullN * 2);
+            fr.set(full);
+          } else {
+            fr = new Uint16Array(run.N * 2);
+            for (let i = 0, j = 0; j < run.N; i += run.stride, j++) {
+              fr[j*2] = full[i*2]; fr[j*2+1] = full[i*2+1];
+            }
+          }
+          run.frames[t] = fr;
+          run.loaded = ++t;
+          carryLen = 0;
+          if ((t & 7) === 0 || t === run.T) { refreshSimList(); state.dirty = true; }
+        }
+      }
+    }
+  } catch (e) {
+    toast(`Loading ${run.meta.run_name} failed: ${e.message}. Try a larger particle stride.`, true);
+  }
+  refreshSimList(); updateLoadStatus(); updateCounts(); state.dirty = true;
+}
+
+async function streamBurial(run) {
+  if (run.burFrames || run.burLoading || !run.meta.has_burial) return;
+  run.burLoading = true;
+  const fullN = run.meta.n_particles;
+  const frameBytes = fullN * 2;
+  try {
+    run.burFrames = new Array(run.T).fill(null);
+    const resp = await fetch(`/data/${run.id}/burial.bin`);
+    if (!resp.ok) throw new Error('burial.bin not available');
+    const reader = resp.body.getReader();
+    const carry = new Uint8Array(frameBytes);
+    let carryLen = 0, t = 0;
+    while (t < run.T) {
+      const {done, value} = await reader.read();
+      if (done) break;
+      let o = 0;
+      while (o < value.length && t < run.T) {
+        const take = Math.min(frameBytes - carryLen, value.length - o);
+        carry.set(value.subarray(o, o + take), carryLen);
+        carryLen += take; o += take;
+        if (carryLen === frameBytes) {
+          const full = new Uint16Array(carry.buffer, 0, fullN);
+          const fr = new Uint16Array(run.N);
+          if (run.stride === 1) fr.set(full);
+          else for (let i = 0, j = 0; j < run.N; i += run.stride, j++) fr[j] = full[i];
+          run.burFrames[t] = fr; t++;
+          carryLen = 0;
+        }
+      }
+    }
+    // robust auto color range: p98 of the final burial field — burial_max is
+    // often dominated by a few extreme cells, flattening all real signal
+    const lastFr = [...run.burFrames].reverse().find(f => f);
+    if (lastFr) {
+      const vals = [];
+      const st = Math.max(1, Math.floor(lastFr.length / 20000));
+      for (let i = 0; i < lastFr.length; i += st)
+        if (lastFr[i] !== SENT) vals.push(lastFr[i]);
+      vals.sort((a, b) => a - b);
+      if (vals.length)
+        run.burP98 = Math.max(vals[Math.floor(vals.length * 0.98)] / 65534
+                              * (run.meta.burial_max || 0.01), 0.01);
+    }
+    run.bufFrame = [-1, -1];
+    updateColorbars(); refreshScaleRows();
+    state.dirty = true;
+  } catch (e) {
+    run.burFrames = null;
+    toast(`Burial data: ${e.message}`, true);
+  }
+  run.burLoading = false;
+}
+
+async function streamFlags(run) {
+  if (run.flagFrames || run.flagLoading) return;
+  if (!run.meta.has_flags) {
+    toast(`${run.meta.run_name}: no particle status in this bundle — re-open the simulation once to extract it`, true);
+    return;
+  }
+  run.flagLoading = true;
+  const fullN = run.meta.n_particles;
+  try {
+    run.flagFrames = new Array(run.T).fill(null);
+    const resp = await fetch(`/data/${run.id}/flags.bin`);
+    if (!resp.ok) throw new Error('flags.bin not available');
+    const reader = resp.body.getReader();
+    const carry = new Uint8Array(fullN);
+    let carryLen = 0, t = 0;
+    while (t < run.T) {
+      const {done, value} = await reader.read();
+      if (done) break;
+      let o = 0;
+      while (o < value.length && t < run.T) {
+        const take = Math.min(fullN - carryLen, value.length - o);
+        carry.set(value.subarray(o, o + take), carryLen);
+        carryLen += take; o += take;
+        if (carryLen === fullN) {
+          const fr = new Uint8Array(run.N);
+          if (run.stride === 1) fr.set(carry);
+          else for (let i = 0, j = 0; j < run.N; i += run.stride, j++) fr[j] = carry[i];
+          run.flagFrames[t] = fr; t++;
+          carryLen = 0;
+        }
+      }
+    }
+    run.bufFrame = [-1, -1];
+    state.dirty = true;
+  } catch (e) {
+    run.flagFrames = null;
+    toast(`Status data: ${e.message}`, true);
+  }
+  run.flagLoading = false;
+}
+
+/* ═════════════════════════ classification ═════════════════════════ */
+const requestClassifyAll = debounce(() => state.runs.forEach(requestClassify), 500);
+
+async function requestClassify(run) {
+  if (run.classifying) { run.classifyPending = true; return; }
+  const polys = allPolys().map(p => ({key: p.key, verts: p.verts}));
+  if (!polys.length) {
+    run.attrs.origin.fill(255); run.attrs.final.fill(255);
+    run.attrs.first.fill(SENT); run.attrs.visited.fill(0);
+    run.attrs.at0.fill(0); run.attrs.atEnd.fill(0);
+    uploadAttrs(run); afterClassify();
+    return;
+  }
+  run.classifying = true; refreshClassifyStatus();
+  const progTimer = setInterval(async () => {
+    try {
+      const p = await apiJson('/api/classify/progress?bundle=' + run.id);
+      if (p.T) $('classify-status').innerHTML =
+        `<b style="color:var(--warn)">⟳ classifying ${p.n} new polygon(s) — ` +
+        `day ${p.t + 1}/${p.T} · filters use the previous polygons until done</b>`;
+    } catch (e) {}
+  }, 1500);
+  const tStart = performance.now();
+  try {
+    const r = await api('/api/classify', {bundle_id: run.id, polygons: polys});
+    const buf = new Uint8Array(await r.arrayBuffer());
+    const nl = buf.indexOf(10);
+    const header = JSON.parse(new TextDecoder().decode(buf.subarray(0, nl)));
+    const N = header.n;
+    let o = nl + 1;
+    const slice32 = start => new Uint32Array(
+      buf.buffer.slice(buf.byteOffset + start, buf.byteOffset + start + 4*N));
+    const fOrigin = buf.subarray(o, o + N);
+    const fFinal = buf.subarray(o + N, o + 2*N);
+    const fFirst = new Uint16Array(buf.buffer.slice(buf.byteOffset + o + 2*N, buf.byteOffset + o + 4*N));
+    const fVisited = slice32(o + 4*N);
+    const fAt0 = slice32(o + 8*N);
+    const fAtEnd = slice32(o + 12*N);
+    const s = run.stride;
+    for (let i = 0, j = 0; j < run.N; i += s, j++) {
+      run.attrs.origin[j] = fOrigin[i];
+      run.attrs.final[j] = fFinal[i];
+      run.attrs.first[j] = fFirst[i];
+      run.attrs.visited[j] = fVisited[i];
+      run.attrs.at0[j] = fAt0[i];
+      run.attrs.atEnd[j] = fAtEnd[i];
+    }
+    uploadAttrs(run);
+    run.pathsDirty = true;
+    if (performance.now() - tStart > 3000)
+      toast('Polygon classification updated — filters now reflect the new polygons');
+    // (no auto-switch to polygon coloring — "in their simulation color" is
+    // the default appearance now)
+  } catch (e) {
+    toast(`Classification failed: ${e.message}`, true);
+  }
+  clearInterval(progTimer);
+  run.classifying = false;
+  afterClassify();
+  if (run.classifyPending) {           // polygon set changed meanwhile —
+    run.classifyPending = false;       // collapse all edits into one re-run
+    requestClassify(run);
+  }
+}
+
+function afterClassify() {
+  refreshClassifyStatus(); updateCounts();
+  state.runs.forEach(r => { r.pathsDirty = true; });
+  state.dirty = true;
+}
+
+function refreshClassifyStatus() {
+  const busy = state.runs.some(r => r.classifying);
+  $('classify-status').innerHTML = busy
+    ? '<b style="color:var(--warn)">⟳ classifying particles… rules use the previous polygons until done</b>'
+    : allPolys().length ? `${allPolys().length} polygon(s) classified` : '';
+}
+
+/* ═════════════════════════ rule engine (CPU mirror) ═════════════════════════ */
+function compileCond(cond, poly, thresh, keys, run) {
+  if (cond === 'always' || !cond) return {c: 0, a: 0, t: 0};
+  if (cond === 'bur_ge' || cond === 'bur_lt')
+    return {c: cond === 'bur_ge' ? 4 : 5, a: 0,
+            t: Math.max(0, thresh || 0) / run.meta.burial_max * 65534};
+  const c = cond === 'start' ? 1 : cond === 'end' ? 2 : 3;
+  let a;
+  if (poly === '*any*') a = -1;
+  else if (poly === '*none*') a = -2;
+  else { a = keys.indexOf(poly); if (a < 0) return null; }
+  return {c, a, t: 0};
+}
+
+function compiledRules(run) {
+  const keys = allPolys().map(p => p.key);
+  const out = [];
+  for (const rule of state.rules) {
+    if (rule.sim !== '*' && rule.sim !== run.id) continue;
+    if (out.length >= MAX_RULES) break;
+    const c1 = compileCond(rule.cond, rule.poly, rule.thresh, keys, run);
+    const c2 = rule.cond2 ? compileCond(rule.cond2, rule.poly2, rule.thresh2, keys, run)
+                          : {c: 0, a: 0, t: 0};
+    if (!c1 || !c2) continue;
+    const action = rule.action === 'hide' ? 0 : rule.action === 'color' ? 1
+      : rule.colorby === 'burial' ? 2 : rule.colorby === 'age' ? 3 : 4;
+    out.push({c1, c2, action, rgb: hex2rgb(rule.color || '#888888')});
+  }
+  return out;
+}
+
+function condEval(run, cc, i, bur) {
+  const mask = cc.c === 1 ? run.attrs.at0[i] : cc.c === 2 ? run.attrs.atEnd[i]
+             : run.attrs.visited[i];
+  switch (cc.c) {
+    case 0: return true;
+    case 4: return bur >= cc.t;
+    case 5: return bur < cc.t;
+    default:
+      if (cc.a === -1) return mask !== 0;
+      if (cc.a === -2) return mask === 0;
+      return (mask & (1 << cc.a)) !== 0;
+  }
+}
+
+function evalVisible(run, compiled, i, bur) {
+  for (const r of compiled)
+    if (condEval(run, r.c1, i, bur) && condEval(run, r.c2, i, bur))
+      return r.action !== 0;
+  return state.defaultApp.action !== 'hide';
+}
+
+function updateCounts() {
+  let total = 0;
+  const {k} = state.runs.length ? frameAt(state.runs[0], state.clock.t) : {k: 0};
+  for (const run of state.runs) {
+    if (!run.visible || !run.loaded) { run.counts = 0; continue; }
+    const compiled = compiledRules(run);
+    const kk = Math.min(k, run.loaded - 1);
+    const bf = run.burFrames && run.burFrames[kk];
+    let c = 0;
+    for (let i = 0; i < run.N; i++)
+      if (evalVisible(run, compiled, i, bf ? bf[i] : 0)) c++;
+    run.counts = c;
+    total += c * run.stride;
+  }
+  state.selCount = total;
+  $('st-sel').innerHTML = `<b>${fmtInt(total)}</b> selected`;
+  updateColorbars();
+}
+
+function rulesNeedBurial() {
+  return state.rules.some(r => ['bur_ge', 'bur_lt'].includes(r.cond)
+      || ['bur_ge', 'bur_lt'].includes(r.cond2)
+      || (r.action === 'colorby' && r.colorby === 'burial'))
+    || (state.defaultApp.action === 'colorby' && state.defaultApp.colorby === 'burial')
+    || (state.paths.show && state.paths.mode === 'burial');
+}
+
+function onRulesChanged() {
+  if (rulesNeedBurial()) state.runs.forEach(streamBurial);
+  updateCounts(); refreshScaleRows(); schedulePathRebuild(); state.dirty = true;
+}
+
+/* ═════════════════════════ color scales & colorbars ═════════════════════════ */
+function autoRange(prop) {
+  const spanDays = Math.max(1, Math.round(state.clock.t1 - state.clock.t0));
+  const burP98 = Math.max(...state.runs.map(r => r.burP98 || 0), 0);
+  const burMax = burP98 > 0 ? burP98
+               : Math.max(0.01, ...state.runs.map(r => r.meta.burial_max || 0));
+  const distMax = Math.max(...state.runs.map(r => r.distMax || 0), 1);
+  return prop === 'burial' ? [0, burMax]
+       : prop === 'dist' ? [0, distMax]
+       : [0, spanDays];
+}
+function effRange(prop) {
+  const [lo, hi] = state.ranges[prop] || [null, null];
+  const [alo, ahi] = autoRange(prop);
+  return [lo === null || lo === undefined ? alo : lo,
+          hi === null || hi === undefined ? ahi : hi];
+}
+function activePointProps() {
+  const used = new Set();
+  if (state.defaultApp.action === 'colorby') used.add(state.defaultApp.colorby);
+  for (const r of state.rules) if (r.action === 'colorby') used.add(r.colorby);
+  return used;
+}
+
+const PROP_INFO = {
+  burial: {title: 'burial depth (m)', unit: 'm', dec: 2},
+  age: {title: 'age (days)', unit: 'd', dec: 0},
+  first: {title: 'first polygon visit (days)', unit: 'd', dec: 0},
+  dist: {title: 'distance travelled (km)', unit: 'km', dec: 1},
+};
+
+function cmapCss(name) {
+  const stops = CMAPS[name] || CMAPS.viridis;
+  return 'linear-gradient(90deg,' + stops.map((c, i) =>
+    `rgb(${c[0]},${c[1]},${c[2]}) ${(i / (stops.length - 1) * 100).toFixed(0)}%`).join(',') + ')';
+}
+
+function fmtVal(v, prop) {
+  const d = PROP_INFO[prop].dec;
+  return prop === 'dist' ? (v / 1000).toFixed(d) : v.toFixed(d);
+}
+
+function updateColorbars() {
+  const el = $('colorbars');
+  el.innerHTML = '';
+  const add = (tag, prop, cmap) => {
+    const [lo, hi] = effRange(prop);
+    const div = document.createElement('div');
+    div.className = 'cbar';
+    div.innerHTML = `<div class="title">${tag} · ${PROP_INFO[prop].title}</div>
+      <div class="ramp" style="background:${cmapCss(cmap)}"></div>
+      <div class="lbl"><span>${fmtVal(lo, prop)}</span><span>${fmtVal(hi, prop)}</span></div>`;
+    el.appendChild(div);
+  };
+  for (const prop of activePointProps()) add('points', prop, state.pointCmap);
+  if (state.paths.show && state.paths.mode !== 'solid')
+    add('paths', state.paths.mode, state.paths.cmap);
+}
+
+function mkScaleRow(labelTxt, prop, cmapGet, cmapSet) {
+  const div = document.createElement('div');
+  div.className = 'scalerow';
+  div.innerHTML = `<span class="dim">${labelTxt}</span>`;
+  const sel = document.createElement('select');
+  for (const name of Object.keys(CMAPS)) {
+    const o = document.createElement('option');
+    o.value = name; o.textContent = name;
+    if (name === cmapGet()) o.selected = true;
+    sel.appendChild(o);
+  }
+  sel.onchange = () => { cmapSet(sel.value); updateColorbars(); state.dirty = true; };
+  div.appendChild(sel);
+  const [alo, ahi] = effRange(prop);
+  const mkNum = (idx, val) => {
+    const inp = document.createElement('input');
+    inp.type = 'number'; inp.step = 'any';
+    inp.value = fmtVal(val, prop);
+    inp.onchange = () => {
+      let v = parseFloat(inp.value);
+      if (prop === 'dist') v *= 1000;
+      state.ranges[prop][idx] = isFinite(v) ? v : null;
+      updateColorbars(); state.dirty = true;
+    };
+    return inp;
+  };
+  const lo = mkNum(0, alo), hi = mkNum(1, ahi);
+  const dash = document.createElement('span'); dash.className = 'dim'; dash.textContent = '–';
+  const unit = document.createElement('span'); unit.className = 'dim';
+  unit.textContent = PROP_INFO[prop].unit;
+  const auto = document.createElement('button'); auto.className = 'mini'; auto.textContent = 'auto';
+  auto.onclick = () => {
+    state.ranges[prop] = [null, null];
+    refreshScaleRows(); updateColorbars(); state.dirty = true;
+  };
+  div.append(lo, dash, hi, unit, auto);
+  return div;
+}
+
+function refreshScaleRows() {
+  const el = $('pointscale');
+  el.innerHTML = '';
+  for (const prop of activePointProps())
+    el.appendChild(mkScaleRow('scale · ' + PROP_INFO[prop].title.split(' (')[0], prop,
+      () => state.pointCmap, v => { state.pointCmap = v; }));
+  const pe = $('pathscale');
+  pe.innerHTML = '';
+  if (state.paths.show && state.paths.mode !== 'solid')
+    pe.appendChild(mkScaleRow('scale', state.paths.mode,
+      () => state.paths.cmap, v => { state.paths.cmap = v; }));
+}
+
+/* ═════════════════════════ paths ═════════════════════════ */
+function rebuildPaths(run) {
+  run.pathsDirty = false;
+  const compiled = compiledRules(run);
+  const {k} = frameAt(run, state.clock.t);
+  const kk = Math.min(k, Math.max(run.loaded - 1, 0));
+  const bf = run.burFrames && run.burFrames[kk];
+  const limit = Math.ceil(run.N / state.decim);
+  const sel = [];
+  for (let s = 0; s < limit; s++) {
+    const i = run.shuffle[s];
+    if (evalVisible(run, compiled, i, bf ? bf[i] : 0)) sel.push(i);
+  }
+  // cap the number of drawn trajectories: each is ~T CPU-built segments, so
+  // unlimited paths of a large selection would freeze the tab
+  const segBudget = softwareGL ? 600000 : 3000000;
+  const maxPaths = Math.max(50, Math.floor(segBudget / Math.max(run.T - 1, 1)));
+  const step = Math.max(1, Math.ceil(sel.length / maxPaths));
+  const chosen = [];
+  for (let i = 0; i < sel.length; i += step) chosen.push(sel[i]);
+  run.pathsShown = chosen.length;
+  run.pathsTotal = sel.length;
+
+  const T = run.loaded;
+  const mode = state.paths.mode;
+  const q = run.meta.quant;
+  const maxSegs = Math.max(1, chosen.length * Math.max(T - 1, 1));
+  const seg = new Uint16Array(maxSegs * 6);
+  let ns = 0, distMax = 0;
+  const segDist = mode === 'dist' ? new Float32Array(maxSegs) : null;
+
+  for (const p of chosen) {
+    let px = -1, py = -1, cum = 0;
+    for (let t = 0; t < T; t++) {
+      const fr = run.frames[t];
+      if (!fr) break;
+      const x = fr[p*2], y = fr[p*2+1];
+      if (x === SENT) { px = -1; continue; }
+      if (px >= 0) {
+        const o = ns * 6;
+        seg[o] = px; seg[o+1] = py; seg[o+2] = x; seg[o+3] = y;
+        seg[o+4] = t;
+        if (mode === 'burial') {
+          const b = run.burFrames && run.burFrames[t] ? run.burFrames[t][p] : 0;
+          seg[o+5] = b === SENT ? 0 : b;
+        } else if (mode === 'age') {
+          seg[o+5] = Math.round(t / Math.max(run.T - 1, 1) * 65534);
+        } else if (mode === 'dist') {
+          cum += Math.hypot((x - px) * q.sx, (y - py) * q.sy);
+          segDist[ns] = cum;
+        }
+        ns++;
+      }
+      px = x; py = y;
+    }
+    if (cum > distMax) distMax = cum;
+  }
+  if (mode === 'dist' && ns) {
+    const f = 65534 / Math.max(distMax, 1e-9);
+    for (let i = 0; i < ns; i++) seg[i*6+5] = Math.round(segDist[i] * f);
+  }
+  run.distMax = distMax;
+  gl.bindBuffer(gl.ARRAY_BUFFER, run.segVBO);
+  gl.bufferData(gl.ARRAY_BUFFER, seg.subarray(0, ns * 6), gl.DYNAMIC_DRAW);
+  run.segCount = ns;
+  run.pathLoadedAt = run.loaded;
+  updateColorbars();
+  updatePathsNote();
+}
+
+function updatePathsNote() {
+  let shown = 0, tot = 0;
+  for (const r of state.runs) { shown += r.pathsShown || 0; tot += r.pathsTotal || 0; }
+  $('paths-note').textContent = !state.paths.show || !tot ? ''
+    : shown < tot ? `showing ${fmtInt(shown)} of ${fmtInt(tot)} filtered paths (auto-capped for speed)`
+    : `all ${fmtInt(tot)} filtered paths`;
+}
+const schedulePathRebuild = debounce(() => {
+  state.runs.forEach(r => { r.pathsDirty = true; });
+  state.dirty = true;
+}, 250);
+

--- a/src/sedtrails/application_interfaces/cli/main.py
+++ b/src/sedtrails/application_interfaces/cli/main.py
@@ -46,6 +46,42 @@ def main(
     pass
 
 
+# Subcommand to launch the local GUI (lives in the repository's sedtrails-gui/ folder).
+@app.command('gui')
+def gui_cmd():
+    """
+    Launch the SedTRAILS GUI.
+
+    Runs sedtrails-gui/sedtrails_gui.py with the current Python interpreter,
+    looking in the current directory, the repository the installed sedtrails
+    package comes from (editable install), or next to that repository.
+    Stop the GUI with Ctrl+C.
+    """
+    import subprocess
+    import sys
+
+    repo = Path(__file__).resolve().parents[4]  # .../src/sedtrails/application_interfaces/cli/main.py
+    candidates = [
+        Path.cwd() / 'sedtrails_gui.py',
+        Path.cwd() / 'sedtrails-gui' / 'sedtrails_gui.py',
+        repo / 'sedtrails-gui' / 'sedtrails_gui.py',
+        repo.parent / 'sedtrails-gui' / 'sedtrails_gui.py',
+    ]
+    for gui in candidates:
+        if gui.is_file():
+            typer.echo(f'Starting SedTRAILS GUI: {gui}')
+            try:
+                rc = subprocess.run([sys.executable, str(gui)]).returncode
+            except KeyboardInterrupt:
+                rc = 0
+            raise typer.Exit(code=rc)
+    typer.echo(
+        'sedtrails-gui not found. Check out the GUI branch (git checkout bvw/gui) '
+        'or run this command from a folder containing sedtrails-gui/.'
+    )
+    raise typer.Exit(code=1)
+
+
 # Subcommand to run a simulation; it also validates the configuration.
 @app.command('run')
 def run_simulation_cmd(


### PR DESCRIPTION
## What

A local GUI for the full SedTRAILS workflow, grown out of the standalone particle viewer shared earlier. Everything lives in a new self-contained `sedtrails-gui/` folder — no changes to the sedtrails package itself, no build step, no web framework (stdlib `http.server` + vanilla JS/WebGL).

Five tabs:

| Tab | What it does |
|---|---|
| **Settings** | Open/edit/save a simulation yaml through a form generated from the packaged JSON schemas — every option shows its docs, defaults and allowed values, with live validation. Comment-preserving saves (ruamel.yaml). |
| **Populations** | Draw seeding per population on the map (points, transects, boxes, polygons) and preview the exact seed locations, computed by sedtrails' own seeding strategies. |
| **Run** | Start/stop `sedtrails run` with live log, progress bar and ETA; one click imports the result into the Viewer. |
| **Viewer** | Particles and forcing on one WebGL map: trajectories, paths, filtering/coloring, PNG/MP4 export, plus netCDF forcing layers (scalar Voronoi fields + quiver arrows) with time scrubbing. |
| **Connectivity** | Very early v0: polygon→polygon connectivity matrix (start→end / start→ever-visited) with CSV export and a network overlay on the map. |

## How to run

```
git fetch && git checkout bvw/gui
sedtrails gui               # with your sedtrails venv active
# (or: python sedtrails-gui/sedtrails_gui.py)
```

Opens in its own app window (Edge/Chrome). Requires `numpy` + `netCDF4`; the sedtrails package provides schemas/seeding/run. See `sedtrails-gui/README.md` for details.

## Status

**Early development, opened as a draft for feedback and testing** — not proposed for merge yet. It has seen real use on Westerschelde and Sand Engine cases but no systematic testing across workflows. Bug reports, feature requests and PRs onto this branch are all welcome.